### PR TITLE
feat: improve empty state messages with actionable links

### DIFF
--- a/frontend/e2e/invoices.spec.ts
+++ b/frontend/e2e/invoices.spec.ts
@@ -366,4 +366,39 @@ test.describe('Invoices', () => {
     const today = new Date().toISOString().slice(0, 10);
     expect(value).toBe(today);
   });
+
+  test('shows search-no-results message when search finds nothing', async ({ authedPage: page }) => {
+    await page.click('[href="/invoices"]');
+    await page.waitForTimeout(500);
+    await page.fill('#invoice-search', 'ZZZZNONEXISTENT999');
+    await page.waitForTimeout(500);
+
+    await expect(page.locator('.empty-state')).toContainText('No invoices match your search.');
+    // CTA for truly-empty state must not appear during a search
+    await expect(page.locator('button:has-text("Create your first invoice")')).not.toBeVisible();
+  });
+
+  test('shows friendly empty state with CTA when no invoices exist', async ({ authedPage: page }) => {
+    // Mock only the invoices list to return empty so we can verify the empty-state UI
+    await page.route(/\/api\/invoices\//, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ items: [], total: 0, total_pages: 0, page: 1 }),
+      })
+    );
+
+    await page.goto('/invoices');
+    await page.waitForTimeout(500);
+
+    const emptyState = page.locator('.empty-state');
+    await expect(emptyState).toContainText('No invoices yet');
+    await expect(emptyState).toContainText('first invoice');
+
+    const ctaButton = page.locator('button:has-text("Create your first invoice")');
+    await expect(ctaButton).toBeVisible();
+    // CTA should focus the voucher type selector so the user can start filling the form
+    await ctaButton.click();
+    await expect(page.locator('#invoice-voucher-type')).toBeFocused();
+  });
 });

--- a/frontend/e2e/ledgers.spec.ts
+++ b/frontend/e2e/ledgers.spec.ts
@@ -190,4 +190,38 @@ test.describe('Ledgers CRUD', () => {
     await expect(page.locator('.table-row', { hasText: nameB })).toBeVisible();
     await expect(page.locator('.table-row', { hasText: nameA })).not.toBeVisible();
   });
+
+  test('shows search-no-results message when search finds nothing', async ({ authedPage: page }) => {
+    await page.click('[href="/ledgers"]');
+    await page.fill('#ledger-search', 'ZZZZNONEXISTENT999');
+    await page.waitForTimeout(500);
+
+    await expect(page.locator('.empty-state')).toContainText('No ledgers match your search.');
+    // CTA for truly-empty state must not appear during a search
+    await expect(page.locator('button:has-text("Create your first ledger")')).not.toBeVisible();
+  });
+
+  test('shows friendly empty state with CTA that navigates to create form', async ({ authedPage: page }) => {
+    // Mock the ledgers list to return empty so we can verify the empty-state UI
+    await page.route(/\/api\/ledgers\//, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ items: [], total: 0, total_pages: 0, page: 1 }),
+      })
+    );
+
+    await page.goto('/ledgers');
+
+    const emptyState = page.locator('.empty-state');
+    await expect(emptyState).toContainText('No ledgers yet');
+    await expect(emptyState).toContainText('first ledger');
+
+    const ctaButton = page.locator('button:has-text("Create your first ledger")');
+    await expect(ctaButton).toBeVisible();
+    // CTA should navigate to the ledger create form
+    await page.unroute(/\/api\/ledgers\//); // unblock navigation target
+    await ctaButton.click();
+    await expect(page).toHaveURL('/ledgers/new', { timeout: 5_000 });
+  });
 });

--- a/frontend/e2e/products.spec.ts
+++ b/frontend/e2e/products.spec.ts
@@ -137,9 +137,9 @@ test.describe('Products CRUD', () => {
     await page.waitForTimeout(500);
     const row = page.locator('.table-row', { hasText: sku });
     await expect(row).toBeVisible({ timeout: 10_000 });
-    page.on('dialog', (dialog) => dialog.accept());
-    // Wait for old banner to disappear then the new one to appear
+    // Delete it — click Delete row button, then confirm in the custom dialog
     await row.locator('button:has-text("Delete")').click();
+    await page.locator('.modal-overlay button:has-text("Delete")').click();
     await expect(page.locator('.toast--success')).toContainText('Product deleted', { timeout: 10_000 });
 
     // Should no longer appear
@@ -167,5 +167,38 @@ test.describe('Products CRUD', () => {
       .locator('button:has-text("Create product")')
       .isVisible();
     expect(errorVisible || stillOnForm).toBeTruthy();
+  });
+
+  test('shows search-no-results message when search finds nothing', async ({ authedPage: page }) => {
+    await page.click('[href="/products"]');
+    await page.fill('#product-search', 'ZZZZNONEXISTENT999');
+    await page.waitForTimeout(500);
+
+    await expect(page.locator('.empty-state')).toContainText('No products match your search.');
+    // CTA for truly-empty state must not appear during a search
+    await expect(page.locator('button:has-text("Create your first product")')).not.toBeVisible();
+  });
+
+  test('shows friendly empty state with CTA when no products exist', async ({ authedPage: page }) => {
+    // Mock the products list to return empty so we can verify the empty-state UI
+    await page.route(/\/api\/products\//, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ items: [], total: 0, total_pages: 0, page: 1 }),
+      })
+    );
+
+    await page.goto('/products');
+
+    const emptyState = page.locator('.empty-state');
+    await expect(emptyState).toContainText('No products yet');
+    await expect(emptyState).toContainText('first product');
+
+    const ctaButton = page.locator('button:has-text("Create your first product")');
+    await expect(ctaButton).toBeVisible();
+    // CTA should focus the SKU input so the user can start filling the form
+    await ctaButton.click();
+    await expect(page.locator('#sku')).toBeFocused();
   });
 });

