### PR TITLE
feat: add form field helper text for GSTIN, IFSC, and phone formats

### DIFF
--- a/frontend/src/pages/CompanyPage.tsx
+++ b/frontend/src/pages/CompanyPage.tsx
@@ -133,6 +133,7 @@ export default function CompanyPage() {
                     onChange={(event) => setForm((current) => ({ ...current, gst: event.target.value }))}
                     placeholder="27ABCDE1234F1Z5"
                   />
+                  <small className="field-hint">Format: 27ABCDE1234F1Z5</small>
                 </div>
 
                 <div className="field">
@@ -144,6 +145,7 @@ export default function CompanyPage() {
                     onChange={(event) => setForm((current) => ({ ...current, phone_number: event.target.value }))}
                     placeholder="+91 9876543210"
                   />
+                  <small className="field-hint">e.g. +91 98765 43210</small>
                 </div>
 
                 <div className="field">
@@ -249,6 +251,7 @@ export default function CompanyPage() {
                     onChange={(event) => setForm((current) => ({ ...current, ifsc_code: event.target.value }))}
                     placeholder="HDFC0001234"
                   />
+                  <small className="field-hint">Format: SBIN0001234</small>
                 </div>
               </div>
 

--- a/frontend/src/pages/LedgerCreatePage.tsx
+++ b/frontend/src/pages/LedgerCreatePage.tsx
@@ -141,6 +141,7 @@ export default function LedgerCreatePage() {
                   placeholder="27ABCDE1234F1Z5"
                   required
                 />
+                <small className="field-hint">Format: 27ABCDE1234F1Z5</small>
               </div>
               <div className="field">
                 <label htmlFor="ledger-phone">Phone number</label>
@@ -152,6 +153,7 @@ export default function LedgerCreatePage() {
                   placeholder="+91 9876543210"
                   required
                 />
+                <small className="field-hint">e.g. +91 98765 43210</small>
               </div>
               <div className="field">
                 <label htmlFor="ledger-email">Email</label>
@@ -233,6 +235,7 @@ export default function LedgerCreatePage() {
                   onChange={(e) => setForm((c) => ({ ...c, ifsc_code: e.target.value }))}
                   placeholder="HDFC0001234"
                 />
+                <small className="field-hint">Format: SBIN0001234</small>
               </div>
             </div>
 

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -293,6 +293,7 @@ textarea {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 14px;
+  align-items: start;
 }
 
 .field,


### PR DESCRIPTION
## Summary

Add inline hint text beneath GSTIN, IFSC, and phone input fields on the Company and Ledger pages so users know the expected format at a glance.

## Changes

- **CompanyPage.tsx** — added `.field-hint` helper text below GST, phone, and IFSC inputs
- **LedgerCreatePage.tsx** — same hints for the matching fields
- **styles.css** — added `align-items: start` to `.field-grid` so hint text doesn't cause uneven row heights

## Hints added

| Field | Hint text |
|-------|-----------|
| GSTIN | `Format: 27ABCDE1234F1Z5` |
| Phone | `e.g. +91 98765 43210` |
| IFSC  | `Format: SBIN0001234` |

Closes #46