### PR TITLE
feat [Phase 1/3][1/5]: Create user_shortcuts DB migration

### DIFF
--- a/backend/migrations/20260407000001_create_user_shortcuts_table.py
+++ b/backend/migrations/20260407000001_create_user_shortcuts_table.py
@@ -1,0 +1,24 @@
+"""
+create_user_shortcuts_table
+"""
+
+from sqlalchemy import text
+
+
+def up(conn) -> None:
+    conn.execute(text("""
+        CREATE TABLE IF NOT EXISTS user_shortcuts (
+            id SERIAL PRIMARY KEY,
+            user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            action_key VARCHAR NOT NULL,
+            shortcut_key VARCHAR NOT NULL,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            CONSTRAINT uq_user_shortcuts_user_action UNIQUE (user_id, action_key)
+        )
+    """))
+    conn.execute(text("CREATE INDEX IF NOT EXISTS ix_user_shortcuts_user_id ON user_shortcuts (user_id)"))
+
+
+def down(conn) -> None:
+    conn.execute(text("DROP TABLE IF EXISTS user_shortcuts"))


### PR DESCRIPTION
## Summary

Creates the `user_shortcuts` DB migration as specified in #119.

- Adds `user_shortcuts` table with `id`, `user_id`, `action_key`, `shortcut_key`, `created_at`, `updated_at`
- Unique constraint on `(user_id, action_key)`
- Index on `user_id`
- Idempotent `up()` using `CREATE TABLE IF NOT EXISTS`
- `down()` drops the table

Closes #119