### PR TITLE
feat [Phase 1/3][2/5]: SQLAlchemy model for UserShortcut

### DIFF
--- a/backend/src/models/__init__.py
+++ b/backend/src/models/__init__.py
@@ -6,3 +6,4 @@ from src.models.buyer import Buyer
 from src.models.company import CompanyProfile
 from src.models.payment import Payment
 from src.models.smtp_config import SMTPConfig
+from src.models.user_shortcut import UserShortcut

--- a/backend/src/models/user_shortcut.py
+++ b/backend/src/models/user_shortcut.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+
+from sqlalchemy import Column, DateTime, ForeignKey, Index, Integer, String, UniqueConstraint
+
+from src.db.base import Base
+
+
+class UserShortcut(Base):
+    __tablename__ = "user_shortcuts"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    action_key = Column(String, nullable=False)
+    shortcut_key = Column(String, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint("user_id", "action_key", name="uq_user_shortcuts_user_action"),
+        Index("ix_user_shortcuts_user_id", "user_id"),
+    )


### PR DESCRIPTION
Closes #120

## Changes
- Add `backend/src/models/user_shortcut.py` with `UserShortcut` SQLAlchemy model
  - `__tablename__ = "user_shortcuts"`
  - Columns: `id`, `user_id` (ForeignKey → `users.id` with CASCADE), `action_key`, `shortcut_key`, `created_at`, `updated_at`
  - `UniqueConstraint("user_id", "action_key")` matching the migration constraint name `uq_user_shortcuts_user_action`
  - Index on `user_id` matching `ix_user_shortcuts_user_id`
- Export `UserShortcut` from `backend/src/models/__init__.py`

## References
- Migration: #119
- Epic: #115 / Phase 1: #116