### PR TITLE
frontend: Add due_date to TypeScript invoice types

### DIFF
--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -147,6 +147,7 @@ export type Invoice = {
   igst_amount: number;
   total_amount: number;
   invoice_date: string;
+  due_date: string | null;
   created_at: string;
   items: InvoiceItem[];
 };
@@ -173,6 +174,7 @@ export type InvoiceCreate = {
   voucher_type: 'sales' | 'purchase';
   ledger_id: number;
   invoice_date?: string;
+  due_date?: string;
   items: InvoiceItemInput[];
 };
 


### PR DESCRIPTION
Adds due_date to Invoice and InvoiceCreate in frontend/src/types/api.ts.

Refs #62
Part of #66

Verification
- npx tsc --noEmit passed in frontend/.