### PR TITLE
Fix #103: Add skeleton loaders to dashboard

### DIFF
--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -79,22 +79,22 @@ export default function DashboardPage() {
       <section className="stats-grid">
         <article className="stat-card">
           <p className="eyebrow">Catalog</p>
-          <p className="stat-card__value">{loading ? '...' : state.products.length}</p>
+          <p className="stat-card__value">{loading ? <div className="skeleton" style={{ width: '60px', height: '38px', display: 'inline-block' }} /> : state.products.length}</p>
           <p className="muted-text">Products available for quoting and invoicing.</p>
         </article>
         <article className="stat-card">
           <p className="eyebrow">Stock units</p>
-          <p className="stat-card__value">{loading ? '...' : totalInventoryUnits}</p>
+          <p className="stat-card__value">{loading ? <div className="skeleton" style={{ width: '80px', height: '38px', display: 'inline-block' }} /> : totalInventoryUnits}</p>
           <p className="muted-text">Total quantity currently registered across inventory rows.</p>
         </article>
         <article className="stat-card">
           <p className="eyebrow">Low stock</p>
-          <p className="stat-card__value">{loading ? '...' : lowStockCount}</p>
+          <p className="stat-card__value">{loading ? <div className="skeleton" style={{ width: '40px', height: '38px', display: 'inline-block' }} /> : lowStockCount}</p>
           <p className="muted-text">Rows at 5 units or less that likely need replenishment.</p>
         </article>
         <article className="stat-card">
           <p className="eyebrow">Invoice value</p>
-          <p className="stat-card__value">{loading ? '...' : formatCurrency(invoiceRevenue, activeCurrencyCode)}</p>
+          <p className="stat-card__value">{loading ? <div className="skeleton" style={{ width: '120px', height: '38px', display: 'inline-block' }} /> : formatCurrency(invoiceRevenue, activeCurrencyCode)}</p>
           <p className="muted-text">Combined gross amount from currently listed invoices.</p>
         </article>
       </section>
@@ -110,7 +110,13 @@ export default function DashboardPage() {
           </div>
 
           <div className="table-list">
-            {loading ? <div className="empty-state">Loading inventory...</div> : null}
+            {loading ? (
+              <>
+                <div className="table-row skeleton" style={{ height: '76px', border: 'transparent' }}></div>
+                <div className="table-row skeleton" style={{ height: '76px', border: 'transparent' }}></div>
+                <div className="table-row skeleton" style={{ height: '76px', border: 'transparent' }}></div>
+              </>
+            ) : null}
             {!loading && state.inventory.length === 0 ? <div className="empty-state">No inventory rows yet.</div> : null}
             {!loading
               ? state.inventory
@@ -140,7 +146,13 @@ export default function DashboardPage() {
           </div>
 
           <div className="invoice-list">
-            {loading ? <div className="empty-state">Loading invoices...</div> : null}
+            {loading ? (
+              <>
+                <div className="invoice-row skeleton" style={{ height: '88px', border: 'transparent' }}></div>
+                <div className="invoice-row skeleton" style={{ height: '88px', border: 'transparent' }}></div>
+                <div className="invoice-row skeleton" style={{ height: '88px', border: 'transparent' }}></div>
+              </>
+            ) : null}
             {!loading && state.invoices.length === 0 ? <div className="empty-state">No invoices have been created yet.</div> : null}
             {!loading
               ? state.invoices.slice(0, 6).map((invoice) => (

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -940,6 +940,18 @@ textarea {
   margin: 0;
 }
 
+.skeleton {
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0.04) 25%, rgba(255, 255, 255, 0.1) 50%, rgba(255, 255, 255, 0.04) 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.4s infinite;
+  border-radius: 8px;
+}
+
+@keyframes shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
 .no-print {
   display: flex;
 }


### PR DESCRIPTION
## Summary

Added a modern CSS skeleton loader animation to `styles.css` and applied it to the `DashboardPage` component. This replaces the hardcoded `...` and standard loading text with a premium shimmer effect during data fetching.

## Type of change

-feat (new feature)


## How to test

1. Start the React frontend
2. Navigate to the `/dashboard` page
3. The stat cards and list panels will now show shimmering skeleton loader elements instead of plain text during loading states.


## Related issue

Closes #103
