### PR TITLE
feat: icon buttons, split-button dropdown, and e2e test updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,13 @@
 SHELL := /bin/bash
 
-.PHONY: help dev prod down logs seed migrate migrate-up migrate-down migrate-down-all migrate-status migrate-create backend-shell frontend-shell test lint
+.PHONY: help dev prod down logs seed migrate migrate-up migrate-down migrate-down-all migrate-status migrate-create backend-shell frontend-shell test lint build install install-backend install-frontend
 
 help:
 	@echo "Available commands:"
+	@echo "  make build            - Rebuild dev images (use after changing Dockerfiles or system deps)"
+	@echo "  make install          - Install backend + frontend deps in running containers"
+	@echo "  make install-backend  - pip install -r requirements.txt in running backend-dev"
+	@echo "  make install-frontend - npm install in running frontend-dev"
 	@echo "  make dev              - Start development profile (backend-dev, frontend-dev, db)"
 	@echo "  make prod             - Start production profile (backend, frontend, db)"
 	@echo "  make down             - Stop all containers"
@@ -64,3 +68,14 @@ test:
 lint:
 	docker-compose --profile dev exec backend-dev python -m compileall .
 	docker-compose --profile dev exec frontend-dev npm run build
+
+build:
+	docker-compose --profile dev build backend-dev frontend-dev
+
+install: install-backend install-frontend
+
+install-backend:
+	docker-compose --profile dev exec backend-dev pip install -r requirements.txt
+
+install-frontend:
+	docker-compose --profile dev exec frontend-dev npm install

--- a/frontend/e2e/email.spec.ts
+++ b/frontend/e2e/email.spec.ts
@@ -28,7 +28,7 @@ async function createLedgerAndNavigateToView(
   await page.waitForTimeout(500);
   const row = page.locator('.table-row', { hasText: ledgerName });
   await expect(row).toBeVisible({ timeout: 10_000 });
-  await row.locator('button:has-text("View")').click();
+  await row.locator('[aria-label^="View ledger"]').click();
   await expect(page.locator('h1')).toContainText(ledgerName, { timeout: 10_000 });
 }
 
