### PR TITLE
fix(security): address PR #86 review feedback

### DIFF
--- a/backend/src/core/config.py
+++ b/backend/src/core/config.py
@@ -1,4 +1,5 @@
 from pydantic_settings import BaseSettings
+from pydantic import model_validator
 import os
 from pathlib import Path
 
@@ -26,15 +27,18 @@ class Settings(BaseSettings):
     N8N_EMAIL_WEBHOOK_PASS: str = ""
     SMTP_ENCRYPTION_KEY: str | None = None
 
+    @model_validator(mode="after")
+    def validate_smtp_key_in_production(self):
+        if self.ENVIRONMENT == "production" and not self.SMTP_ENCRYPTION_KEY:
+            raise ValueError("SMTP_ENCRYPTION_KEY is required in production environment")
+        return self
+
     class Config:
         env_file = str(env_file_path)
         case_sensitive = False
 
 
 settings = Settings()
-
-if settings.ENVIRONMENT == "production" and not settings.SMTP_ENCRYPTION_KEY:
-    raise ValueError("SMTP_ENCRYPTION_KEY is required in production environment")
 
 # Log which environment is being used
 print(f"🚀 Backend running in {settings.ENVIRONMENT} mode (loaded from {env_file_path})")

--- a/backend/src/core/security.py
+++ b/backend/src/core/security.py
@@ -9,11 +9,21 @@ from cryptography.fernet import Fernet
 
 logger = logging.getLogger(__name__)
 
+_fernet_warned = False
+
 def _get_fernet() -> Fernet:
+    # NOTE: Changing SMTP_ENCRYPTION_KEY rotates the Fernet key. SMTP passwords
+    # previously encrypted with a different key (or the SECRET_KEY fallback) will
+    # fail to decrypt — re-encrypt existing records before switching keys.
+    global _fernet_warned
     if settings.SMTP_ENCRYPTION_KEY:
         key = hashlib.sha256(settings.SMTP_ENCRYPTION_KEY.encode()).digest()
     else:
-        logger.warning("SMTP_ENCRYPTION_KEY is not set. Falling back to SECRET_KEY for deriving Fernet encryption key.")
+        if not _fernet_warned:
+            logger.warning(
+                "SMTP_ENCRYPTION_KEY is not set. Falling back to SECRET_KEY for deriving Fernet encryption key."
+            )
+            _fernet_warned = True
         key = hashlib.sha256(settings.SECRET_KEY.encode()).digest()
     return Fernet(base64.urlsafe_b64encode(key))
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,8 @@
+import os
+
+
+def pytest_configure(config):
+    """Set required env vars before any test module is imported."""
+    os.environ.setdefault("DATABASE_URL", "sqlite:///./test.db")
+    os.environ.setdefault("SECRET_KEY", "test-secret-key-for-testing-only")
+    os.environ.setdefault("ENVIRONMENT", "development")


### PR DESCRIPTION
Fixes the three issues raised in the review of #86.

**1. Production validation now triggers per instantiation**
Moved the SMTP_ENCRYPTION_KEY check into a Pydantic model_validator so it fires on every Settings() call, making test_config_production_requires_smtp_key actually pass.

**2. Warning fires only once**
Added _fernet_warned flag so the fallback warning logs exactly once, not on every encrypt/decrypt call.

**3. Data migration risk documented**
Added a comment in _get_fernet() noting that switching SMTP_ENCRYPTION_KEY rotates the key and existing ciphertext will fail to decrypt.

**Bonus: tests/conftest.py**
Added pytest_configure to set required env vars before test modules import, fixing collection-time ValidationError.
