### PR TITLE
feat: add selectable invoice date for backdated invoice creation

### DIFF
--- a/backend/migrations/20260101000008_add_invoice_date.py
+++ b/backend/migrations/20260101000008_add_invoice_date.py
@@ -1,0 +1,26 @@
+"""
+Add invoice_date column to invoices table for backdated invoice creation.
+Defaults to created_at for existing rows and NOW() for new rows.
+"""
+
+from sqlalchemy import text
+
+
+def up(conn) -> None:
+    conn.execute(text(
+        "ALTER TABLE invoices ADD COLUMN IF NOT EXISTS invoice_date TIMESTAMPTZ"
+    ))
+    # Back-fill existing rows so invoice_date = created_at
+    conn.execute(text(
+        "UPDATE invoices SET invoice_date = created_at WHERE invoice_date IS NULL"
+    ))
+    # Make the column NOT NULL with a default for future inserts
+    conn.execute(text(
+        "ALTER TABLE invoices ALTER COLUMN invoice_date SET NOT NULL"
+    ))
+    conn.execute(text(
+        "ALTER TABLE invoices ALTER COLUMN invoice_date SET DEFAULT NOW()"
+    ))
+    conn.execute(text(
+        "CREATE INDEX IF NOT EXISTS ix_invoices_invoice_date ON invoices (invoice_date)"
+    ))

--- a/backend/src/api/routes/invoices.py
+++ b/backend/src/api/routes/invoices.py
@@ -1,5 +1,6 @@
 from io import BytesIO
 from html import escape
