### PR TITLE
feat: replace status banners with toast notifications

### DIFF
--- a/frontend/src/components/StatusToasts.tsx
+++ b/frontend/src/components/StatusToasts.tsx
@@ -1,0 +1,70 @@
+import { useEffect } from 'react';
+
+type ToastKind = 'success' | 'error';
+
+type ToastProps = {
+  kind: ToastKind;
+  message: string;
+  onDismiss: () => void;
+};
+
+type StatusToastsProps = {
+  error?: string;
+  success?: string;
+  onClearError: () => void;
+  onClearSuccess: () => void;
+  successDurationMs?: number;
+};
+
+function Toast({ kind, message, onDismiss }: ToastProps) {
+  const title = kind === 'success' ? 'Success notification' : 'Error notification';
+
+  return (
+    <div className={`toast toast--${kind}`} role={kind === 'error' ? 'alert' : 'status'} aria-live={kind === 'error' ? 'assertive' : 'polite'}>
+      <div className="toast__content">
+        <strong className="toast__title">{title}</strong>
+        <span className="toast__message">{message}</span>
+      </div>
+      <button
+        type="button"
+        className="toast__dismiss"
+        onClick={onDismiss}
+        aria-label={`Dismiss ${kind} notification`}
+        title="Dismiss notification"
+      >
+        ×
+      </button>
+    </div>
+  );
+}
+
+export default function StatusToasts({
+  error,
+  success,
+  onClearError,
+  onClearSuccess,
+  successDurationMs = 5000,
+}: StatusToastsProps) {
+  useEffect(() => {
+    if (!success) {
+      return undefined;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      onClearSuccess();
+    }, successDurationMs);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [success, successDurationMs, onClearSuccess]);
+
+  if (!error && !success) {
+    return null;
+  }
+
+  return (
+    <div className="toast-stack" aria-live="polite" aria-atomic="true">
+      {error ? <Toast kind="error" message={error} onDismiss={onClearError} /> : null}
+      {success ? <Toast kind="success" message={success} onDismiss={onClearSuccess} /> : null}
+    </div>
+  );
+}

