### PR TITLE
feat(smtp): add Jinja2 HTML email templates and test-template endpoint

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,3 +13,4 @@ email-validator==2.2.0
 httpx==0.27.2
 weasyprint==63.1
 cryptography>=42.0.0
+Jinja2==3.1.6

--- a/backend/src/api/routes/smtp.py
+++ b/backend/src/api/routes/smtp.py
@@ -1,13 +1,73 @@
-from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy.orm import Session
-from src.models.user import User, UserRole
-from src.models.smtp_config import SMTPConfig
-from src.db.session import get_db
-from src.schemas.smtp_config import SmtpConfigResponse, SmtpConfigCreate, SmtpConfigUpdate, SmtpConfigTest
-from src.api.deps import require_roles
+from pathlib import Path
 import smtplib
-from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+
+from fastapi import APIRouter, Depends, HTTPException
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+from sqlalchemy.orm import Session
+
+from src.api.deps import require_roles
+from src.db.session import get_db
+from src.models.smtp_config import SMTPConfig
+from src.models.user import User, UserRole
+from src.schemas.smtp_config import (
+    SmtpConfigCreate,
+    SmtpConfigResponse,
+    SmtpConfigTest,
+    SmtpConfigTestTemplate,
+    SmtpConfigUpdate,
+)
+
+_TEMPLATE_DIR = Path(__file__).parent.parent.parent / "services" / "email_templates"
+_jinja_env = Environment(
+    loader=FileSystemLoader(str(_TEMPLATE_DIR)),
+    autoescape=select_autoescape(["html"]),
+)
+
+_TEMPLATE_MOCK_DATA: dict[str, dict] = {
+    "invoice_email": {
+        "company_name": "Acme Corp",
+        "company_email": "billing@acme.com",
+        "company_phone": "+91 98765 43210",
+        "invoice_number": "INV-2026-001",
+        "invoice_date": "01 Apr 2026",
+        "due_date": "15 Apr 2026",
+        "buyer_name": "Test Buyer",
+        "total_amount": "12,500.00",
+        "items_count": 3,
+        "currency": "\u20b9",
+    },
+    "payment_reminder": {
+        "company_name": "Acme Corp",
+        "company_email": "billing@acme.com",
+        "buyer_name": "Test Buyer",
+        "outstanding_balance": "8,750.00",
+        "last_payment_date": "20 Mar 2026",
+        "currency": "\u20b9",
+        "unpaid_invoices": [
+            {"invoice_number": "INV-2026-001", "invoice_date": "01 Mar 2026", "due_date": "15 Mar 2026", "amount": "5,000.00"},
+            {"invoice_number": "INV-2026-002", "invoice_date": "10 Mar 2026", "due_date": None, "amount": "3,750.00"},
+        ],
+    },
+    "ledger_statement": {
+        "company_name": "Acme Corp",
+        "company_email": "billing@acme.com",
+        "ledger_name": "Test Buyer",
+        "date_from": "01 Jan 2026",
+        "date_to": "31 Mar 2026",
+        "total_invoices": "50,000.00",
+        "total_payments": "42,500.00",
+        "balance": "7,500.00",
+        "currency": "\u20b9",
+    },
+}
+
+_TEMPLATE_SUBJECTS = {
+    "invoice_email": "[Test] Invoice Email — INV-2026-001",
+    "payment_reminder": "[Test] Payment Reminder",
+    "ledger_statement": "[Test] Account Statement — Jan–Mar 2026",
+}
 
 router = APIRouter()
 
