### PR TITLE
chore: Update Makefile to use Docker Compose V2 (docker compose)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,57 +25,57 @@ help:
 	@echo "  make lint             - Run lightweight backend/frontend checks"
 
 dev:
-	docker-compose --profile dev up -d
+	docker compose --profile dev up -d
 
 prod:
-	docker-compose --profile prod up -d
+	docker compose --profile prod up -d
 
 down:
-	docker-compose down
+	docker compose down
 
 logs:
-	docker-compose logs -f
+	docker compose logs -f
 
 seed:
-	docker-compose --profile dev exec backend-dev python seed_admin.py
+	docker compose --profile dev exec backend-dev python seed_admin.py
 
 migrate: migrate-up
 
 migrate-up:
-	docker-compose --profile dev exec backend-dev python migrate.py up
+	docker compose --profile dev exec backend-dev python migrate.py up
 
 migrate-down:
-	docker-compose --profile dev exec backend-dev python migrate.py down
+	docker compose --profile dev exec backend-dev python migrate.py down
 
 migrate-down-all:
-	docker-compose --profile dev exec backend-dev python migrate.py down --all
+	docker compose --profile dev exec backend-dev python migrate.py down --all
 
 migrate-status:
-	docker-compose --profile dev exec backend-dev python migrate.py status
+	docker compose --profile dev exec backend-dev python migrate.py status
 
 migrate-create:
-	docker-compose --profile dev exec backend-dev python migrate.py create "$(name)"
+	docker compose --profile dev exec backend-dev python migrate.py create "$(name)"
 
 backend-shell:
-	docker-compose --profile dev exec backend-dev /bin/sh
+	docker compose --profile dev exec backend-dev /bin/sh
 
 frontend-shell:
-	docker-compose --profile dev exec frontend-dev /bin/sh
+	docker compose --profile dev exec frontend-dev /bin/sh
 
 test:
-	docker-compose --profile dev exec frontend-dev npm run test:e2e
+	docker compose --profile dev exec frontend-dev npm run test:e2e
 
 lint:
-	docker-compose --profile dev exec backend-dev python -m compileall .
-	docker-compose --profile dev exec frontend-dev npm run build
+	docker compose --profile dev exec backend-dev python -m compileall .
+	docker compose --profile dev exec frontend-dev npm run build
 
 build:
-	docker-compose --profile dev build backend-dev frontend-dev
+	docker compose --profile dev build backend-dev frontend-dev
 
 install: install-backend install-frontend
 
 install-backend:
-	docker-compose --profile dev exec backend-dev pip install -r requirements.txt
+	docker compose --profile dev exec backend-dev pip install -r requirements.txt
 
 install-frontend:
-	docker-compose --profile dev exec frontend-dev npm install
+	docker compose --profile dev exec frontend-dev npm install


### PR DESCRIPTION
## Summary\n\nReplaces all occurrences of `docker-compose` with `docker compose` in the `Makefile` to use Docker Compose V2.\n\nDocker Compose V1 (`docker-compose`) reached end-of-life in July 2023. Docker Desktop and modern Linux installs only ship V2 (`docker compose`).\n\nCloses #132