--- a/frontend/src/pages/CompanyPage.tsx
+++ b/frontend/src/pages/CompanyPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import api, { getApiErrorMessage } from '../api/client';
+import StatusToasts from '../components/StatusToasts';
 import type { CompanyProfile, CompanyProfileUpdate } from '../types/api';
 
 export default function CompanyPage() {
@@ -95,8 +96,7 @@ export default function CompanyPage() {
         </div>
       </section>
 
-      {error ? <div className="status-banner status-banner--error">{error}</div> : null}
-      {success ? <div className="status-banner status-banner--success">{success}</div> : null}
+      <StatusToasts error={error} success={success} onClearError={() => setError('')} onClearSuccess={() => setSuccess('')} />
 
       <section className="content-grid">
         <article className="panel stack">

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import api, { getApiErrorMessage } from '../api/client';
+import StatusToasts from '../components/StatusToasts';
 import type { CompanyProfile, InventoryRow, Invoice, Product } from '../types/api';
 
 type DashboardState = {
@@ -88,7 +89,7 @@ export default function DashboardPage() {
         <div className="status-chip">Backend synced</div>
       </section>
 
-      {error ? <div className="status-banner status-banner--error">{error}</div> : null}
+      <StatusToasts error={error} onClearError={() => setError('')} onClearSuccess={() => {}} />
 
       <section className="stats-grid">
         <article className="stat-card">

--- a/frontend/src/pages/DayBookPage.tsx
+++ b/frontend/src/pages/DayBookPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import api, { getApiErrorMessage } from '../api/client';
+import StatusToasts from '../components/StatusToasts';
 import type { CompanyProfile, DayBook } from '../types/api';
 
 function formatCurrency(value: number, currencyCode = 'USD') {
@@ -76,7 +77,7 @@ export default function DayBookPage() {
         <div className="status-chip">{dayBook?.entries.length ?? 0} vouchers</div>
       </section>
 
-      {error ? <div className="status-banner status-banner--error">{error}</div> : null}
+      <StatusToasts error={error} onClearError={() => setError('')} onClearSuccess={() => {}} />
 
       <section className="content-grid">
         <article className="panel stack">

--- a/frontend/src/pages/InventoryPage.tsx
+++ b/frontend/src/pages/InventoryPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import api, { getApiErrorMessage } from '../api/client';
+import StatusToasts from '../components/StatusToasts';
 import type { InventoryAdjust, InventoryRow, Product } from '../types/api';
 
 export default function InventoryPage() {
@@ -72,8 +73,7 @@ export default function InventoryPage() {
         <div className="status-chip">{rows.length} rows tracked</div>
       </section>
 
-      {error ? <div className="status-banner status-banner--error">{error}</div> : null}
-      {success ? <div className="status-banner status-banner--success">{success}</div> : null}
+      <StatusToasts error={error} success={success} onClearError={() => setError('')} onClearSuccess={() => setSuccess('')} />
 
       <section className="content-grid">
         <article className="panel stack">

--- a/frontend/src/pages/InvoicesPage.tsx
+++ b/frontend/src/pages/InvoicesPage.tsx
@@ -3,6 +3,7 @@ import api, { getApiErrorMessage } from '../api/client';
 import type { CompanyProfile, Invoice, InvoiceCreate, Ledger, LedgerCreate, PaginatedInvoices, Product } from '../types/api';
 import InvoicePreview from '../components/InvoicePreview';
 import ConfirmDialog from '../components/ConfirmDialog';
+import StatusToasts from '../components/StatusToasts';
 
 type InvoiceFormItem = {
   id: number;
@@ -371,8 +372,7 @@ export default function InvoicesPage() {
         <div className="status-chip">{invoiceTotal} invoices listed</div>
       </section>
 
-      {error ? <div className="status-banner status-banner--error">{error}</div> : null}
-      {success ? <div className="status-banner status-banner--success">{success}</div> : null}
+      <StatusToasts error={error} success={success} onClearError={() => setError('')} onClearSuccess={() => setSuccess('')} />
 
       <section className="content-grid">
         <article className="panel stack">

--- a/frontend/src/pages/LedgerCreatePage.tsx
+++ b/frontend/src/pages/LedgerCreatePage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import api, { getApiErrorMessage } from '../api/client';
+import StatusToasts from '../components/StatusToasts';
 import type { Ledger, LedgerCreate } from '../types/api';
 
 export default function LedgerCreatePage() {
@@ -113,7 +114,7 @@ export default function LedgerCreatePage() {
         </div>
       </section>
 
-      {error ? <div className="status-banner status-banner--error">{error}</div> : null}
+      <StatusToasts error={error} onClearError={() => setError('')} onClearSuccess={() => {}} />
 
       <section className="content-grid">
         <article className="panel stack">

--- a/frontend/src/pages/LedgerViewPage.tsx
+++ b/frontend/src/pages/LedgerViewPage.tsx
@@ -4,6 +4,7 @@ import api, { getApiErrorMessage } from '../api/client';
 import type { CompanyProfile, Invoice, Ledger, LedgerStatement, PaymentCreate, Product } from '../types/api';
 import InvoicePreview from '../components/InvoicePreview';
 import StatementPreview from '../components/StatementPreview';
+import StatusToasts from '../components/StatusToasts';
 import CreateInvoiceModal from '../components/CreateInvoiceModal';
 
 function formatCurrency(value: number, currencyCode = 'INR') {
@@ -165,7 +166,7 @@ export default function LedgerViewPage() {
             <h1 className="page-title">Ledger not found</h1>
           </div>
         </section>
-        {error ? <div className="status-banner status-banner--error">{error}</div> : null}
+        <StatusToasts error={error} onClearError={() => setError('')} onClearSuccess={() => {}} />
       </div>
     );
   }
@@ -192,7 +193,7 @@ export default function LedgerViewPage() {
         </button>
       </section>
 
-      {error ? <div className="status-banner status-banner--error">{error}</div> : null}
+      <StatusToasts error={error} onClearError={() => setError('')} onClearSuccess={() => {}} />
 
       <section className="content-grid">
         <article className="panel stack">

--- a/frontend/src/pages/LedgersPage.tsx
+++ b/frontend/src/pages/LedgersPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import api, { getApiErrorMessage } from '../api/client';
+import StatusToasts from '../components/StatusToasts';
 import type { Ledger, PaginatedLedgers } from '../types/api';
 import ConfirmDialog from '../components/ConfirmDialog';
 
@@ -95,8 +96,7 @@ export default function LedgersPage() {
         </div>
       </section>
 
-      {error ? <div className="status-banner status-banner--error">{error}</div> : null}
-      {success ? <div className="status-banner status-banner--success">{success}</div> : null}
+      <StatusToasts error={error} success={success} onClearError={() => setError('')} onClearSuccess={() => setSuccess('')} />
 
       <section className="content-grid">
         <article className="panel stack">

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion';
 import { useNavigate } from 'react-router-dom';
 import { getApiErrorMessage } from '../api/client';
 import { useAuth } from '../context/AuthContext';
+import StatusToasts from '../components/StatusToasts';
 
 export default function LoginPage() {
   const [email, setEmail] = useState('');
@@ -105,7 +106,7 @@ export default function LoginPage() {
             />
           </div>
 
-          {error ? <div className="status-banner status-banner--error">{error}</div> : null}
+          <StatusToasts error={error} onClearError={() => setError('')} onClearSuccess={() => {}} />
 
           <button className="button button--primary" disabled={submitting}>
             {submitting ? 'Signing in...' : 'Open dashboard'}

--- a/frontend/src/pages/ProductsPage.tsx
+++ b/frontend/src/pages/ProductsPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import api, { getApiErrorMessage } from '../api/client';
 import type { CompanyProfile, PaginatedProducts, Product, ProductCreate } from '../types/api';
+import StatusToasts from '../components/StatusToasts';
 
 function formatCurrency(value: number, currencyCode = 'USD') {
   try {
@@ -155,8 +156,7 @@ export default function ProductsPage() {
         <div className="status-chip">{total} loaded</div>
       </section>
 
-      {error ? <div className="status-banner status-banner--error">{error}</div> : null}
-      {success ? <div className="status-banner status-banner--success">{success}</div> : null}
+      <StatusToasts error={error} success={success} onClearError={() => setError('')} onClearSuccess={() => setSuccess('')} />
 
       <section className="content-grid">
         <article className="panel stack">

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -393,22 +393,77 @@ textarea {
   transform: translateY(-1px);
 }
 
-.status-banner {
-  padding: 12px 14px;
-  border-radius: 16px;
-  font-weight: 600;
+.toast-stack {
+  position: fixed;
+  top: 24px;
+  right: 24px;
+  display: grid;
+  gap: 12px;
+  width: min(360px, calc(100vw - 32px));
+  z-index: 1200;
+  pointer-events: none;
 }
 
-.status-banner--error {
-  background: rgba(255, 139, 139, 0.12);
-  border: 1px solid rgba(255, 139, 139, 0.18);
+.toast {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 14px 16px;
+  border-radius: 18px;
+  border: 1px solid rgba(148, 184, 255, 0.16);
+  background: rgba(9, 18, 33, 0.92);
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.28);
+  backdrop-filter: blur(12px);
+  animation: toast-slide-in 180ms ease-out;
+  pointer-events: auto;
+}
+
+.toast--error {
+  border-color: rgba(255, 139, 139, 0.28);
   color: #ffc1c1;
 }
 
-.status-banner--success {
-  background: rgba(87, 209, 201, 0.12);
-  border: 1px solid rgba(87, 209, 201, 0.18);
+.toast--success {
+  border-color: rgba(87, 209, 201, 0.28);
   color: #bcfff9;
+}
+
+.toast__content {
+  display: grid;
+  gap: 4px;
+  flex: 1;
+}
+
+.toast__title {
+  font-size: 0.8rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.toast__message {
+  line-height: 1.45;
+}
+
+.toast__dismiss {
+  border: none;
+  background: transparent;
+  color: inherit;
+  font-size: 1.15rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 2px;
+}
+
+@keyframes toast-slide-in {
+  from {
+    opacity: 0;
+    transform: translateY(-8px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 .status-chip {


### PR DESCRIPTION
## Summary

Replaces inline success/error status banners with reusable toast notifications across the frontend.

## Changes

- add a reusable `StatusToasts` component in `frontend/src/components/`
- render toasts in a fixed top-right position so messages no longer shift page layout
- auto-dismiss success notifications after 5 seconds
- keep error notifications visible until manually dismissed
- replace existing `status-banner` usage across the main pages

## Testing

- `cd frontend && npm install --ignore-scripts`
- `cd frontend && npm run build`

Closes #40
