### PR TITLE
fix: correct locale mapping and catch fallback in formatCurrency

### DIFF
--- a/frontend/src/utils/formatting.ts
+++ b/frontend/src/utils/formatting.ts
@@ -1,6 +1,5 @@
 export default function formatCurrency(value: number, currencyCode = 'USD') {
-    const isUSD = currencyCode === 'USD';
-    const locale = isUSD ? 'en-US' : 'en-IN';
+    const locale = currencyCode === 'INR' ? 'en-IN' : 'en-US';
     try {
         return new Intl.NumberFormat(locale, {
             style: 'currency',
@@ -8,7 +7,7 @@ export default function formatCurrency(value: number, currencyCode = 'USD') {
             maximumFractionDigits: 2,
         }).format(value);
     } catch {
-        return new Intl.NumberFormat(locale, {
+        return new Intl.NumberFormat('en-US', {
             style: 'currency',
             currency: 'USD',
             maximumFractionDigits: 2,


### PR DESCRIPTION
## Summary

Patches two bugs introduced by the `formatCurrency` utility extracted in #91.

**1. Wrong locale for non-INR/non-USD currencies**

The original condition was:
```ts
const locale = isUSD ? 'en-US' : 'en-IN';
```
This sends EUR, GBP, JPY, AED, etc. to `en-IN` locale, producing Indian-style number grouping (e.g. `€1,00,000` instead of `€100,000`).

Fixed to:
```ts
const locale = currencyCode === 'INR' ? 'en-IN' : 'en-US';
```

**2. Mixed locale/currency in catch fallback**

The catch block was:
```ts
return new Intl.NumberFormat(locale, { currency: 'USD' }).format(value);
```
When `locale` was `'en-IN'` (INR call), this produced `en-IN` + `USD` — a mixed state. Fixed to always use `'en-US'` + `'USD'` as the safe, consistent fallback.

**3. Trailing newline**

Added missing trailing newline to `formatting.ts`.

## Type of change

- [x] fix (bug fix)

## How to test

1. Set company currency to EUR (or any non-USD/non-INR currency)
2. Verify numbers render with correct `en-US` grouping (e.g. `€100,000.00`) not Indian grouping (`€1,00,000.00`)
3. INR amounts still render with `en-IN` grouping (`₹1,00,000.00`)

## Related issue

Follows up on #91