@@ -38,7 +38,8 @@ test.describe('Send Email Modal', () => {
       const ledgerName = `EmailLedger-${Date.now().toString(36)}`;
       await createLedgerAndNavigateToView(page, ledgerName);
 
-      await page.click('button:has-text("Send Reminder")');
+      await page.click('[aria-label="More ledger actions"]');
+      await page.click('[role="menuitem"][aria-label="Send Reminder"]');
 
       const modal = page.locator('[role="dialog"][aria-labelledby="send-email-title"]');
       await expect(modal).toBeVisible({ timeout: 5_000 });
@@ -64,7 +65,8 @@ test.describe('Send Email Modal', () => {
       const ledgerName = `EmailLedger-${Date.now().toString(36)}`;
       await createLedgerAndNavigateToView(page, ledgerName);
 
-      await page.click('button:has-text("Send Reminder")');
+      await page.click('[aria-label="More ledger actions"]');
+      await page.click('[role="menuitem"][aria-label="Send Reminder"]');
       const modal = page.locator('[role="dialog"][aria-labelledby="send-email-title"]');
       await expect(modal).toBeVisible({ timeout: 5_000 });
 
@@ -76,7 +78,8 @@ test.describe('Send Email Modal', () => {
       const ledgerName = `EmailLedger-${Date.now().toString(36)}`;
       await createLedgerAndNavigateToView(page, ledgerName);
 
-      await page.click('button:has-text("Send Reminder")');
+      await page.click('[aria-label="More ledger actions"]');
+      await page.click('[role="menuitem"][aria-label="Send Reminder"]');
       const modal = page.locator('[role="dialog"][aria-labelledby="send-email-title"]');
       await expect(modal).toBeVisible({ timeout: 5_000 });
 
@@ -88,7 +91,8 @@ test.describe('Send Email Modal', () => {
       const ledgerName = `EmailLedger-${Date.now().toString(36)}`;
       await createLedgerAndNavigateToView(page, ledgerName);
 
-      await page.click('button:has-text("Send Reminder")');
+      await page.click('[aria-label="More ledger actions"]');
+      await page.click('[role="menuitem"][aria-label="Send Reminder"]');
       const modal = page.locator('[role="dialog"][aria-labelledby="send-email-title"]');
       await expect(modal).toBeVisible({ timeout: 5_000 });
 
@@ -101,7 +105,8 @@ test.describe('Send Email Modal', () => {
       const ledgerName = `EmailLedger-${Date.now().toString(36)}`;
       await createLedgerAndNavigateToView(page, ledgerName);
 
-      await page.click('button:has-text("Send Reminder")');
+      await page.click('[aria-label="More ledger actions"]');
+      await page.click('[role="menuitem"][aria-label="Send Reminder"]');
       const modal = page.locator('[role="dialog"][aria-labelledby="send-email-title"]');
       await expect(modal).toBeVisible({ timeout: 5_000 });
 
@@ -113,7 +118,8 @@ test.describe('Send Email Modal', () => {
       const ledgerName = `EmailLedger-${Date.now().toString(36)}`;
       await createLedgerAndNavigateToView(page, ledgerName);
 
-      await page.click('button:has-text("Send Reminder")');
+      await page.click('[aria-label="More ledger actions"]');
+      await page.click('[role="menuitem"][aria-label="Send Reminder"]');
       const modal = page.locator('[role="dialog"][aria-labelledby="send-email-title"]');
       await expect(modal).toBeVisible({ timeout: 5_000 });
 
@@ -214,7 +220,7 @@ test.describe('Send Email Modal', () => {
       // Open preview of the first invoice matching the ledger
       const invoiceRow = page.locator('.invoice-row', { hasText: ledgerName }).first();
       await expect(invoiceRow).toBeVisible({ timeout: 10_000 });
-      await invoiceRow.locator('button:has-text("Preview")').click();
+      await invoiceRow.locator('[aria-label^="Preview invoice"]').click();
 
       const preview = page.locator('.modal-panel--invoice-preview');
       await expect(preview).toBeVisible({ timeout: 5_000 });
@@ -333,7 +339,7 @@ test.describe('Send Email Modal', () => {
       await page.waitForTimeout(500);
       const row = page.locator('.table-row', { hasText: ledgerName });
       await expect(row).toBeVisible({ timeout: 10_000 });
-      await row.locator('button:has-text("View")').click();
+      await row.locator('[aria-label^="View ledger"]').click();
       await expect(page.locator('h1')).toContainText(ledgerName, { timeout: 10_000 });
 
       // Wait for statement to load with today's date range (default)

--- a/frontend/e2e/invoices.spec.ts
+++ b/frontend/e2e/invoices.spec.ts
@@ -287,7 +287,7 @@ test.describe('Invoices', () => {
 
     // Delete the invoice — click Delete row button, then confirm in the custom dialog
     const invoiceRow = page.locator('.invoice-row', { hasText: ledgerName }).first();
-    await invoiceRow.locator('button:has-text("Delete")').click();
+    await invoiceRow.locator('[aria-label^="Delete invoice"]').click();
     await page.locator('.modal-overlay button:has-text("Delete")').click();
     await expect(page.locator('.toast--success')).toContainText('deleted', { timeout: 10_000 });
   });

--- a/frontend/e2e/ledger-invoice.spec.ts
+++ b/frontend/e2e/ledger-invoice.spec.ts
@@ -53,7 +53,7 @@ test.describe('Create Invoice from Ledger View', () => {
     await page.waitForTimeout(500);
     const row = page.locator('.table-row', { hasText: ledgerName });
     await expect(row).toBeVisible({ timeout: 10_000 });
-    await row.locator('button:has-text("View")').click();
+    await row.locator('[aria-label^="View ledger"]').click();
     await expect(page.locator('h1')).toContainText(ledgerName, { timeout: 10_000 });
 
     return { sku, productName, ledgerName };
@@ -63,7 +63,8 @@ test.describe('Create Invoice from Ledger View', () => {
     const { sku, ledgerName } = await seedAndNavigateToLedger(page);
 
     // Open the Create Invoice modal
-    await page.click('button:has-text("Create Invoice")');
+    await page.click('[aria-label="More ledger actions"]');
+    await page.click('[role="menuitem"][aria-label="Create Invoice"]');
     const modal = page.locator('.modal-overlay');
     await expect(modal).toBeVisible({ timeout: 5_000 });
 
@@ -108,7 +109,8 @@ test.describe('Create Invoice from Ledger View', () => {
     const { sku } = await seedAndNavigateToLedger(page);
 
     // Open the Create Invoice modal
-    await page.click('button:has-text("Create Invoice")');
+    await page.click('[aria-label="More ledger actions"]');
+    await page.click('[role="menuitem"][aria-label="Create Invoice"]');
     const modal = page.locator('.modal-overlay');
     await expect(modal).toBeVisible({ timeout: 5_000 });
 
@@ -144,12 +146,75 @@ test.describe('Create Invoice from Ledger View', () => {
   test('can close modal without creating invoice', async ({ authedPage: page }) => {
     await seedAndNavigateToLedger(page);
 
-    await page.click('button:has-text("Create Invoice")');
+    await page.click('[aria-label="More ledger actions"]');
+    await page.click('[role="menuitem"][aria-label="Create Invoice"]');
     const modal = page.locator('.modal-overlay');
     await expect(modal).toBeVisible({ timeout: 5_000 });
 
     // Click cancel
     await modal.locator('button:has-text("Cancel")').click();
     await expect(modal).not.toBeVisible({ timeout: 3_000 });
+  });
+});
+
+test.describe('Ledger View Actions Dropdown', () => {
+  test('dropdown opens on caret click and shows both actions', async ({ authedPage: page }) => {
+    // Create a minimal ledger and navigate to its view page
+    await page.click('[href="/ledgers"]');
+    await page.click('button:has-text("Create ledger")');
+    await expect(page.locator('h1')).toContainText('Create ledger', { timeout: 10_000 });
+    const ledgerName = `DropdownLedger-${Date.now().toString(36)}`;
+    await page.fill('#ledger-name', ledgerName);
+    await page.fill('#ledger-address', '1 Dropdown Rd');
+    await page.fill('#ledger-gst', uniqueGstin());
+    await page.fill('#ledger-phone', '+91 1111111111');
+    await page.click('button:has-text("Create ledger")');
+    await expect(page.locator('h1')).toContainText('Ledger master', { timeout: 10_000 });
+
+    await page.fill('#ledger-search', ledgerName);
+    await page.waitForTimeout(500);
+    const row = page.locator('.table-row', { hasText: ledgerName });
+    await expect(row).toBeVisible({ timeout: 10_000 });
+    await row.locator('[aria-label^="View ledger"]').click();
+    await expect(page.locator('h1')).toContainText(ledgerName, { timeout: 10_000 });
+
+    // Dropdown is closed initially
+    await expect(page.locator('[role="menuitem"][aria-label="Send Reminder"]')).not.toBeVisible();
+    await expect(page.locator('[role="menuitem"][aria-label="Create Invoice"]')).not.toBeVisible();
+
+    // Open dropdown via caret button
+    await page.click('[aria-label="More ledger actions"]');
+
+    // Both menu items should now be visible
+    await expect(page.locator('[role="menuitem"][aria-label="Send Reminder"]')).toBeVisible({ timeout: 3_000 });
+    await expect(page.locator('[role="menuitem"][aria-label="Create Invoice"]')).toBeVisible({ timeout: 3_000 });
+  });
+
+  test('dropdown closes when clicking outside', async ({ authedPage: page }) => {
+    await page.click('[href="/ledgers"]');
+    await page.click('button:has-text("Create ledger")');
+    await expect(page.locator('h1')).toContainText('Create ledger', { timeout: 10_000 });
+    const ledgerName = `DropdownClose-${Date.now().toString(36)}`;
+    await page.fill('#ledger-name', ledgerName);
+    await page.fill('#ledger-address', '2 Close Rd');
+    await page.fill('#ledger-gst', uniqueGstin());
+    await page.fill('#ledger-phone', '+91 2222222222');
+    await page.click('button:has-text("Create ledger")');
+    await expect(page.locator('h1')).toContainText('Ledger master', { timeout: 10_000 });
+
+    await page.fill('#ledger-search', ledgerName);
+    await page.waitForTimeout(500);
+    const row = page.locator('.table-row', { hasText: ledgerName });
+    await expect(row).toBeVisible({ timeout: 10_000 });
+    await row.locator('[aria-label^="View ledger"]').click();
+    await expect(page.locator('h1')).toContainText(ledgerName, { timeout: 10_000 });
+
+    // Open dropdown
+    await page.click('[aria-label="More ledger actions"]');
+    await expect(page.locator('[role="menuitem"][aria-label="Send Reminder"]')).toBeVisible({ timeout: 3_000 });
+
+    // Click outside — click on the page heading
+    await page.click('h1');
+    await expect(page.locator('[role="menuitem"][aria-label="Send Reminder"]')).not.toBeVisible({ timeout: 3_000 });
   });
 });

--- a/frontend/e2e/ledger-statement.spec.ts
+++ b/frontend/e2e/ledger-statement.spec.ts
@@ -22,7 +22,7 @@ test.describe('Ledger Statement', () => {
     await page.waitForTimeout(500);
     const row = page.locator('.table-row', { hasText: ledgerName });
     await expect(row).toBeVisible({ timeout: 10_000 });
-    await row.locator('button:has-text("View")').click();
+    await row.locator('[aria-label^="View ledger"]').click();
     await expect(page.locator('h1')).toContainText(ledgerName, { timeout: 10_000 });
 
     // Check for period selection inputs
@@ -124,7 +124,7 @@ test.describe('Ledger Statement', () => {
     await page.waitForTimeout(500);
     const ledgerRow = page.locator('.table-row', { hasText: ledgerName });
     await expect(ledgerRow).toBeVisible({ timeout: 10_000 });
-    await ledgerRow.locator('button:has-text("View")').click();
+    await ledgerRow.locator('[aria-label^="View ledger"]').click();
     await expect(page.locator('h1')).toContainText(ledgerName, { timeout: 10_000 });
 
     // Set date range covering today

--- a/frontend/e2e/ledgers.spec.ts
+++ b/frontend/e2e/ledgers.spec.ts
@@ -71,7 +71,7 @@ test.describe('Ledgers CRUD', () => {
     await page.waitForTimeout(500);
     const row = page.locator('.table-row', { hasText: name });
     await expect(row).toBeVisible({ timeout: 10_000 });
-    await row.locator('button:has-text("Edit")').click();
+    await row.locator('[aria-label^="Edit ledger"]').click();
     await expect(page.locator('h1')).toContainText('Edit ledger', { timeout: 10_000 });
 
     // Update the name
@@ -105,7 +105,7 @@ test.describe('Ledgers CRUD', () => {
     await page.waitForTimeout(500);
     const row = page.locator('.table-row', { hasText: name });
     await expect(row).toBeVisible({ timeout: 10_000 });
-    await row.locator('button:has-text("Delete")').click();
+    await row.locator('[aria-label^="Delete ledger"]').click();
     await page.locator('.modal-overlay button:has-text("Delete")').click();
     await expect(page.locator('.toast--success')).toContainText('Ledger deleted', { timeout: 10_000 });
     await expect(page.locator('.table-row', { hasText: name })).not.toBeVisible();
@@ -130,7 +130,7 @@ test.describe('Ledgers CRUD', () => {
     await page.waitForTimeout(500);
     const row = page.locator('.table-row', { hasText: name });
     await expect(row).toBeVisible({ timeout: 10_000 });
-    await row.locator('button:has-text("View")').click();
+    await row.locator('[aria-label^="View ledger"]').click();
 
     // Should navigate to ledger view page
     await expect(page.locator('h1')).toContainText(name, { timeout: 10_000 });
@@ -138,7 +138,7 @@ test.describe('Ledgers CRUD', () => {
     await expect(page.locator('#statement-to')).toBeVisible();
 
     // Back to ledgers
-    await page.click('button:has-text("Back to ledgers")');
+    await page.click('[aria-label="Back to ledgers"]');
     await expect(page.locator('h1')).toContainText('Ledger master', { timeout: 10_000 });
   });
 

--- a/frontend/e2e/payments.spec.ts
+++ b/frontend/e2e/payments.spec.ts
@@ -20,7 +20,7 @@ test.describe('Payments (Receipt / Payment)', () => {
     await page.waitForTimeout(500);
     const row = page.locator('.table-row', { hasText: ledgerName });
     await expect(row).toBeVisible({ timeout: 10_000 });
-    await row.locator('button:has-text("View")').click();
+    await row.locator('[aria-label^="View ledger"]').click();
     await expect(page.locator('h1')).toContainText(ledgerName, { timeout: 10_000 });
 
     // 3. Open payment form
@@ -68,7 +68,7 @@ test.describe('Payments (Receipt / Payment)', () => {
     await page.waitForTimeout(500);
     const row = page.locator('.table-row', { hasText: ledgerName });
     await expect(row).toBeVisible({ timeout: 10_000 });
-    await row.locator('button:has-text("View")').click();
+    await row.locator('[aria-label^="View ledger"]').click();
     await expect(page.locator('h1')).toContainText(ledgerName, { timeout: 10_000 });
 
     // 3. Open payment form and record a payment (money paid out)
@@ -110,7 +110,7 @@ test.describe('Payments (Receipt / Payment)', () => {
     await page.waitForTimeout(500);
     const row = page.locator('.table-row', { hasText: ledgerName });
     await expect(row).toBeVisible({ timeout: 10_000 });
-    await row.locator('button:has-text("View")').click();
+    await row.locator('[aria-label^="View ledger"]').click();
     await expect(page.locator('h1')).toContainText(ledgerName, { timeout: 10_000 });
 
     await page.click('button:has-text("Record Receipt / Payment")');

--- a/frontend/e2e/products.spec.ts
+++ b/frontend/e2e/products.spec.ts
@@ -104,7 +104,7 @@ test.describe('Products CRUD', () => {
     await page.waitForTimeout(500);
     const row = page.locator('.table-row', { hasText: sku });
     await expect(row).toBeVisible({ timeout: 10_000 });
-    await row.locator('button:has-text("Edit")').click();
+    await row.locator('[aria-label^="Edit product"]').click();
 
     // Form should show "Editing product" heading
     await expect(page.getByRole('heading', { name: /Editing product/ })).toBeVisible();
@@ -138,7 +138,7 @@ test.describe('Products CRUD', () => {
     const row = page.locator('.table-row', { hasText: sku });
     await expect(row).toBeVisible({ timeout: 10_000 });
     // Delete it — click Delete row button, then confirm in the custom dialog
-    await row.locator('button:has-text("Delete")').click();
+    await row.locator('[aria-label^="Delete product"]').click();
     await page.locator('.modal-overlay button:has-text("Delete")').click();
     await expect(page.locator('.toast--success')).toContainText('Product deleted', { timeout: 10_000 });
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "axios": "^1.7.7",
         "framer-motion": "^11.11.9",
+        "lucide-react": "^1.7.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.26.2"
@@ -70,7 +71,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1248,7 +1248,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1426,7 +1425,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2061,7 +2059,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -2138,6 +2135,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.7.0.tgz",
+      "integrity": "sha512-yI7BeItCLZJTXikmK4KNUGCKoGzSvbKlfCvw44bU4fXAL6v3gYS4uHD1jzsLkfwODYwI6Drw5Tu9Z5ulDe0TSg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/math-intrinsics": {
@@ -2398,7 +2404,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -2574,7 +2579,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -2587,7 +2591,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -2929,7 +2932,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3021,7 +3023,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "axios": "^1.7.7",
     "framer-motion": "^11.11.9",
+    "lucide-react": "^1.7.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.26.2"

--- a/frontend/src/pages/InvoicesPage.tsx
+++ b/frontend/src/pages/InvoicesPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { Eye, Pencil, Trash2 } from 'lucide-react';
 import api, { getApiErrorMessage } from '../api/client';
 import type { CompanyProfile, Invoice, InvoiceCreate, Ledger, LedgerCreate, PaginatedInvoices, Product } from '../types/api';
 import InvoicePreview from '../components/InvoicePreview';
@@ -666,21 +667,34 @@ export default function InvoicesPage() {
                       </div>
 
                       <div className="invoice-row__actions">
-                        <button type="button" className="button button--ghost button--small" onClick={() => setPreviewInvoice(invoice)} title="Preview invoice" aria-label={`Preview invoice ${invoice.invoice_number || invoice.id}`}>
-                          Preview
-                        </button>
-                        <button type="button" className="button button--ghost button--small" onClick={() => startEditingInvoice(invoice)} disabled={submitting} title="Edit invoice" aria-label={`Edit invoice ${invoice.invoice_number || invoice.id}`}>
-                          Edit
+                        <button
+                          type="button"
+                          className="button button--ghost button--icon"
+                          onClick={() => setPreviewInvoice(invoice)}
+                          title="Preview invoice"
+                          aria-label={`Preview invoice ${invoice.invoice_number || invoice.id}`}
+                        >
+                          <Eye size={16} />
                         </button>
                         <button
                           type="button"
-                          className="button button--danger button--small"
+                          className="button button--ghost button--icon"
+                          onClick={() => startEditingInvoice(invoice)}
+                          disabled={submitting}
+                          title="Edit invoice"
+                          aria-label={`Edit invoice ${invoice.invoice_number || invoice.id}`}
+                        >
+                          <Pencil size={16} />
+                        </button>
+                        <button
+                          type="button"
+                          className="button button--danger button--icon"
                           onClick={() => void handleDeleteInvoice(invoice.id)}
                           disabled={deletingInvoiceId === invoice.id}
                           title="Delete invoice"
                           aria-label={`Delete invoice ${invoice.invoice_number || invoice.id}`}
                         >
-                          {deletingInvoiceId === invoice.id ? 'Deleting...' : 'Delete'}
+                          <Trash2 size={16} />
                         </button>
                       </div>
                     </div>

--- a/frontend/src/pages/LedgerViewPage.tsx
+++ b/frontend/src/pages/LedgerViewPage.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import { ArrowLeft, ChevronDown, FileText, FilePlus, Mail, Pencil, ReceiptText } from 'lucide-react';
 import api, { getApiErrorMessage } from '../api/client';
 import type { CompanyProfile, Invoice, Ledger, LedgerStatement, PaymentCreate, Product } from '../types/api';
 import InvoicePreview from '../components/InvoicePreview';
@@ -45,6 +46,19 @@ export default function LedgerViewPage() {
   const [showStatementPreview, setShowStatementPreview] = useState(false);
   const [showInvoiceModal, setShowInvoiceModal] = useState(false);
   const [showEmailModal, setShowEmailModal] = useState(false);
+  const [showActionsDropdown, setShowActionsDropdown] = useState(false);
+  const actionsDropdownRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!showActionsDropdown) return;
+    function handleClickOutside(e: MouseEvent) {
+      if (actionsDropdownRef.current && !actionsDropdownRef.current.contains(e.target as Node)) {
+        setShowActionsDropdown(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [showActionsDropdown]);
 
   useEffect(() => {
     let cancelled = false;
@@ -171,18 +185,69 @@ export default function LedgerViewPage() {
             {ledger.email ? ` · ${ledger.email}` : ''}
           </p>
         </div>
-        <button type="button" className="button button--secondary" onClick={() => navigate('/ledgers')} title="Back to ledgers" aria-label="Back to ledgers">
-          Back to ledgers
-        </button>
-        <button type="button" className="button button--primary" onClick={() => setShowPaymentForm(true)} title="Record receipt or payment" aria-label="Record receipt or payment">
-          Record Receipt / Payment
-        </button>
-        <button type="button" className="button button--primary" onClick={() => setShowEmailModal(true)} title="Send payment reminder" aria-label="Send payment reminder">
-          Send Reminder
-        </button>
-        <button type="button" className="button button--primary" onClick={() => setShowInvoiceModal(true)} title="Create invoice" aria-label="Create invoice">
-          Create Invoice
-        </button>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+          <button
+            type="button"
+            className="button button--ghost"
+            onClick={() => navigate('/ledgers')}
+            title="Back to ledgers"
+            aria-label="Back to ledgers"
+            style={{ display: 'inline-flex', alignItems: 'center', gap: '6px' }}
+          >
+            <ArrowLeft size={16} />
+            Back
+          </button>
+
+          <div className="split-button">
+            <button
+              type="button"
+              className="button button--primary split-button__main"
+              onClick={() => setShowPaymentForm(true)}
+              title="Record receipt or payment"
+              aria-label="Record Receipt / Payment"
+            >
+              <ReceiptText size={16} />
+              Record Receipt / Payment
+            </button>
+            <div className="action-dropdown" ref={actionsDropdownRef}>
+              <button
+                type="button"
+                className="button button--primary split-button__caret"
+                onClick={() => setShowActionsDropdown((v) => !v)}
+                aria-label="More ledger actions"
+                aria-haspopup="true"
+                aria-expanded={showActionsDropdown}
+                title="More actions"
+              >
+                <ChevronDown size={14} />
+              </button>
+              {showActionsDropdown ? (
+                <div className="action-dropdown__menu" role="menu">
+                  <button
+                    type="button"
+                    className="action-dropdown__item"
+                    role="menuitem"
+                    aria-label="Send Reminder"
+                    onClick={() => { setShowActionsDropdown(false); setShowEmailModal(true); }}
+                  >
+                    <Mail size={16} />
+                    Send Reminder
+                  </button>
+                  <button
+                    type="button"
+                    className="action-dropdown__item"
+                    role="menuitem"
+                    aria-label="Create Invoice"
+                    onClick={() => { setShowActionsDropdown(false); setShowInvoiceModal(true); }}
+                  >
+                    <FilePlus size={16} />
+                    Create Invoice
+                  </button>
+                </div>
+              ) : null}
+            </div>
+          </div>
+        </div>
       </section>
 
       <StatusToasts error={error} onClearError={() => setError('')} onClearSuccess={() => {}} />
@@ -194,8 +259,14 @@ export default function LedgerViewPage() {
               <p className="eyebrow">Ledger details</p>
               <h2 className="nav-panel__title">Account info</h2>
             </div>
-            <button type="button" className="button button--ghost" onClick={() => navigate(`/ledgers/${ledgerId}/edit`)} title="Edit ledger" aria-label="Edit ledger">
-              Edit
+            <button
+              type="button"
+              className="button button--ghost button--icon"
+              onClick={() => navigate(`/ledgers/${ledgerId}/edit`)}
+              title="Edit ledger"
+              aria-label="Edit ledger"
+            >
+              <Pencil size={16} />
             </button>
           </div>
 
@@ -219,7 +290,15 @@ export default function LedgerViewPage() {
               <h2 className="nav-panel__title">Period view</h2>
             </div>
             {statement && statement.entries.length > 0 ? (
-              <button type="button" className="button button--secondary" onClick={() => setShowStatementPreview(true)} title="Preview statement PDF" aria-label="Preview statement PDF">
+              <button
+                type="button"
+                className="button button--secondary"
+                onClick={() => setShowStatementPreview(true)}
+                title="Preview statement PDF"
+                aria-label="Preview statement PDF"
+                style={{ display: 'inline-flex', alignItems: 'center', gap: '6px' }}
+              >
+                <FileText size={15} />
                 Preview / PDF
               </button>
             ) : null}

--- a/frontend/src/pages/LedgersPage.tsx
+++ b/frontend/src/pages/LedgersPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
+import { Eye, Pencil, Plus, Trash2 } from 'lucide-react';
 import api, { getApiErrorMessage } from '../api/client';
 import StatusToasts from '../components/StatusToasts';
 import type { Ledger, PaginatedLedgers } from '../types/api';
@@ -90,7 +91,14 @@ export default function LedgersPage() {
         </div>
         <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
           <div className="status-chip">{total} ledgers listed</div>
-          <button className="button button--primary" onClick={() => navigate('/ledgers/new')} title="Create ledger" aria-label="Create ledger">
+          <button
+            className="button button--primary"
+            onClick={() => navigate('/ledgers/new')}
+            title="Create ledger"
+            aria-label="Create ledger"
+            style={{ display: 'inline-flex', alignItems: 'center', gap: '6px' }}
+          >
+            <Plus size={16} />
             Create ledger
           </button>
         </div>
@@ -166,21 +174,33 @@ export default function LedgersPage() {
                     </div>
                     <span className="table-subtext text-right">Ledger #{ledger.id}</span>
                     <div className="table-row__actions">
-                      <button type="button" className="button button--ghost" onClick={() => navigate(`/ledgers/${ledger.id}`)} title={`View ledger ${ledger.name}`} aria-label={`View ledger ${ledger.name}`}>
-                        View
-                      </button>
-                      <button type="button" className="button button--ghost" onClick={() => navigate(`/ledgers/${ledger.id}/edit`)} title={`Edit ledger ${ledger.name}`} aria-label={`Edit ledger ${ledger.name}`}>
-                        Edit
+                      <button
+                        type="button"
+                        className="button button--ghost button--icon"
+                        onClick={() => navigate(`/ledgers/${ledger.id}`)}
+                        title={`View ledger ${ledger.name}`}
+                        aria-label={`View ledger ${ledger.name}`}
+                      >
+                        <Eye size={16} />
                       </button>
                       <button
                         type="button"
-                        className="button button--danger"
+                        className="button button--ghost button--icon"
+                        onClick={() => navigate(`/ledgers/${ledger.id}/edit`)}
+                        title={`Edit ledger ${ledger.name}`}
+                        aria-label={`Edit ledger ${ledger.name}`}
+                      >
+                        <Pencil size={16} />
+                      </button>
+                      <button
+                        type="button"
+                        className="button button--danger button--icon"
                         onClick={() => handleDeleteLedger(ledger.id)}
                         disabled={deletingLedgerId === ledger.id}
                         title={`Delete ledger ${ledger.name}`}
                         aria-label={`Delete ledger ${ledger.name}`}
                       >
-                        {deletingLedgerId === ledger.id ? 'Deleting...' : 'Delete'}
+                        <Trash2 size={16} />
                       </button>
                     </div>
                   </div>

--- a/frontend/src/pages/ProductsPage.tsx
+++ b/frontend/src/pages/ProductsPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { Pencil, Trash2 } from 'lucide-react';
 import api, { getApiErrorMessage } from '../api/client';
 import type { CompanyProfile, PaginatedProducts, Product, ProductCreate } from '../types/api';
 import StatusToasts from '../components/StatusToasts';
@@ -309,18 +310,25 @@ export default function ProductsPage() {
                     </div>
                     <span className="table-row__price">{formatCurrency(product.price, activeCurrencyCode)}</span>
                     <div className="table-row__actions">
-                      <button type="button" className="button button--ghost" onClick={() => startEditProduct(product)} disabled={submitting} title={`Edit product ${product.name}`} aria-label={`Edit product ${product.name}`}>
-                        Edit
+                      <button
+                        type="button"
+                        className="button button--ghost button--icon"
+                        onClick={() => startEditProduct(product)}
+                        disabled={submitting}
+                        title={`Edit product ${product.name}`}
+                        aria-label={`Edit product ${product.name}`}
+                      >
+                        <Pencil size={16} />
                       </button>
                       <button
                         type="button"
-                        className="button button--danger"
+                        className="button button--danger button--icon"
                         onClick={() => handleDeleteProduct(product.id)}
                         disabled={deletingProductId === product.id}
                         title={`Delete product ${product.name}`}
                         aria-label={`Delete product ${product.name}`}
                       >
-                        {deletingProductId === product.id ? 'Deleting...' : 'Delete'}
+                        <Trash2 size={16} />
                       </button>
                     </div>
                   </div>

--- a/frontend/src/pages/SmtpSettingsPage.tsx
+++ b/frontend/src/pages/SmtpSettingsPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { CheckCircle, Pencil, Plus, Send, Trash2 } from 'lucide-react';
 import api, { getApiErrorMessage } from '../api/client';
 import type { SmtpConfig, SmtpConfigCreate, SmtpConfigUpdate } from '../types/api';
 import StatusToasts from '../components/StatusToasts';
@@ -403,7 +404,12 @@ export default function SmtpSettingsPage() {
           <h1 className="page-title">SMTP settings</h1>
           <p className="section-copy">Manage outgoing email configurations used for invoices, statements, and reminders.</p>
         </div>
-        <button className="button button--primary" onClick={openAdd}>
+        <button
+          className="button button--primary"
+          onClick={openAdd}
+          style={{ display: 'inline-flex', alignItems: 'center', gap: '6px' }}
+        >
+          <Plus size={16} />
           Add configuration
         </button>
       </section>
@@ -458,35 +464,39 @@ export default function SmtpSettingsPage() {
                 <div className="button-row" style={{ gap: '8px', flexShrink: 0 }}>
                   {!config.is_active && (
                     <button
-                      className="button button--secondary"
+                      className="button button--ghost button--icon"
                       onClick={() => void handleActivate(config)}
                       disabled={activatingId === config.id}
                       title="Set as active configuration"
+                      aria-label="Set active"
                     >
-                      {activatingId === config.id ? 'Activating…' : 'Set active'}
+                      <CheckCircle size={16} />
                     </button>
                   )}
                   <button
-                    className="button button--secondary"
+                    className="button button--ghost button--icon"
                     onClick={() => setTestingConfig(config)}
                     title="Send a test email"
+                    aria-label="Test email"
                   >
-                    Test email
+                    <Send size={16} />
                   </button>
                   <button
-                    className="button button--secondary"
+                    className="button button--ghost button--icon"
                     onClick={() => openEdit(config)}
                     title="Edit this configuration"
+                    aria-label="Edit configuration"
                   >
-                    Edit
+                    <Pencil size={16} />
                   </button>
                   <button
-                    className="button button--danger"
+                    className="button button--danger button--icon"
                     onClick={() => setPendingDeleteId(config.id)}
                     disabled={deletingId === config.id || config.is_active}
                     title={config.is_active ? 'Cannot delete active configuration' : 'Delete this configuration'}
+                    aria-label="Delete configuration"
                   >
-                    {deletingId === config.id ? 'Deleting…' : 'Delete'}
+                    <Trash2 size={16} />
                   </button>
                 </div>
               </div>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -394,6 +394,84 @@ textarea {
   transform: translateY(-1px);
 }
 
+/* Icon-only square button */
+.button--icon {
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  border-radius: 10px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+/* Split button group: primary action + caret dropdown trigger */
+.split-button {
+  display: inline-flex;
+  align-items: stretch;
+  border-radius: 16px;
+}
+
+.split-button__main {
+  border-radius: 16px 0 0 16px !important;
+  gap: 6px;
+  display: inline-flex;
+  align-items: center;
+}
+
+.split-button__caret {
+  border-radius: 0 16px 16px 0 !important;
+  border-left: 1px solid rgba(5, 45, 42, 0.25) !important;
+  width: 34px;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Dropdown menu */
+.action-dropdown {
+  position: relative;
+  display: inline-flex;
+}
+
+.action-dropdown__menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  min-width: 200px;
+  background: var(--bg);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 6px;
+  display: grid;
+  gap: 2px;
+  z-index: 200;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+}
+
+.action-dropdown__item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border: 0;
+  background: transparent;
+  border-radius: 10px;
+  cursor: pointer;
+  font-weight: 700;
+  font-size: 0.9rem;
+  color: var(--text);
+  text-align: left;
+  transition: background 140ms ease;
+  width: 100%;
+}
+
+.action-dropdown__item:hover {
+  background: rgba(255, 255, 255, 0.07);
+}
+
 .toast-stack {
   position: fixed;
   top: 24px;


### PR DESCRIPTION
## Summary

Improves the button-heavy UI across all pages by replacing text-only row buttons with icon buttons, and restructuring the LedgerView hero actions into a split button with a dropdown.

## Changes

### Frontend — UI
- **Install** `lucide-react` icon library
- **CSS** — new utility classes: `.button--icon`, `.split-button`, `.split-button__main`, `.split-button__caret`, `.action-dropdown`, `.action-dropdown__menu`, `.action-dropdown__item`
- **LedgerViewPage** — hero restructured: back button with arrow icon, primary "Record Receipt / Payment" split button, caret opens dropdown with **Send Reminder** and **Create Invoice** actions; panel Edit → icon button
- **LedgersPage** — row actions (View / Edit / Delete) converted to icon-only buttons; hero gets `+` icon
- **InvoicesPage** — invoice row actions (Preview / Edit / Delete) converted to icon-only buttons
- **ProductsPage** — product row actions (Edit / Delete) converted to icon-only buttons
- **SmtpSettingsPage** — card action buttons (Set Active / Test / Edit / Delete) converted to icon buttons

### E2E Tests
- Migrate all brittle `button:has-text(...)` selectors to `[aria-label^="..."]` across: `ledgers`, `payments`, `email`, `ledger-statement`, `ledger-invoice`, `invoices`, `products`  
- Update **Send Reminder** and **Create Invoice** flows to use the two-step dropdown interaction
- Add two new tests in `ledger-invoice.spec.ts`: dropdown opens on caret click, dropdown closes on outside click