### PR TITLE
email: add Pydantic schemas for SmtpConfig CRUD

### DIFF
--- a/backend/src/schemas/smtp_config.py
+++ b/backend/src/schemas/smtp_config.py
@@ -1,0 +1,40 @@
+from datetime import datetime
+from pydantic import BaseModel, EmailStr
+
+
+class SmtpConfigCreate(BaseModel):
+    name: str
+    host: str
+    port: int
+    username: str
+    password: str
+    from_email: EmailStr
+    from_name: str
+    use_tls: bool = True
+
+
+class SmtpConfigUpdate(BaseModel):
+    name: str | None = None
+    host: str | None = None
+    port: int | None = None
+    username: str | None = None
+    password: str | None = None
+    from_email: EmailStr | None = None
+    from_name: str | None = None
+    use_tls: bool | None = None
+
+
+class SmtpConfigResponse(BaseModel):
+    id: int
+    name: str
+    host: str
+    port: int
+    username: str
+    from_email: str
+    from_name: str
+    use_tls: bool
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True


### PR DESCRIPTION
- Add SmtpConfigCreate with EmailStr for from_email validation
- Add SmtpConfigUpdate with all optional fields
- Add SmtpConfigResponse excluding password, including updated_at
- Fixes #70

## Summary

Adds Pydantic schemas for SmtpConfig CRUD operations used by the API layer for request validation and response serialization. SmtpConfigCreate and SmtpConfigUpdate use EmailStr for proper email validation on from_email. SmtpConfigResponse exposes all relevant fields but explicitly excludes password  to prevent credential leakage.

## Type of change

- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs (documentation)
- [ ] test (tests)
- [ ] chore/refactor



## Checklist

- [x] My code follows the project style and conventions
- [x] I added/updated tests where appropriate
- [x] I updated docs where needed
- [x] I ran relevant checks locally
- [x] I verified this does not break existing behavior



## Related issue

Closes #70