@@ -153,3 +213,39 @@ def test_smtp_config(
         return {"detail": "Test email sent successfully"}
     except Exception as e:
         raise HTTPException(status_code=400, detail=f"Failed to send test email: {str(e)}")
+
+
+@router.post("/test-template", response_model=dict)
+def test_smtp_template(
+    payload: SmtpConfigTestTemplate,
+    db: Session = Depends(get_db),
+    _: User = Depends(require_roles(UserRole.admin)),
+):
+    """Send a test email rendered from one of the Jinja2 HTML templates using mock data."""
+    config = db.query(SMTPConfig).filter(SMTPConfig.id == payload.id).first()
+    if not config:
+        raise HTTPException(status_code=404, detail="SMTP configuration not found")
+
+    context = _TEMPLATE_MOCK_DATA[payload.template_name]
+    html_body = _jinja_env.get_template(f"{payload.template_name}.html").render(**context)
+    subject = _TEMPLATE_SUBJECTS[payload.template_name]
+
+    try:
+        msg = MIMEMultipart("alternative")
+        msg["From"] = f"{config.from_name} <{config.from_email}>"
+        msg["To"] = payload.to
+        msg["Subject"] = subject
+        msg.attach(MIMEText(html_body, "html"))
+
+        if config.use_tls:
+            server = smtplib.SMTP(config.host, config.port)
+            server.starttls()
+        else:
+            server = smtplib.SMTP_SSL(config.host, config.port)
+
+        server.login(config.username, config.password)
+        server.send_message(msg)
+        server.quit()
+        return {"detail": f"Test template email '{payload.template_name}' sent successfully to {payload.to}"}
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"Failed to send template test email: {str(e)}")

--- a/backend/src/schemas/smtp_config.py
+++ b/backend/src/schemas/smtp_config.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Literal
 from pydantic import BaseModel, EmailStr, Field
 
 
@@ -27,6 +28,12 @@ class SmtpConfigUpdate(BaseModel):
 class SmtpConfigTest(BaseModel):
     id: int
     to: EmailStr
+
+
+class SmtpConfigTestTemplate(BaseModel):
+    id: int
+    to: EmailStr
+    template_name: Literal["invoice_email", "payment_reminder", "ledger_statement"]
 
 
 class SmtpConfigResponse(BaseModel):

