### PR TITLE
feat: add accessible labels to action buttons

### DIFF
--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -54,6 +54,8 @@ export default function ConfirmDialog({
             type="button"
             className="button button--secondary"
             onClick={onCancel}
+            title={cancelText}
+            aria-label={cancelText}
           >
             {cancelText}
           </button>
@@ -61,6 +63,8 @@ export default function ConfirmDialog({
             type="button"
             className={`button ${danger ? 'button--danger' : 'button--primary'}`}
             onClick={onConfirm}
+            title={confirmText}
+            aria-label={confirmText}
           >
             {confirmText}
           </button>

--- a/frontend/src/components/CreateInvoiceModal.tsx
+++ b/frontend/src/components/CreateInvoiceModal.tsx
@@ -142,7 +142,7 @@ export default function CreateInvoiceModal({
           </div>
           <div className="button-row">
             <div className="status-chip">Total {formatCurrency(totalAmount, currencyCode)}</div>
-            <button type="button" className="button button--ghost" onClick={onClose}>✕</button>
+            <button type="button" className="button button--ghost" onClick={onClose} title="Close invoice dialog" aria-label="Close invoice dialog">✕</button>
           </div>
         </div>
 
@@ -257,18 +257,18 @@ export default function CreateInvoiceModal({
                       {formatCurrency(lineTotal, currencyCode)}
                       <div className="table-subtext">Incl GST {gstRate}% ({formatCurrency(taxAmount, currencyCode)})</div>
                     </div>
-                    <button type="button" className="button button--danger" onClick={() => removeItem(item.id)}>Remove</button>
+                    <button type="button" className="button button--danger" onClick={() => removeItem(item.id)} title={`Remove line item ${index + 1}`} aria-label={`Remove line item ${index + 1}`}>Remove</button>
                   </div>
                 );
               })}
             </div>
 
             <div className="button-row">
-              <button type="button" className="button button--ghost" onClick={addItem} disabled={products.length === 0}>
+              <button type="button" className="button button--ghost" onClick={addItem} disabled={products.length === 0} title="Add line item" aria-label="Add line item">
                 Add line item
               </button>
-              <button type="button" className="button button--secondary" onClick={onClose}>Cancel</button>
-              <button className="button button--primary" disabled={submitting || products.length === 0 || !selectedLedgerId}>
+              <button type="button" className="button button--secondary" onClick={onClose} title="Cancel invoice creation" aria-label="Cancel invoice creation">Cancel</button>
+              <button className="button button--primary" disabled={submitting || products.length === 0 || !selectedLedgerId} title="Create invoice" aria-label="Create invoice">
                 {submitting ? 'Creating invoice...' : 'Create invoice'}
               </button>
             </div>

--- a/frontend/src/components/InvoicePreview.tsx
+++ b/frontend/src/components/InvoicePreview.tsx
@@ -53,12 +53,14 @@ export default function InvoicePreview({ invoice, products, currencyCode, onClos
             <h2 id="invoice-preview-title" className="nav-panel__title">Printable invoice {invoice.invoice_number || `#${invoice.id}`}</h2>
           </div>
           <div className="button-row">
-            <button type="button" className="button button--secondary" onClick={() => window.print()}>
+            <button type="button" className="button button--secondary" onClick={() => window.print()} title="Print invoice" aria-label="Print invoice">
               Print
             </button>
             <button
               type="button"
               className="button button--primary"
+              title="Download invoice PDF"
+              aria-label="Download invoice PDF"
               onClick={async () => {
                 try {
                   const response = await api.get(`/invoices/${invoice.id}/pdf`, {
@@ -77,7 +79,7 @@ export default function InvoicePreview({ invoice, products, currencyCode, onClos
             >
               Download PDF
             </button>
-            <button type="button" className="button button--ghost" onClick={onClose}>
+            <button type="button" className="button button--ghost" onClick={onClose} title="Close invoice preview" aria-label="Close invoice preview">
               Close
             </button>
           </div>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -32,7 +32,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
             <p className="eyebrow">Signed in as</p>
             <p className="session-email">{userEmail ?? 'Active user'}</p>
           </div>
-          <button className="button button--ghost" onClick={logout}>
+          <button className="button button--ghost" onClick={logout} title="Logout" aria-label="Logout">
             Logout
           </button>
         </div>

--- a/frontend/src/components/StatementPreview.tsx
+++ b/frontend/src/components/StatementPreview.tsx
@@ -46,12 +46,14 @@ export default function StatementPreview({ ledger, statement, company, currencyC
             </h2>
           </div>
           <div className="button-row">
-            <button type="button" className="button button--secondary" onClick={() => window.print()}>
+            <button type="button" className="button button--secondary" onClick={() => window.print()} title="Print statement" aria-label="Print statement">
               Print
             </button>
             <button
               type="button"
               className="button button--primary"
+              title="Download statement PDF"
+              aria-label="Download statement PDF"
               onClick={async () => {
                 try {
                   const response = await api.get(`/ledgers/${ledger.id}/statement/pdf`, {
@@ -71,7 +73,7 @@ export default function StatementPreview({ ledger, statement, company, currencyC
             >
               Download PDF
             </button>
-            <button type="button" className="button button--ghost" onClick={onClose}>
+            <button type="button" className="button button--ghost" onClick={onClose} title="Close statement preview" aria-label="Close statement preview">
               Close
             </button>
           </div>

--- a/frontend/src/pages/CompanyPage.tsx
+++ b/frontend/src/pages/CompanyPage.tsx
@@ -253,7 +253,7 @@ export default function CompanyPage() {
               </div>
 
               <div className="button-row">
-                <button className="button button--primary" disabled={submitting}>
+                <button className="button button--primary" disabled={submitting} title="Save company details" aria-label="Save company details">
                   {submitting ? 'Saving company...' : 'Save company details'}
                 </button>
               </div>

--- a/frontend/src/pages/InventoryPage.tsx
+++ b/frontend/src/pages/InventoryPage.tsx
@@ -119,7 +119,7 @@ export default function InventoryPage() {
             </div>
 
             <div className="button-row">
-              <button className="button button--secondary" disabled={submitting || products.length === 0}>
+              <button className="button button--secondary" disabled={submitting || products.length === 0} title="Apply inventory adjustment" aria-label="Apply inventory adjustment">
                 {submitting ? 'Applying change...' : 'Apply adjustment'}
               </button>
             </div>

--- a/frontend/src/pages/InvoicesPage.tsx
+++ b/frontend/src/pages/InvoicesPage.tsx
@@ -457,13 +457,13 @@ export default function InvoicesPage() {
               </div>
 
               <div className="button-row">
-                <button type="button" className="button button--secondary" onClick={() => setShowLedgerModal(true)}>
+                <button type="button" className="button button--secondary" onClick={() => setShowLedgerModal(true)} title="Add ledger" aria-label="Add ledger">
                   Add ledger
                 </button>
-                <button type="button" className="button button--secondary" onClick={() => setShowProductModal(true)}>
+                <button type="button" className="button button--secondary" onClick={() => setShowProductModal(true)} title="Add product" aria-label="Add product">
                   Add product
                 </button>
-                <button type="button" className="button button--secondary" onClick={() => setShowStockModal(true)}>
+                <button type="button" className="button button--secondary" onClick={() => setShowStockModal(true)} title="Update stock" aria-label="Update stock">
                   Update stock
                 </button>
               </div>
@@ -536,7 +536,7 @@ export default function InvoicesPage() {
                       {formatCurrency(lineTotal, activeCurrencyCode)}
                       <div className="table-subtext">Incl GST {gstRate}% ({formatCurrency(taxAmount, activeCurrencyCode)})</div>
                     </div>
-                    <button type="button" className="button button--danger" onClick={() => removeItem(item.id)}>
+                    <button type="button" className="button button--danger" onClick={() => removeItem(item.id)} title={`Remove line item ${index + 1}`} aria-label={`Remove line item ${index + 1}`}>
                       Remove
                     </button>
                   </div>
@@ -545,15 +545,15 @@ export default function InvoicesPage() {
             </div>
 
             <div className="button-row">
-              <button type="button" className="button button--ghost" onClick={addItem} disabled={products.length === 0}>
+              <button type="button" className="button button--ghost" onClick={addItem} disabled={products.length === 0} title="Add line item" aria-label="Add line item">
                 Add line item
               </button>
               {editingInvoiceId ? (
-                <button type="button" className="button button--secondary" onClick={resetInvoiceForm}>
+                <button type="button" className="button button--secondary" onClick={resetInvoiceForm} title="Cancel invoice edit" aria-label="Cancel invoice edit">
                   Cancel edit
                 </button>
               ) : null}
-              <button className="button button--primary" disabled={submitting || products.length === 0 || !selectedLedgerId}>
+              <button className="button button--primary" disabled={submitting || products.length === 0 || !selectedLedgerId} title={editingInvoiceId ? "Update invoice" : "Create invoice"} aria-label={editingInvoiceId ? "Update invoice" : "Create invoice"}>
                 {submitting ? (editingInvoiceId ? 'Updating invoice...' : 'Creating invoice...') : editingInvoiceId ? 'Update invoice' : 'Create invoice'}
               </button>
             </div>
@@ -658,10 +658,10 @@ export default function InvoicesPage() {
                       </div>
 
                       <div className="invoice-row__actions">
-                        <button type="button" className="button button--ghost button--small" onClick={() => setPreviewInvoice(invoice)} title="Preview invoice">
+                        <button type="button" className="button button--ghost button--small" onClick={() => setPreviewInvoice(invoice)} title="Preview invoice" aria-label={`Preview invoice ${invoice.invoice_number || invoice.id}`}>
                           Preview
                         </button>
-                        <button type="button" className="button button--ghost button--small" onClick={() => startEditingInvoice(invoice)} disabled={submitting} title="Edit invoice">
+                        <button type="button" className="button button--ghost button--small" onClick={() => startEditingInvoice(invoice)} disabled={submitting} title="Edit invoice" aria-label={`Edit invoice ${invoice.invoice_number || invoice.id}`}>
                           Edit
                         </button>
                         <button
@@ -670,6 +670,7 @@ export default function InvoicesPage() {
                           onClick={() => void handleDeleteInvoice(invoice.id)}
                           disabled={deletingInvoiceId === invoice.id}
                           title="Delete invoice"
+                          aria-label={`Delete invoice ${invoice.invoice_number || invoice.id}`}
                         >
                           {deletingInvoiceId === invoice.id ? 'Deleting...' : 'Delete'}
                         </button>
@@ -687,6 +688,8 @@ export default function InvoicesPage() {
                 className="button button--ghost"
                 disabled={invoicePage <= 1}
                 onClick={() => setInvoicePage((p) => p - 1)}
+                title="Previous page"
+                aria-label="Previous page"
               >
                 Previous
               </button>
@@ -698,6 +701,8 @@ export default function InvoicesPage() {
                 className="button button--ghost"
                 disabled={invoicePage >= invoiceTotalPages}
                 onClick={() => setInvoicePage((p) => p + 1)}
+                title="Next page"
+                aria-label="Next page"
               >
                 Next
               </button>
@@ -833,10 +838,10 @@ export default function InvoicesPage() {
               </div>
 
               <div className="button-row">
-                <button type="button" className="button button--ghost" onClick={() => setShowLedgerModal(false)}>
+                <button type="button" className="button button--ghost" onClick={() => setShowLedgerModal(false)} title="Cancel ledger creation" aria-label="Cancel ledger creation">
                   Cancel
                 </button>
-                <button className="button button--primary" disabled={ledgerSubmitting}>
+                <button className="button button--primary" disabled={ledgerSubmitting} title="Save ledger" aria-label="Save ledger">
                   {ledgerSubmitting ? 'Saving ledger...' : 'Save ledger'}
                 </button>
               </div>
@@ -929,10 +934,10 @@ export default function InvoicesPage() {
               </div>
 
               <div className="button-row">
-                <button type="button" className="button button--ghost" onClick={() => setShowProductModal(false)}>
+                <button type="button" className="button button--ghost" onClick={() => setShowProductModal(false)} title="Cancel product creation" aria-label="Cancel product creation">
                   Cancel
                 </button>
-                <button className="button button--primary" disabled={productSubmitting}>
+                <button className="button button--primary" disabled={productSubmitting} title="Save product" aria-label="Save product">
                   {productSubmitting ? 'Saving product...' : 'Save product'}
                 </button>
               </div>
@@ -986,10 +991,10 @@ export default function InvoicesPage() {
               </div>
 
               <div className="button-row">
-                <button type="button" className="button button--ghost" onClick={() => setShowStockModal(false)}>
+                <button type="button" className="button button--ghost" onClick={() => setShowStockModal(false)} title="Cancel stock update" aria-label="Cancel stock update">
                   Cancel
                 </button>
-                <button className="button button--primary" disabled={stockSubmitting}>
+                <button className="button button--primary" disabled={stockSubmitting} title="Update stock" aria-label="Update stock">
                   {stockSubmitting ? 'Updating stock...' : 'Update stock'}
                 </button>
               </div>

--- a/frontend/src/pages/LedgerCreatePage.tsx
+++ b/frontend/src/pages/LedgerCreatePage.tsx
@@ -236,10 +236,10 @@ export default function LedgerCreatePage() {
             </div>
 
             <div className="button-row">
-              <button type="button" className="button button--secondary" onClick={() => navigate('/ledgers')}>
+              <button type="button" className="button button--secondary" onClick={() => navigate('/ledgers')} title="Cancel and return to ledgers" aria-label="Cancel and return to ledgers">
                 Cancel
               </button>
-              <button className="button button--primary" disabled={submitting}>
+              <button className="button button--primary" disabled={submitting} title={editingLedgerId ? "Update ledger" : "Create ledger"} aria-label={editingLedgerId ? "Update ledger" : "Create ledger"}>
                 {submitting
                   ? (editingLedgerId ? 'Updating ledger...' : 'Saving ledger...')
                   : (editingLedgerId ? 'Update ledger' : 'Create ledger')}

--- a/frontend/src/pages/LedgerViewPage.tsx
+++ b/frontend/src/pages/LedgerViewPage.tsx
@@ -181,13 +181,13 @@ export default function LedgerViewPage() {
             {ledger.email ? ` · ${ledger.email}` : ''}
           </p>
         </div>
-        <button type="button" className="button button--secondary" onClick={() => navigate('/ledgers')}>
+        <button type="button" className="button button--secondary" onClick={() => navigate('/ledgers')} title="Back to ledgers" aria-label="Back to ledgers">
           Back to ledgers
         </button>
-        <button type="button" className="button button--primary" onClick={() => setShowPaymentForm(true)}>
+        <button type="button" className="button button--primary" onClick={() => setShowPaymentForm(true)} title="Record receipt or payment" aria-label="Record receipt or payment">
           Record Receipt / Payment
         </button>
-        <button type="button" className="button button--primary" onClick={() => setShowInvoiceModal(true)}>
+        <button type="button" className="button button--primary" onClick={() => setShowInvoiceModal(true)} title="Create invoice" aria-label="Create invoice">
           Create Invoice
         </button>
       </section>
@@ -201,7 +201,7 @@ export default function LedgerViewPage() {
               <p className="eyebrow">Ledger details</p>
               <h2 className="nav-panel__title">Account info</h2>
             </div>
-            <button type="button" className="button button--ghost" onClick={() => navigate(`/ledgers/${ledgerId}/edit`)}>
+            <button type="button" className="button button--ghost" onClick={() => navigate(`/ledgers/${ledgerId}/edit`)} title="Edit ledger" aria-label="Edit ledger">
               Edit
             </button>
           </div>
@@ -226,7 +226,7 @@ export default function LedgerViewPage() {
               <h2 className="nav-panel__title">Period view</h2>
             </div>
             {statement && statement.entries.length > 0 ? (
-              <button type="button" className="button button--secondary" onClick={() => setShowStatementPreview(true)}>
+              <button type="button" className="button button--secondary" onClick={() => setShowStatementPreview(true)} title="Preview statement PDF" aria-label="Preview statement PDF">
                 Preview / PDF
               </button>
             ) : null}
@@ -286,6 +286,7 @@ export default function LedgerViewPage() {
                         className="button button--ghost button--small"
                         onClick={() => void handleViewInvoice(entry.entry_id)}
                         title="View invoice"
+                        aria-label="View invoice"
                       >
                         View
                       </button>
@@ -314,7 +315,7 @@ export default function LedgerViewPage() {
             <div className="panel stack">
               <div className="panel__header">
                 <h2 className="nav-panel__title">Record Receipt / Payment</h2>
-                <button type="button" className="button button--ghost" onClick={() => setShowPaymentForm(false)}>✕</button>
+                <button type="button" className="button button--ghost" onClick={() => setShowPaymentForm(false)} title="Close payment dialog" aria-label="Close payment dialog">✕</button>
               </div>
               <form onSubmit={(e) => void handleSubmitPayment(e)} className="stack">
                 <div className="field">
@@ -388,7 +389,7 @@ export default function LedgerViewPage() {
                     onChange={(e) => setPaymentForm((f) => ({ ...f, notes: e.target.value }))}
                   />
                 </div>
-                <button type="submit" className="button button--primary" disabled={submittingPayment}>
+                <button type="submit" className="button button--primary" disabled={submittingPayment} title="Save payment" aria-label="Save payment">
                   {submittingPayment ? 'Saving...' : 'Save'}
                 </button>
               </form>

--- a/frontend/src/pages/LedgersPage.tsx
+++ b/frontend/src/pages/LedgersPage.tsx
@@ -89,7 +89,7 @@ export default function LedgersPage() {
         </div>
         <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
           <div className="status-chip">{total} ledgers listed</div>
-          <button className="button button--primary" onClick={() => navigate('/ledgers/new')}>
+          <button className="button button--primary" onClick={() => navigate('/ledgers/new')} title="Create ledger" aria-label="Create ledger">
             Create ledger
           </button>
         </div>
@@ -151,10 +151,10 @@ export default function LedgersPage() {
                     </div>
                     <span className="table-subtext text-right">Ledger #{ledger.id}</span>
                     <div className="table-row__actions">
-                      <button type="button" className="button button--ghost" onClick={() => navigate(`/ledgers/${ledger.id}`)}>
+                      <button type="button" className="button button--ghost" onClick={() => navigate(`/ledgers/${ledger.id}`)} title={`View ledger ${ledger.name}`} aria-label={`View ledger ${ledger.name}`}>
                         View
                       </button>
-                      <button type="button" className="button button--ghost" onClick={() => navigate(`/ledgers/${ledger.id}/edit`)}>
+                      <button type="button" className="button button--ghost" onClick={() => navigate(`/ledgers/${ledger.id}/edit`)} title={`Edit ledger ${ledger.name}`} aria-label={`Edit ledger ${ledger.name}`}>
                         Edit
                       </button>
                       <button
@@ -162,6 +162,8 @@ export default function LedgersPage() {
                         className="button button--danger"
                         onClick={() => handleDeleteLedger(ledger.id)}
                         disabled={deletingLedgerId === ledger.id}
+                        title={`Delete ledger ${ledger.name}`}
+                        aria-label={`Delete ledger ${ledger.name}`}
                       >
                         {deletingLedgerId === ledger.id ? 'Deleting...' : 'Delete'}
                       </button>
@@ -178,6 +180,8 @@ export default function LedgersPage() {
                 className="button button--ghost"
                 disabled={page <= 1}
                 onClick={() => setPage((p) => p - 1)}
+                title="Previous page"
+                aria-label="Previous page"
               >
                 Previous
               </button>
@@ -189,6 +193,8 @@ export default function LedgersPage() {
                 className="button button--ghost"
                 disabled={page >= totalPages}
                 onClick={() => setPage((p) => p + 1)}
+                title="Next page"
+                aria-label="Next page"
               >
                 Next
               </button>

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -107,7 +107,7 @@ export default function LoginPage() {
 
           {error ? <div className="status-banner status-banner--error">{error}</div> : null}
 
-          <button className="button button--primary" disabled={submitting}>
+          <button className="button button--primary" disabled={submitting} title="Open dashboard" aria-label="Open dashboard">
             {submitting ? 'Signing in...' : 'Open dashboard'}
           </button>
         </motion.form>

--- a/frontend/src/pages/ProductsPage.tsx
+++ b/frontend/src/pages/ProductsPage.tsx
@@ -244,11 +244,11 @@ export default function ProductsPage() {
 
             <div className="button-row">
               {editingProductId ? (
-                <button type="button" className="button button--secondary" onClick={resetForm}>
+                <button type="button" className="button button--secondary" onClick={resetForm} title="Cancel edit" aria-label="Cancel edit">
                   Cancel edit
                 </button>
               ) : null}
-              <button className="button button--primary" disabled={submitting}>
+              <button className="button button--primary" disabled={submitting} title={editingProductId ? "Update product" : "Create product"} aria-label={editingProductId ? "Update product" : "Create product"}>
                 {submitting ? (editingProductId ? 'Updating product...' : 'Saving product...') : editingProductId ? 'Update product' : 'Create product'}
               </button>
             </div>
@@ -295,7 +295,7 @@ export default function ProductsPage() {
                     </div>
                     <span className="table-row__price">{formatCurrency(product.price, activeCurrencyCode)}</span>
                     <div className="table-row__actions">
-                      <button type="button" className="button button--ghost" onClick={() => startEditProduct(product)} disabled={submitting}>
+                      <button type="button" className="button button--ghost" onClick={() => startEditProduct(product)} disabled={submitting} title={`Edit product ${product.name}`} aria-label={`Edit product ${product.name}`}>
                         Edit
                       </button>
                       <button
@@ -303,6 +303,8 @@ export default function ProductsPage() {
                         className="button button--danger"
                         onClick={() => void handleDeleteProduct(product.id)}
                         disabled={deletingProductId === product.id}
+                        title={`Delete product ${product.name}`}
+                        aria-label={`Delete product ${product.name}`}
                       >
                         {deletingProductId === product.id ? 'Deleting...' : 'Delete'}
                       </button>
@@ -319,6 +321,8 @@ export default function ProductsPage() {
                 className="button button--ghost"
                 disabled={page <= 1}
                 onClick={() => setPage((p) => p - 1)}
+                title="Previous page"
+                aria-label="Previous page"
               >
                 Previous
               </button>
@@ -330,6 +334,8 @@ export default function ProductsPage() {
                 className="button button--ghost"
                 disabled={page >= totalPages}
                 onClick={() => setPage((p) => p + 1)}
+                title="Next page"
+                aria-label="Next page"
               >
                 Next
               </button>


### PR DESCRIPTION
## Summary

Adds descriptive `title` and `aria-label` attributes to action buttons across the main frontend flows.

## Changes

- label primary action buttons for create, update, save, cancel, delete, preview, pagination, and modal-close flows
- cover shared components like confirmation dialogs, invoice/statement previews, and invoice creation modal
- improve screen-reader announcements while also surfacing native browser tooltips on hover

## Testing

- `cd frontend && npm run build`

Closes #37
