### PR TITLE
fix: e2e tests failing in Docker due to network/dependency issues

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,6 +84,8 @@ services:
       dockerfile: Dockerfile.dev
     container_name: simple_invoicing_frontend_dev
     profiles: ["dev"]
+    environment:
+      API_PROXY_TARGET: http://backend-dev:8000
     depends_on:
       - backend-dev
     ports:

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,8 +1,8 @@
 # Frontend Environment Variables Template
 # Copy this file to .env.development or .env.production and update values
 
-# API Base URL - for development use full URL, for production use /api (nginx proxy)
-VITE_API_BASE_URL=http://localhost:8000/api
+# API Base URL - use /api so the Vite dev-server proxy forwards to the backend
+VITE_API_BASE_URL=/api
 
 # Application display name
 VITE_APP_NAME=Simple Invoicing

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -6,6 +6,9 @@ WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci
 
+# Install Playwright chromium browser and its OS-level dependencies
+RUN npx playwright install --with-deps chromium
+
 # Source code is mounted as a volume — not copied
 EXPOSE 5173
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,5 +5,11 @@ export default defineConfig({
   plugins: [react()],
   server: {
     port: 5173,
+    proxy: {
+      '/api': {
+        target: process.env.API_PROXY_TARGET || 'http://localhost:8000',
+        changeOrigin: true,
+      },
+    },
   },
 });


### PR DESCRIPTION
## Changes
- Add Playwright chromium install to `frontend/Dockerfile.dev`
- Add Vite `/api` proxy in `vite.config.ts` to forward requests to backend container
- Set `API_PROXY_TARGET` env var in `docker-compose.yml` for frontend-dev service
- Update `.env.example` to use relative `/api` path as default

## Problem
`make test` (e2e tests) failed inside Docker for two reasons:
1. Playwright browsers weren't installed in the container
2. The frontend's API base URL pointed to `http://localhost:8000` which is unreachable from inside the frontend container — the backend lives at `backend-dev:8000` in Docker networking

## Fix
The Vite dev server now proxies `/api` requests to the backend, and the env default uses the relative `/api` path so the proxy handles routing in both local and Docker environments.