### PR TITLE
feat: Add confirmation dialog for delete actions

### DIFF
--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -1,0 +1,71 @@
+import type { ReactNode } from 'react';
+
+type ConfirmDialogProps = {
+  /** Message to display in the dialog */
+  message: string;
+  /** Called when user confirms the action */
+  onConfirm: () => void;
+  /** Called when user cancels the action */
+  onCancel: () => void;
+  /** Optional custom title for the dialog */
+  title?: string;
+  /** Optional custom confirm button text (defaults to "Delete") */
+  confirmText?: string;
+  /** Optional custom cancel button text (defaults to "Cancel") */
+  cancelText?: string;
+  /** Optional danger level - affects confirm button styling */
+  danger?: boolean;
+};
+
+/**
+ * A reusable confirmation dialog component.
+ * Displays a modal with a message and Cancel/Confirm buttons.
+ * Used for confirming destructive actions like delete.
+ */
+export default function ConfirmDialog({
+  message,
+  onConfirm,
+  onCancel,
+  title = 'Confirm action',
+  confirmText = 'Confirm',
+  cancelText = 'Cancel',
+  danger = false,
+}: ConfirmDialogProps) {
+  return (
+    <div
+      className="modal-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="confirm-dialog-title"
+      aria-describedby="confirm-dialog-message"
+      onClick={onCancel}
+    >
+      <div
+        className="modal-panel"
+        onClick={(e) => e.stopPropagation()}
+        style={{ maxWidth: '400px' }}
+      >
+        <div className="panel__header">
+          <h2 id="confirm-dialog-title" className="nav-panel__title">{title}</h2>
+        </div>
+        <p id="confirm-dialog-message" style={{ margin: '16px 0' }}>{message}</p>
+        <div className="button-row" style={{ justifyContent: 'flex-end', gap: '12px' }}>
+          <button
+            type="button"
+            className="button button--secondary"
+            onClick={onCancel}
+          >
+            {cancelText}
+          </button>
+          <button
+            type="button"
+            className={`button ${danger ? 'button--danger' : 'button--primary'}`}
+            onClick={onConfirm}
+          >
+            {confirmText}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/InvoicesPage.tsx
+++ b/frontend/src/pages/InvoicesPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import api, { getApiErrorMessage } from '../api/client';
 import type { CompanyProfile, Invoice, InvoiceCreate, Ledger, LedgerCreate, PaginatedInvoices, Product } from '../types/api';
 import InvoicePreview from '../components/InvoicePreview';
+import ConfirmDialog from '../components/ConfirmDialog';
 
 type InvoiceFormItem = {
   id: number;
@@ -66,6 +67,8 @@ export default function InvoicesPage() {
   const [nextItemId, setNextItemId] = useState(2);
   const [editingInvoiceId, setEditingInvoiceId] = useState<number | null>(null);
   const [deletingInvoiceId, setDeletingInvoiceId] = useState<number | null>(null);
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const [pendingDeleteInvoiceId, setPendingDeleteInvoiceId] = useState<number | null>(null);
   const [previewInvoice, setPreviewInvoice] = useState<Invoice | null>(null);
   const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
@@ -227,18 +230,26 @@ export default function InvoicesPage() {
   }
 
   async function handleDeleteInvoice(invoiceId: number) {
-    const shouldDelete = window.confirm(`Delete invoice #${invoiceId}? Inventory will be rolled back.`);
-    if (!shouldDelete) {
-      return;
-    }
+    setPendingDeleteInvoiceId(invoiceId);
+    setShowDeleteDialog(true);
+  }
+
+  function cancelDeleteInvoice() {
+    setShowDeleteDialog(false);
+    setPendingDeleteInvoiceId(null);
+  }
+
+  async function confirmDeleteInvoice() {
+    if (pendingDeleteInvoiceId === null) return;
+    setShowDeleteDialog(false);
 
     try {
-      setDeletingInvoiceId(invoiceId);
+      setDeletingInvoiceId(pendingDeleteInvoiceId);
       setError('');
       setSuccess('');
-      await api.delete(`/invoices/${invoiceId}`);
+      await api.delete(`/invoices/${pendingDeleteInvoiceId}`);
 
-      if (editingInvoiceId === invoiceId) {
+      if (editingInvoiceId === pendingDeleteInvoiceId) {
         resetInvoiceForm();
       }
 
@@ -248,6 +259,7 @@ export default function InvoicesPage() {
       setError(getApiErrorMessage(err, 'Unable to delete invoice'));
     } finally {
       setDeletingInvoiceId(null);
+      setPendingDeleteInvoiceId(null);
     }
   }
 
@@ -984,6 +996,18 @@ export default function InvoicesPage() {
             </form>
           </div>
         </div>
+      ) : null}
+
+      {showDeleteDialog ? (
+        <ConfirmDialog
+          message={`Are you sure you want to delete invoice #${pendingDeleteInvoiceId}? Inventory will be rolled back.`}
+          title="Delete invoice"
+          confirmText="Delete"
+          cancelText="Cancel"
+          danger={true}
+          onConfirm={() => void confirmDeleteInvoice()}
+          onCancel={cancelDeleteInvoice}
+        />
       ) : null}
     </div>
   );

--- a/frontend/src/pages/LedgersPage.tsx
+++ b/frontend/src/pages/LedgersPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import api, { getApiErrorMessage } from '../api/client';
 import type { Ledger, PaginatedLedgers } from '../types/api';
+import ConfirmDialog from '../components/ConfirmDialog';
 
 export default function LedgersPage() {
   const navigate = useNavigate();
@@ -9,6 +10,8 @@ export default function LedgersPage() {
   const [ledgers, setLedgers] = useState<Ledger[]>([]);
   const [loading, setLoading] = useState(true);
   const [deletingLedgerId, setDeletingLedgerId] = useState<number | null>(null);
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const [pendingDeleteLedgerId, setPendingDeleteLedgerId] = useState<number | null>(null);
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
   const [search, setSearch] = useState('');
@@ -46,22 +49,33 @@ export default function LedgersPage() {
     void loadLedgers(page, search);
   }, [page, search]);
 
-  async function handleDeleteLedger(ledgerId: number) {
-    const confirmed = window.confirm(`Delete ledger #${ledgerId}?`);
-    if (!confirmed) return;
+  function handleDeleteLedger(ledgerId: number) {
+    setPendingDeleteLedgerId(ledgerId);
+    setShowDeleteDialog(true);
+  }
+
+  function cancelDeleteLedger() {
+    setShowDeleteDialog(false);
+    setPendingDeleteLedgerId(null);
+  }
+
+  async function confirmDeleteLedger() {
+    if (pendingDeleteLedgerId === null) return;
+    setShowDeleteDialog(false);
 
     try {
-      setDeletingLedgerId(ledgerId);
+      setDeletingLedgerId(pendingDeleteLedgerId);
       setError('');
       setSuccess('');
-      await api.delete(`/ledgers/${ledgerId}`);
-      setLedgers((current) => current.filter((l) => l.id !== ledgerId));
+      await api.delete(`/ledgers/${pendingDeleteLedgerId}`);
+      setLedgers((current) => current.filter((l) => l.id !== pendingDeleteLedgerId));
       setTotal((t) => t - 1);
       setSuccess('Ledger deleted successfully.');
     } catch (err) {
       setError(getApiErrorMessage(err, 'Unable to delete ledger'));
     } finally {
       setDeletingLedgerId(null);
+      setPendingDeleteLedgerId(null);
     }
   }
 
@@ -146,7 +160,7 @@ export default function LedgersPage() {
                       <button
                         type="button"
                         className="button button--danger"
-                        onClick={() => void handleDeleteLedger(ledger.id)}
+                        onClick={() => handleDeleteLedger(ledger.id)}
                         disabled={deletingLedgerId === ledger.id}
                       >
                         {deletingLedgerId === ledger.id ? 'Deleting...' : 'Delete'}
@@ -182,6 +196,18 @@ export default function LedgersPage() {
           ) : null}
         </article>
       </section>
+
+      {showDeleteDialog ? (
+        <ConfirmDialog
+          message={`Are you sure you want to delete ledger #${pendingDeleteLedgerId}?`}
+          title="Delete ledger"
+          confirmText="Delete"
+          cancelText="Cancel"
+          danger={true}
+          onConfirm={() => void confirmDeleteLedger()}
+          onCancel={cancelDeleteLedger}
+        />
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
This PR implements issue #23 by adding a reusable confirmation dialog for delete actions.

## Changes
- **New**: Created  component in 
- **Modified**: Updated  to use ConfirmDialog instead of window.confirm
- **Modified**: Updated  to use ConfirmDialog instead of window.confirm

## Features
- Reusable modal dialog component with customizable:
  - Title
  - Message
  - Confirm/Cancel button text
  - Danger styling (for destructive actions)
- Proper accessibility attributes (aria-modal, aria-labelledby, aria-describedby)
- Clear visual confirmation before destructive actions

## Acceptance Criteria (from #23)
- ✅ Clicking Delete opens a confirmation dialog instead of deleting immediately
- ✅ The dialog has Cancel (closes dialog) and Delete (executes action) buttons
- ✅ Component is reusable for other delete actions in the app
- ✅ Existing delete functionality still works after confirmation

## Testing
The implementation follows the existing modal pattern in the project (using the same CSS classes as CreateInvoiceModal).

Fixes #23