+from datetime import date, datetime
 
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import StreamingResponse
@@ -97,6 +98,10 @@ def _apply_payload_to_invoice(
     invoice.voucher_type = payload.voucher_type
     if created_by is not None:
         invoice.created_by = created_by
+
+    if payload.invoice_date is not None:
+        invoice.invoice_date = datetime.combine(payload.invoice_date, datetime.min.time())
+
     invoice.invoice_number = _generate_invoice_number(invoice.id)
 
     if not invoice.company_gst or not invoice.ledger_gst:
@@ -310,7 +315,7 @@ def _build_invoice_html(invoice: Invoice, products: list[Product]) -> str:
     currency = invoice.company_currency_code or "USD"
     voucher_label = "Sales" if invoice.voucher_type == "sales" else "Purchase"
     inv_number = invoice.invoice_number or f"#{invoice.id}"
-    inv_date = invoice.created_at.strftime("%d %b %Y") if invoice.created_at else "N/A"
+    inv_date = invoice.invoice_date.strftime("%d %b %Y") if invoice.invoice_date else (invoice.created_at.strftime("%d %b %Y") if invoice.created_at else "N/A")
 
     product_map = {p.id: p for p in products}
 

--- a/backend/src/api/routes/ledgers.py
+++ b/backend/src/api/routes/ledgers.py
@@ -101,9 +101,9 @@ def get_day_book(
 
     invoices = (
         db.query(Invoice)
-        .filter(Invoice.created_at >= period_start)
-        .filter(Invoice.created_at <= period_end)
-        .order_by(Invoice.created_at.asc(), Invoice.id.asc())
+        .filter(Invoice.invoice_date >= period_start)
+        .filter(Invoice.invoice_date <= period_end)
+        .order_by(Invoice.invoice_date.asc(), Invoice.id.asc())
         .all()
     )
 
@@ -120,7 +120,7 @@ def get_day_book(
         entries.append(DayBookEntry(
             entry_id=invoice.id,
             entry_type="invoice",
-            date=invoice.created_at,
+            date=invoice.invoice_date,
             voucher_type=invoice.voucher_type.title(),
             ledger_name=invoice.ledger_name or "Unknown ledger",
             particulars=f"{invoice.voucher_type.title()} Invoice #{invoice.id}",
@@ -242,7 +242,7 @@ def get_ledger_statement(
             func.coalesce(func.sum(case((Invoice.voucher_type == "purchase", Invoice.total_amount), else_=0)), 0),
         )
         .filter(Invoice.ledger_id == ledger_id)
-        .filter(Invoice.created_at < period_start)
+        .filter(Invoice.invoice_date < period_start)
         .one()
     )
 
@@ -259,9 +259,9 @@ def get_ledger_statement(
     period_invoices = (
         db.query(Invoice)
         .filter(Invoice.ledger_id == ledger_id)
-        .filter(Invoice.created_at >= period_start)
-        .filter(Invoice.created_at <= period_end)
-        .order_by(Invoice.created_at.asc(), Invoice.id.asc())
+        .filter(Invoice.invoice_date >= period_start)
+        .filter(Invoice.invoice_date <= period_end)
+        .order_by(Invoice.invoice_date.asc(), Invoice.id.asc())
         .all()
     )
 
@@ -279,7 +279,7 @@ def get_ledger_statement(
         entries.append(LedgerStatementEntry(
             entry_id=invoice.id,
             entry_type="invoice",
-            date=invoice.created_at,
+            date=invoice.invoice_date,
             voucher_type=invoice.voucher_type.title(),
             particulars=invoice.ledger_name or ledger.name,
             debit=float(invoice.total_amount) if invoice.voucher_type == "sales" else 0.0,
@@ -641,7 +641,7 @@ def download_ledger_statement_pdf(
             func.coalesce(func.sum(case((Invoice.voucher_type == "purchase", Invoice.total_amount), else_=0)), 0),
         )
         .filter(Invoice.ledger_id == ledger_id)
-        .filter(Invoice.created_at < period_start)
+        .filter(Invoice.invoice_date < period_start)
         .one()
     )
 
@@ -658,9 +658,9 @@ def download_ledger_statement_pdf(
     period_invoices = (
         db.query(Invoice)
         .filter(Invoice.ledger_id == ledger_id)
-        .filter(Invoice.created_at >= period_start)
-        .filter(Invoice.created_at <= period_end)
-        .order_by(Invoice.created_at.asc(), Invoice.id.asc())
+        .filter(Invoice.invoice_date >= period_start)
+        .filter(Invoice.invoice_date <= period_end)
+        .order_by(Invoice.invoice_date.asc(), Invoice.id.asc())
         .all()
     )
 
@@ -678,7 +678,7 @@ def download_ledger_statement_pdf(
         entries.append(LedgerStatementEntry(
             entry_id=invoice.id,
             entry_type="invoice",
-            date=invoice.created_at,
+            date=invoice.invoice_date,
             voucher_type=invoice.voucher_type.title(),
             particulars=invoice.ledger_name or ledger.name,
             debit=float(invoice.total_amount) if invoice.voucher_type == "sales" else 0.0,

--- a/backend/src/models/invoice.py
+++ b/backend/src/models/invoice.py
@@ -34,6 +34,7 @@ class Invoice(Base):
     sgst_amount = Column(Numeric(10, 2), nullable=False, default=0)
     igst_amount = Column(Numeric(10, 2), nullable=False, default=0)
     total_amount = Column(Numeric(10, 2), nullable=False)
+    invoice_date = Column(DateTime, nullable=False, default=datetime.utcnow)
     created_at = Column(DateTime, default=datetime.utcnow)
 
     ledger = relationship("Buyer", back_populates="invoices")

--- a/backend/src/schemas/invoice.py
+++ b/backend/src/schemas/invoice.py
@@ -1,6 +1,6 @@
-from datetime import datetime
+from datetime import date, datetime
 from pydantic import BaseModel, Field
-from typing import List, Literal
+from typing import List, Literal, Optional
 from src.schemas.ledger import LedgerOut
 
 
@@ -13,6 +13,7 @@ class InvoiceItemCreate(BaseModel):
 class InvoiceCreate(BaseModel):
     ledger_id: int
     voucher_type: Literal["sales", "purchase"] = "sales"
+    invoice_date: Optional[date] = None
     items: List[InvoiceItemCreate]
 
 
@@ -59,6 +60,7 @@ class InvoiceOut(BaseModel):
     sgst_amount: float
     igst_amount: float
     total_amount: float
+    invoice_date: datetime
     created_at: datetime
     items: list[InvoiceItemOut] = Field(default_factory=list)
 

--- a/frontend/e2e/invoices.spec.ts
+++ b/frontend/e2e/invoices.spec.ts
@@ -300,4 +300,70 @@ test.describe('Invoices', () => {
     // The projected total chip should exist somewhere on page
     // It updates as line items are filled
   });
+
+  test('creates an invoice with a custom (backdated) invoice date', async ({ authedPage: page }) => {
+    const { sku, ledgerName } = await seedInvoiceData(page);
+
+    await page.click('[href="/invoices"]');
+    await page.waitForTimeout(500);
+
+    // Select voucher type
+    await page.selectOption('#invoice-voucher-type', 'sales');
+
+    // Select ledger
+    const ledgerSelect = page.locator('#invoice-ledger');
+    const ledgerOptions = ledgerSelect.locator('option');
+    const ledgerCount = await ledgerOptions.count();
+    for (let i = 0; i < ledgerCount; i++) {
+      const text = await ledgerOptions.nth(i).textContent();
+      if (text?.includes(ledgerName)) {
+        const val = (await ledgerOptions.nth(i).getAttribute('value')) || '';
+        await ledgerSelect.selectOption(val);
+        break;
+      }
+    }
+
+    // Set a past invoice date
+    const pastDate = '2025-06-15';
+    await page.fill('#invoice-date', pastDate);
+
+    // Select product in line item
+    const productSelect = page.locator('[id^="invoice-product-"]').first();
+    const prodOptions = productSelect.locator('option');
+    const prodCount = await prodOptions.count();
+    for (let i = 0; i < prodCount; i++) {
+      const text = await prodOptions.nth(i).textContent();
+      if (text?.includes(sku)) {
+        const val = (await prodOptions.nth(i).getAttribute('value')) || '';
+        await productSelect.selectOption(val);
+        break;
+      }
+    }
+    await page.locator('[id^="invoice-quantity-"]').first().fill('2');
+
+    await page.click('button:has-text("Create invoice")');
+    await expectSuccess(page, 'invoice created');
+
+    // Verify the invoice appears in the list with the backdated date
+    const invoiceRow = page.locator('.invoice-row', { hasText: ledgerName }).first();
+    await expect(invoiceRow).toBeVisible();
+    // The date chip should show 6/15/2025 (locale-dependent, check for the year)
+    await expect(invoiceRow.locator('.invoice-meta-chip', { hasText: 'Date' })).toContainText('2025');
+
+    // Verify the invoice date field resets to today after creation
+    const dateInput = page.locator('#invoice-date');
+    const resetValue = await dateInput.inputValue();
+    const today = new Date().toISOString().slice(0, 10);
+    expect(resetValue).toBe(today);
+  });
+
+  test('invoice date defaults to today', async ({ authedPage: page }) => {
+    await page.click('[href="/invoices"]');
+    await page.waitForTimeout(500);
+
+    const dateInput = page.locator('#invoice-date');
+    const value = await dateInput.inputValue();
+    const today = new Date().toISOString().slice(0, 10);
+    expect(value).toBe(today);
+  });
 });

--- a/frontend/src/components/CreateInvoiceModal.tsx
+++ b/frontend/src/components/CreateInvoiceModal.tsx
@@ -43,6 +43,7 @@ export default function CreateInvoiceModal({
   const [ledgers, setLedgers] = useState<Ledger[]>([]);
   const [selectedLedgerId, setSelectedLedgerId] = useState(preselectedLedgerId ? String(preselectedLedgerId) : '');
   const [voucherType, setVoucherType] = useState<'sales' | 'purchase'>(preselectedVoucherType || 'sales');
+  const [invoiceDate, setInvoiceDate] = useState(new Date().toISOString().slice(0, 10));
   const [items, setItems] = useState<InvoiceFormItem[]>([createItem(1)]);
   const [nextItemId, setNextItemId] = useState(2);
   const [loading, setLoading] = useState(true);
@@ -112,6 +113,7 @@ export default function CreateInvoiceModal({
       const payload: InvoiceCreate = {
         ledger_id: Number(selectedLedgerId),
         voucher_type: voucherType,
+        invoice_date: invoiceDate,
         items: items.map((item) => ({
           product_id: Number(item.productId),
           quantity: Number(item.quantity),
@@ -177,6 +179,18 @@ export default function CreateInvoiceModal({
                     <option key={l.id} value={l.id}>{l.name} ({l.gst})</option>
                   ))}
                 </select>
+              </div>
+
+              <div className="field">
+                <label htmlFor="modal-inv-date">Invoice date</label>
+                <input
+                  id="modal-inv-date"
+                  className="input"
+                  type="date"
+                  value={invoiceDate}
+                  onChange={(e) => setInvoiceDate(e.target.value)}
+                  required
+                />
               </div>
             </div>
 

--- a/frontend/src/components/InvoicePreview.tsx
+++ b/frontend/src/components/InvoicePreview.tsx
@@ -102,7 +102,7 @@ export default function InvoicePreview({ invoice, products, currencyCode, onClos
             <div className="invoice-sheet__meta">
               <span className="invoice-badge">{invoice.voucher_type === 'sales' ? 'Sales' : 'Purchase'}</span>
               <h2>Invoice {invoice.invoice_number || `#${invoice.id}`}</h2>
-              <p>Date: {new Date(invoice.created_at).toLocaleDateString()}</p>
+              <p>Date: {new Date(invoice.invoice_date).toLocaleDateString()}</p>
               <p>Currency: {previewCurrencyCode}</p>
             </div>
           </header>

--- a/frontend/src/pages/InvoicesPage.tsx
+++ b/frontend/src/pages/InvoicesPage.tsx
@@ -40,6 +40,7 @@ export default function InvoicesPage() {
   const [company, setCompany] = useState<CompanyProfile | null>(null);
   const [selectedLedgerId, setSelectedLedgerId] = useState('');
   const [voucherType, setVoucherType] = useState<'sales' | 'purchase'>('sales');
+  const [invoiceDate, setInvoiceDate] = useState(new Date().toISOString().slice(0, 10));
   const [showLedgerModal, setShowLedgerModal] = useState(false);
   const [showProductModal, setShowProductModal] = useState(false);
   const [showStockModal, setShowStockModal] = useState(false);
@@ -153,6 +154,7 @@ export default function InvoicesPage() {
     const defaultProduct = products[0];
     setItems([createItem(1, String(defaultProduct?.id ?? ''), String(defaultProduct?.price ?? ''))]);
     setNextItemId(2);
+    setInvoiceDate(new Date().toISOString().slice(0, 10));
   }
 
   function startEditingInvoice(invoice: Invoice) {
@@ -171,6 +173,7 @@ export default function InvoicesPage() {
     setEditingInvoiceId(invoice.id);
     setVoucherType(invoice.voucher_type);
     setSelectedLedgerId(String(invoice.ledger_id));
+    setInvoiceDate(invoice.invoice_date ? invoice.invoice_date.slice(0, 10) : new Date().toISOString().slice(0, 10));
 
     const nextItems = invoice.items.map((line, index) => ({
       id: index + 1,
@@ -194,6 +197,7 @@ export default function InvoicesPage() {
       const payload: InvoiceCreate = {
         ledger_id: Number(selectedLedgerId),
         voucher_type: voucherType,
+        invoice_date: invoiceDate,
         items: items.map((item) => ({
           product_id: Number(item.productId),
           quantity: Number(item.quantity),
@@ -428,6 +432,18 @@ export default function InvoicesPage() {
                 </select>
               </div>
 
+              <div className="field">
+                <label htmlFor="invoice-date">Invoice date</label>
+                <input
+                  id="invoice-date"
+                  className="input"
+                  type="date"
+                  value={invoiceDate}
+                  onChange={(event) => setInvoiceDate(event.target.value)}
+                  required
+                />
+              </div>
+
               <div className="button-row">
                 <button type="button" className="button button--secondary" onClick={() => setShowLedgerModal(true)}>
                   Add ledger
@@ -588,7 +604,7 @@ export default function InvoicesPage() {
                       </div>
 
                       <div className="invoice-row__chips">
-                        <span className="invoice-meta-chip">Date {new Date(invoice.created_at).toLocaleDateString()}</span>
+                        <span className="invoice-meta-chip">Date {new Date(invoice.invoice_date).toLocaleDateString()}</span>
                         <span className="invoice-meta-chip">GST {invoice.ledger?.gst || invoice.ledger_gst || 'N/A'}</span>
                         <span className="invoice-meta-chip">Phone {invoice.ledger?.phone_number || invoice.ledger_phone || 'N/A'}</span>
                       </div>

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -146,6 +146,7 @@ export type Invoice = {
   sgst_amount: number;
   igst_amount: number;
   total_amount: number;
+  invoice_date: string;
   created_at: string;
   items: InvoiceItem[];
 };
@@ -171,6 +172,7 @@ export type InvoiceItemInput = {
 export type InvoiceCreate = {
   voucher_type: 'sales' | 'purchase';
   ledger_id: number;
+  invoice_date?: string;
   items: InvoiceItemInput[];
 };
 


### PR DESCRIPTION
Closes #17

## Changes
- Add `invoice_date` column to invoices table with migration (backfills from `created_at`)
- Accept optional `invoice_date` in create/update payload (defaults to today)
- Use `invoice_date` in PDF generation, day-book, and ledger statement queries
- Add date picker to invoice form and quick-create modal
- Display `invoice_date` in invoice list and preview
- Add e2e tests for backdated invoice creation and default date

## Testing
All 63 e2e tests pass (including 2 new tests for this feature).