### PR TITLE
fix(e2e): use custom ConfirmDialog instead of native dialog for delete tests

### DIFF
--- a/frontend/e2e/invoices.spec.ts
+++ b/frontend/e2e/invoices.spec.ts
@@ -285,10 +285,10 @@ test.describe('Invoices', () => {
     await page.click('button:has-text("Create invoice")');
     await expectSuccess(page, 'invoice created');
 
-    // Delete the invoice — handle confirm dialog
+    // Delete the invoice — click Delete row button, then confirm in the custom dialog
     const invoiceRow = page.locator('.invoice-row', { hasText: ledgerName }).first();
-    page.on('dialog', (dialog) => dialog.accept());
     await invoiceRow.locator('button:has-text("Delete")').click();
+    await page.locator('.modal-overlay button:has-text("Delete")').click();
     await expect(page.locator('.status-banner--success')).toContainText('deleted', { timeout: 10_000 });
   });
 

--- a/frontend/e2e/ledgers.spec.ts
+++ b/frontend/e2e/ledgers.spec.ts
@@ -100,13 +100,13 @@ test.describe('Ledgers CRUD', () => {
     await expect(page.locator('h1')).toContainText('Ledger master', { timeout: 10_000 });
     await expectSuccess(page, 'Ledger created');
 
-    // Search, then delete — accept the confirm dialog and wait for new banner
+    // Search, then delete — click Delete row button, then confirm in the custom dialog
     await page.fill('#ledger-search', name);
     await page.waitForTimeout(500);
     const row = page.locator('.table-row', { hasText: name });
     await expect(row).toBeVisible({ timeout: 10_000 });
-    page.on('dialog', (dialog) => dialog.accept());
     await row.locator('button:has-text("Delete")').click();
+    await page.locator('.modal-overlay button:has-text("Delete")').click();
     await expect(page.locator('.status-banner--success')).toContainText('Ledger deleted', { timeout: 10_000 });
     await expect(page.locator('.table-row', { hasText: name })).not.toBeVisible();
   });


### PR DESCRIPTION
The merge replaced `window.confirm()` with a custom `ConfirmDialog` component in `InvoicesPage` and `LedgersPage`, but the e2e tests still used `page.on('dialog', ...)` which only catches native browser dialogs. The delete confirmation never fired, so tests saw the stale creation banner.

**Fix:** Click the confirm button inside `.modal-overlay` instead of accepting a native dialog.

**Tests:** All 18 tests in `invoices.spec.ts` and `ledgers.spec.ts` pass.