--- a/backend/src/services/email_templates/base.html
+++ b/backend/src/services/email_templates/base.html
@@ -1,0 +1,58 @@
+{#
+  base.html — Shared layout for all email templates.
+
+  Variables:
+    company_name   (str)  — Sender company name shown in the header. Default: "Your Company"
+    company_email  (str)  — Contact email shown in the footer. Default: omitted
+    company_phone  (str)  — Contact phone shown in the footer. Default: omitted
+    company_address (str) — Mailing address shown in the footer. Default: omitted
+#}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}Email{% endblock %}</title>
+</head>
+<body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333333; background-color: #f4f4f4; margin: 0; padding: 0;">
+    <table width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color: #f4f4f4;">
+        <tr>
+            <td align="center" style="padding: 20px 10px;">
+                <table width="600" cellpadding="0" cellspacing="0" border="0" style="max-width: 600px; width: 100%; background-color: #ffffff; border-radius: 8px; overflow: hidden; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
+                    <!-- Header -->
+                    <tr>
+                        <td style="background-color: #2c3e50; color: #ffffff; padding: 30px 20px; text-align: center;">
+                            {% block header %}
+                            <h1 style="font-size: 24px; font-weight: bold; margin: 0; color: #ffffff;">
+                                {{ company_name | default("Your Company") }}
+                            </h1>
+                            {% endblock %}
+                        </td>
+                    </tr>
+
+                    <!-- Content -->
+                    <tr>
+                        <td style="padding: 30px 20px;">
+                            {% block content %}{% endblock %}
+                        </td>
+                    </tr>
+
+                    <!-- Footer -->
+                    <tr>
+                        <td style="background-color: #ecf0f1; color: #7f8c8d; padding: 20px; text-align: center; font-size: 12px; border-top: 1px solid #bdc3c7;">
+                            {% block footer %}
+                            <p style="margin: 0;">
+                                <strong>{{ company_name | default("Your Company") }}</strong><br>
+                                {% if company_email %}Email: {{ company_email }}<br>{% endif %}
+                                {% if company_phone %}Phone: {{ company_phone }}<br>{% endif %}
+                                {% if company_address %}{{ company_address }}{% endif %}
+                            </p>
+                            {% endblock %}
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/backend/src/services/email_templates/invoice_email.html
+++ b/backend/src/services/email_templates/invoice_email.html
@@ -1,0 +1,73 @@
+{#
+  invoice_email.html — Email sent to a buyer when an invoice is issued.
+  Extends base.html.
+
+  Variables (in addition to base.html variables):
+    invoice_number  (str)         — Invoice identifier, e.g. "INV-2026-001"
+    invoice_date    (str)         — Human-readable invoice date, e.g. "01 Apr 2026"
+    due_date        (str|None)    — Payment due date; omitted if not provided
+    buyer_name      (str)         — Buyer / party name
+    total_amount    (str|number)  — Formatted invoice total, e.g. "12,500.00"
+    items_count     (int)         — Number of line items on the invoice
+    currency        (str)         — Currency symbol. Default: "₹"
+    message         (str|None)    — Optional custom message from the sender
+#}
+{% extends "base.html" %}
+
+{% block title %}Invoice {{ invoice_number }}{% endblock %}
+
+{% block content %}
+<h2 style="color: #2c3e50; margin-top: 0; margin-bottom: 20px; font-size: 20px;">Invoice {{ invoice_number }}</h2>
+
+<p style="margin: 0 0 16px 0;">Dear <strong>{{ buyer_name }}</strong>,</p>
+
+{% if message %}
+<p style="margin: 0 0 16px 0;">{{ message }}</p>
+{% else %}
+<p style="margin: 0 0 16px 0;">
+    Please find attached invoice <strong>{{ invoice_number }}</strong> for your reference.
+    Kindly review the details below.
+</p>
+{% endif %}
+
+<!-- Invoice Summary Table -->
+<table width="100%" cellpadding="0" cellspacing="0" border="0"
+       style="border-collapse: collapse; margin: 24px 0; border: 1px solid #e0e0e0; border-radius: 6px; overflow: hidden;">
+    <tr style="background-color: #f8f9fa;">
+        <td style="padding: 10px 16px; font-size: 13px; color: #555555; font-weight: bold; width: 50%; border-bottom: 1px solid #e0e0e0;">Invoice Number</td>
+        <td style="padding: 10px 16px; font-size: 14px; color: #333333; border-bottom: 1px solid #e0e0e0;">{{ invoice_number }}</td>
+    </tr>
+    <tr>
+        <td style="padding: 10px 16px; font-size: 13px; color: #555555; font-weight: bold; border-bottom: 1px solid #e0e0e0;">Invoice Date</td>
+        <td style="padding: 10px 16px; font-size: 14px; color: #333333; border-bottom: 1px solid #e0e0e0;">{{ invoice_date }}</td>
+    </tr>
+    {% if due_date %}
+    <tr style="background-color: #f8f9fa;">
+        <td style="padding: 10px 16px; font-size: 13px; color: #555555; font-weight: bold; border-bottom: 1px solid #e0e0e0;">Due Date</td>
+        <td style="padding: 10px 16px; font-size: 14px; color: #c0392b; font-weight: bold; border-bottom: 1px solid #e0e0e0;">{{ due_date }}</td>
+    </tr>
+    {% endif %}
+    <tr {% if not due_date %}style="background-color: #f8f9fa;"{% endif %}>
+        <td style="padding: 10px 16px; font-size: 13px; color: #555555; font-weight: bold; border-bottom: 1px solid #e0e0e0;">Billed To</td>
+        <td style="padding: 10px 16px; font-size: 14px; color: #333333; border-bottom: 1px solid #e0e0e0;">{{ buyer_name }}</td>
+    </tr>
+    <tr {% if due_date %}style="background-color: #f8f9fa;"{% endif %}>
+        <td style="padding: 10px 16px; font-size: 13px; color: #555555; font-weight: bold; border-bottom: 1px solid #e0e0e0;">Items</td>
+        <td style="padding: 10px 16px; font-size: 14px; color: #333333; border-bottom: 1px solid #e0e0e0;">{{ items_count }} item{% if items_count != 1 %}s{% endif %}</td>
+    </tr>
+    <tr style="background-color: #2c3e50;">
+        <td style="padding: 12px 16px; font-size: 14px; color: #ffffff; font-weight: bold;">Total Amount</td>
+        <td style="padding: 12px 16px; font-size: 16px; color: #ffffff; font-weight: bold;">
+            {{ currency | default("₹") }}{{ total_amount }}
+        </td>
+    </tr>
+</table>
+
+<p style="margin: 0 0 16px 0; color: #555555; font-size: 13px;">
+    📎 The invoice PDF is attached to this email.
+</p>
+
+<p style="margin: 0;">
+    If you have any questions regarding this invoice, please don't hesitate to contact us.
+</p>
+{% endblock %}

--- a/backend/src/services/email_templates/ledger_statement.html
+++ b/backend/src/services/email_templates/ledger_statement.html
@@ -1,0 +1,125 @@
+{#
+  ledger_statement.html — Summary email sent when sharing a ledger / account statement.
+  Extends base.html.
+
+  Variables (in addition to base.html variables):
+    ledger_name     (str)         — Party / ledger name
+    date_from       (str)         — Statement period start date, e.g. "01 Jan 2026"
+    date_to         (str)         — Statement period end date, e.g. "31 Mar 2026"
+    total_invoices  (str|number)  — Sum of all invoices in the period, e.g. "50,000.00"
+    total_payments  (str|number)  — Sum of all payments in the period, e.g. "42,500.00"
+    balance         (str|number)  — Net outstanding balance (invoices − payments), e.g. "7,500.00"
+    currency        (str)         — Currency symbol. Default: "₹"
+    message         (str|None)    — Optional custom message from the sender
+#}
+{% extends "base.html" %}
+
+{% block title %}Account Statement — {{ ledger_name }}{% endblock %}
+
+{% block content %}
+<h2 style="color: #2c3e50; margin-top: 0; margin-bottom: 4px; font-size: 20px;">Account Statement</h2>
+<p style="margin: 0 0 20px 0; font-size: 13px; color: #777777;">
+    {{ date_from }} &ndash; {{ date_to }}
+</p>
+
+<p style="margin: 0 0 16px 0;">Dear <strong>{{ ledger_name }}</strong>,</p>
+
+{% if message %}
+<p style="margin: 0 0 16px 0;">{{ message }}</p>
+{% else %}
+<p style="margin: 0 0 16px 0;">
+    Please find below the account statement for the period
+    <strong>{{ date_from }}</strong> to <strong>{{ date_to }}</strong>.
+    A detailed PDF statement is attached for your records.
+</p>
+{% endif %}
+
+<!-- Summary Cards -->
+<table width="100%" cellpadding="0" cellspacing="0" border="0" style="margin: 20px 0;">
+    <tr>
+        <!-- Total Invoiced -->
+        <td width="33%" style="padding: 0 6px 0 0; vertical-align: top;">
+            <table width="100%" cellpadding="0" cellspacing="0" border="0"
+                   style="background-color: #eaf4fb; border: 1px solid #aed6f1; border-radius: 6px;">
+                <tr>
+                    <td style="padding: 14px 16px; text-align: center;">
+                        <p style="margin: 0; font-size: 11px; color: #1a5276; text-transform: uppercase; letter-spacing: 0.5px;">Invoiced</p>
+                        <p style="margin: 6px 0 0 0; font-size: 18px; font-weight: bold; color: #1a5276;">
+                            {{ currency | default("₹") }}{{ total_invoices }}
+                        </p>
+                    </td>
+                </tr>
+            </table>
+        </td>
+        <!-- Total Payments -->
+        <td width="33%" style="padding: 0 3px; vertical-align: top;">
+            <table width="100%" cellpadding="0" cellspacing="0" border="0"
+                   style="background-color: #eafaf1; border: 1px solid #a9dfbf; border-radius: 6px;">
+                <tr>
+                    <td style="padding: 14px 16px; text-align: center;">
+                        <p style="margin: 0; font-size: 11px; color: #145a32; text-transform: uppercase; letter-spacing: 0.5px;">Received</p>
+                        <p style="margin: 6px 0 0 0; font-size: 18px; font-weight: bold; color: #145a32;">
+                            {{ currency | default("₹") }}{{ total_payments }}
+                        </p>
+                    </td>
+                </tr>
+            </table>
+        </td>
+        <!-- Balance -->
+        <td width="33%" style="padding: 0 0 0 6px; vertical-align: top;">
+            <table width="100%" cellpadding="0" cellspacing="0" border="0"
+                   style="background-color: #fdedec; border: 1px solid #f1948a; border-radius: 6px;">
+                <tr>
+                    <td style="padding: 14px 16px; text-align: center;">
+                        <p style="margin: 0; font-size: 11px; color: #78281f; text-transform: uppercase; letter-spacing: 0.5px;">Balance Due</p>
+                        <p style="margin: 6px 0 0 0; font-size: 18px; font-weight: bold; color: #c0392b;">
+                            {{ currency | default("₹") }}{{ balance }}
+                        </p>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+
+<!-- Statement Details -->
+<table width="100%" cellpadding="0" cellspacing="0" border="0"
+       style="border-collapse: collapse; border: 1px solid #e0e0e0; border-radius: 6px; overflow: hidden; margin: 8px 0 24px 0;">
+    <tr style="background-color: #f8f9fa;">
+        <td style="padding: 10px 16px; font-size: 13px; color: #555555; font-weight: bold; width: 50%; border-bottom: 1px solid #e0e0e0;">Period</td>
+        <td style="padding: 10px 16px; font-size: 14px; color: #333333; border-bottom: 1px solid #e0e0e0;">
+            {{ date_from }} &ndash; {{ date_to }}
+        </td>
+    </tr>
+    <tr>
+        <td style="padding: 10px 16px; font-size: 13px; color: #555555; font-weight: bold; border-bottom: 1px solid #e0e0e0;">Account Name</td>
+        <td style="padding: 10px 16px; font-size: 14px; color: #333333; border-bottom: 1px solid #e0e0e0;">{{ ledger_name }}</td>
+    </tr>
+    <tr style="background-color: #f8f9fa;">
+        <td style="padding: 10px 16px; font-size: 13px; color: #555555; font-weight: bold; border-bottom: 1px solid #e0e0e0;">Total Invoiced</td>
+        <td style="padding: 10px 16px; font-size: 14px; color: #333333; border-bottom: 1px solid #e0e0e0;">
+            {{ currency | default("₹") }}{{ total_invoices }}
+        </td>
+    </tr>
+    <tr>
+        <td style="padding: 10px 16px; font-size: 13px; color: #555555; font-weight: bold; border-bottom: 1px solid #e0e0e0;">Total Payments</td>
+        <td style="padding: 10px 16px; font-size: 14px; color: #27ae60; font-weight: bold; border-bottom: 1px solid #e0e0e0;">
+            {{ currency | default("₹") }}{{ total_payments }}
+        </td>
+    </tr>
+    <tr style="background-color: #2c3e50;">
+        <td style="padding: 12px 16px; font-size: 14px; color: #ffffff; font-weight: bold;">Balance Due</td>
+        <td style="padding: 12px 16px; font-size: 16px; color: #ffffff; font-weight: bold;">
+            {{ currency | default("₹") }}{{ balance }}
+        </td>
+    </tr>
+</table>
+
+<p style="margin: 0 0 16px 0; color: #555555; font-size: 13px;">
+    📎 A detailed PDF statement is attached to this email.
+</p>
+
+<p style="margin: 0;">
+    If you have any queries regarding this statement, please contact us and we will be happy to assist.
+</p>
+{% endblock %}

--- a/backend/src/services/email_templates/payment_reminder.html
+++ b/backend/src/services/email_templates/payment_reminder.html
@@ -1,0 +1,89 @@
+{#
+  payment_reminder.html — Polite payment reminder sent to a buyer with outstanding dues.
+  Extends base.html.
+
+  Variables (in addition to base.html variables):
+    buyer_name          (str)         — Buyer / party name
+    outstanding_balance (str|number)  — Total outstanding amount, e.g. "8,750.00"
+    currency            (str)         — Currency symbol. Default: "₹"
+    last_payment_date   (str|None)    — Date of the most recent payment; omitted if none
+    message             (str|None)    — Optional custom message from the sender
+    unpaid_invoices     (list)        — List of dicts with keys:
+                                          invoice_number (str)
+                                          invoice_date   (str)
+                                          due_date       (str|None)
+                                          amount         (str|number)
+#}
+{% extends "base.html" %}
+
+{% block title %}Payment Reminder{% endblock %}
+
+{% block content %}
+<h2 style="color: #2c3e50; margin-top: 0; margin-bottom: 20px; font-size: 20px;">Payment Reminder</h2>
+
+<p style="margin: 0 0 16px 0;">Dear <strong>{{ buyer_name }}</strong>,</p>
+
+{% if message %}
+<p style="margin: 0 0 16px 0;">{{ message }}</p>
+{% else %}
+<p style="margin: 0 0 16px 0;">
+    This is a gentle reminder that you have an outstanding balance on your account.
+    We would appreciate your prompt attention to settle the dues at your earliest convenience.
+</p>
+{% endif %}
+
+<!-- Outstanding Balance Banner -->
+<table width="100%" cellpadding="0" cellspacing="0" border="0"
+       style="background-color: #fef9e7; border: 1px solid #f39c12; border-radius: 6px; margin: 16px 0;">
+    <tr>
+        <td style="padding: 16px 20px;">
+            <p style="margin: 0; font-size: 13px; color: #7f6000;">Outstanding Balance</p>
+            <p style="margin: 4px 0 0 0; font-size: 26px; font-weight: bold; color: #c0392b;">
+                {{ currency | default("₹") }}{{ outstanding_balance }}
+            </p>
+            {% if last_payment_date %}
+            <p style="margin: 8px 0 0 0; font-size: 12px; color: #7f6000;">
+                Last payment received on {{ last_payment_date }}
+            </p>
+            {% endif %}
+        </td>
+    </tr>
+</table>
+
+{% if unpaid_invoices %}
+<!-- Unpaid Invoices Table -->
+<h3 style="color: #2c3e50; font-size: 15px; margin: 24px 0 12px 0;">Unpaid Invoices</h3>
+<table width="100%" cellpadding="0" cellspacing="0" border="0"
+       style="border-collapse: collapse; border: 1px solid #e0e0e0; border-radius: 6px; overflow: hidden;">
+    <!-- Table header -->
+    <tr style="background-color: #2c3e50;">
+        <td style="padding: 10px 14px; font-size: 12px; color: #ffffff; font-weight: bold;">Invoice #</td>
+        <td style="padding: 10px 14px; font-size: 12px; color: #ffffff; font-weight: bold;">Date</td>
+        <td style="padding: 10px 14px; font-size: 12px; color: #ffffff; font-weight: bold;">Due Date</td>
+        <td style="padding: 10px 14px; font-size: 12px; color: #ffffff; font-weight: bold; text-align: right;">Amount</td>
+    </tr>
+    {% for inv in unpaid_invoices %}
+    <tr style="background-color: {% if loop.index is odd %}#ffffff{% else %}#f8f9fa{% endif %};">
+        <td style="padding: 10px 14px; font-size: 13px; color: #333333; border-bottom: 1px solid #e0e0e0;">
+            {{ inv.invoice_number }}
+        </td>
+        <td style="padding: 10px 14px; font-size: 13px; color: #555555; border-bottom: 1px solid #e0e0e0;">
+            {{ inv.invoice_date }}
+        </td>
+        <td style="padding: 10px 14px; font-size: 13px; border-bottom: 1px solid #e0e0e0;
+                   {% if inv.due_date %}color: #c0392b; font-weight: bold;{% else %}color: #aaaaaa;{% endif %}">
+            {{ inv.due_date if inv.due_date else "—" }}
+        </td>
+        <td style="padding: 10px 14px; font-size: 13px; color: #333333; border-bottom: 1px solid #e0e0e0; text-align: right;">
+            {{ currency | default("₹") }}{{ inv.amount }}
+        </td>
+    </tr>
+    {% endfor %}
+</table>
+{% endif %}
+
+<p style="margin: 24px 0 0 0;">
+    If you have already made the payment, please disregard this message. Should you have any questions,
+    feel free to reach out to us.
+</p>
+{% endblock %}


### PR DESCRIPTION
## Summary

- Add `Jinja2`, `html2text`, and `premailer` to `requirements.txt`
- Add three HTML email templates (`invoice_email`, `payment_reminder`, `ledger_statement`) using a shared `base.html` layout
- Add `SmtpConfigTestTemplate` schema
- Add `POST /smtp-configs/test-template` endpoint to send rendered template emails with mock data for preview/testing