### PR TITLE
fix(e2e): update selectors from .status-banner to .toast

### DIFF
--- a/frontend/e2e/auth.spec.ts
+++ b/frontend/e2e/auth.spec.ts
@@ -14,7 +14,7 @@ test.describe('Authentication', () => {
     await page.fill('#email', 'wrong@example.com');
     await page.fill('#password', 'WrongPassword');
     await page.click('button:has-text("Open dashboard")');
-    await expect(page.locator('.status-banner--error')).toBeVisible({
+    await expect(page.locator('.toast--error')).toBeVisible({
       timeout: 10_000,
     });
     // Should stay on the login page

--- a/frontend/e2e/fixtures.ts
+++ b/frontend/e2e/fixtures.ts
@@ -22,16 +22,16 @@ export const test = base.extend<{ authedPage: Page }>({
 
 export { expect };
 
-/** Helper: wait for a success banner to appear and contain text. */
+/** Helper: wait for a success toast to appear and contain text. */
 export async function expectSuccess(page: Page, substring: string) {
-  const banner = page.locator('.status-banner--success');
+  const banner = page.locator('.toast--success');
   await expect(banner).toBeVisible({ timeout: 10_000 });
   await expect(banner).toContainText(substring);
 }
 
-/** Helper: wait for an error banner to appear. */
+/** Helper: wait for an error toast to appear. */
 export async function expectError(page: Page, substring?: string) {
-  const banner = page.locator('.status-banner--error');
+  const banner = page.locator('.toast--error');
   await expect(banner).toBeVisible({ timeout: 10_000 });
   if (substring) {
     await expect(banner).toContainText(substring);

--- a/frontend/e2e/invoices.spec.ts
+++ b/frontend/e2e/invoices.spec.ts
@@ -289,7 +289,7 @@ test.describe('Invoices', () => {
     const invoiceRow = page.locator('.invoice-row', { hasText: ledgerName }).first();
     await invoiceRow.locator('button:has-text("Delete")').click();
     await page.locator('.modal-overlay button:has-text("Delete")').click();
-    await expect(page.locator('.status-banner--success')).toContainText('deleted', { timeout: 10_000 });
+    await expect(page.locator('.toast--success')).toContainText('deleted', { timeout: 10_000 });
   });
 
   test('shows projected total while composing', async ({

--- a/frontend/e2e/ledgers.spec.ts
+++ b/frontend/e2e/ledgers.spec.ts
@@ -107,7 +107,7 @@ test.describe('Ledgers CRUD', () => {
     await expect(row).toBeVisible({ timeout: 10_000 });
     await row.locator('button:has-text("Delete")').click();
     await page.locator('.modal-overlay button:has-text("Delete")').click();
-    await expect(page.locator('.status-banner--success')).toContainText('Ledger deleted', { timeout: 10_000 });
+    await expect(page.locator('.toast--success')).toContainText('Ledger deleted', { timeout: 10_000 });
     await expect(page.locator('.table-row', { hasText: name })).not.toBeVisible();
   });
 

--- a/frontend/e2e/products.spec.ts
+++ b/frontend/e2e/products.spec.ts
@@ -140,7 +140,7 @@ test.describe('Products CRUD', () => {
     page.on('dialog', (dialog) => dialog.accept());
     // Wait for old banner to disappear then the new one to appear
     await row.locator('button:has-text("Delete")').click();
-    await expect(page.locator('.status-banner--success')).toContainText('Product deleted', { timeout: 10_000 });
+    await expect(page.locator('.toast--success')).toContainText('Product deleted', { timeout: 10_000 });
 
     // Should no longer appear
     await expect(page.locator('.table-row', { hasText: sku })).not.toBeVisible();
@@ -160,7 +160,7 @@ test.describe('Products CRUD', () => {
     // The form has max=100 so the browser may prevent submission
     // or the API will reject it
     const errorVisible = await page
-      .locator('.status-banner--error')
+      .locator('.toast--error')
       .isVisible()
       .catch(() => false);
     const stillOnForm = await page


### PR DESCRIPTION
Replace `.status-banner--success` and `.status-banner--error` with `.toast--success` and `.toast--error` across all e2e tests to match the new StatusToasts component.

**Files changed:**
- `e2e/fixtures.ts` — `expectSuccess` and `expectError` helpers
- `e2e/auth.spec.ts` — error toast selector
- `e2e/ledgers.spec.ts` — success toast selector
- `e2e/invoices.spec.ts` — success toast selector
- `e2e/products.spec.ts` — success and error toast selectors