--- a/frontend/src/pages/InvoicesPage.tsx
+++ b/frontend/src/pages/InvoicesPage.tsx
@@ -604,9 +604,22 @@ export default function InvoicesPage() {
                 <p style={{ fontSize: '0.95rem' }}>Loading invoices...</p>
               </div>
             ) : null}
-            {!loading && invoices.length === 0 ? (
+            {!loading && invoices.length === 0 && !invoiceSearch ? (
               <div className="empty-state">
-                <p style={{ fontSize: '0.95rem' }}>No invoices created yet. Start by creating your first invoice above.</p>
+                <p style={{ fontWeight: 600, marginBottom: '8px' }}>No invoices yet</p>
+                <p style={{ marginBottom: '16px' }}>Create your first invoice to get started.</p>
+                <button
+                  type="button"
+                  className="button button--primary"
+                  onClick={() => document.getElementById('invoice-voucher-type')?.focus()}
+                >
+                  Create your first invoice
+                </button>
+              </div>
+            ) : null}
+            {!loading && invoices.length === 0 && invoiceSearch ? (
+              <div className="empty-state">
+                <p style={{ fontSize: '0.95rem' }}>No invoices match your search.</p>
               </div>
             ) : null}
             {!loading

--- a/frontend/src/pages/LedgersPage.tsx
+++ b/frontend/src/pages/LedgersPage.tsx
@@ -124,7 +124,22 @@ export default function LedgersPage() {
 
           <div className="table-list">
             {loading ? <div className="empty-state">Loading ledgers...</div> : null}
-            {!loading && ledgers.length === 0 ? <div className="empty-state">No ledgers have been created yet.</div> : null}
+            {!loading && ledgers.length === 0 && !search ? (
+              <div className="empty-state">
+                <p style={{ fontWeight: 600, marginBottom: '8px' }}>No ledgers yet</p>
+                <p style={{ marginBottom: '16px' }}>Create your first ledger to start tracking buyers and suppliers.</p>
+                <button
+                  type="button"
+                  className="button button--primary"
+                  onClick={() => navigate('/ledgers/new')}
+                >
+                  Create your first ledger
+                </button>
+              </div>
+            ) : null}
+            {!loading && ledgers.length === 0 && search ? (
+              <div className="empty-state">No ledgers match your search.</div>
+            ) : null}
             {!loading
               ? ledgers.map((ledger) => (
                   <div key={ledger.id} className="table-row">

--- a/frontend/src/pages/ProductsPage.tsx
+++ b/frontend/src/pages/ProductsPage.tsx
@@ -292,7 +292,22 @@ export default function ProductsPage() {
 
           <div className="table-list">
             {loading ? <div className="empty-state">Loading products...</div> : null}
-            {!loading && products.length === 0 ? <div className="empty-state">No products have been created yet.</div> : null}
+            {!loading && products.length === 0 && !search ? (
+              <div className="empty-state">
+                <p style={{ fontWeight: 600, marginBottom: '8px' }}>No products yet</p>
+                <p style={{ marginBottom: '16px' }}>Add your first product to start building your catalog.</p>
+                <button
+                  type="button"
+                  className="button button--primary"
+                  onClick={() => document.getElementById('sku')?.focus()}
+                >
+                  Create your first product
+                </button>
+              </div>
+            ) : null}
+            {!loading && products.length === 0 && search ? (
+              <div className="empty-state">No products match your search.</div>
+            ) : null}
             {!loading
               ? products.map((product) => (
                   <div key={product.id} className="table-row">


### PR DESCRIPTION
Closes #24

## Changes

### ProductsPage, LedgersPage, InvoicesPage
- Replace the generic `No X have been created yet.` empty-state with a friendly heading, helper sentence, and a prominent **Create your first X** CTA button
- CTA actions:
  - **Products** – focuses the `#sku` input so the user can immediately start filling the form
  - **Ledgers** – navigates to `/ledgers/new`
  - **Invoices** – focuses the `#invoice-voucher-type` select
- When the list is empty due to an active search (no real data missing), a distinct `No X match your search.` message is shown instead — without the CTA

### Bug fix
- `e2e/products.spec.ts` *deletes a product* test was using `page.on('dialog', ...)` for a native browser confirm that never fires; updated to click the custom `ConfirmDialog` modal (consistent with `ledgers.spec.ts` and `invoices.spec.ts`)

### E2E tests
- Added **search-no-results** test for each page: verifies the contextual message is shown and the CTA is hidden
- Added **empty-state CTA** test for each page using `page.route()` to mock an empty API response