### PR TITLE
fix: correct inverted TLS/SSL detection for SMTP

### DIFF
--- a/backend/src/api/routes/smtp.py
+++ b/backend/src/api/routes/smtp.py
@@ -200,12 +200,12 @@ def test_smtp_config(
         msg['Subject'] = "Test Email from Invoicing System"
         msg.attach(MIMEText("This is a test email to verify SMTP configuration.", 'plain'))
 
-        # Connect to the SMTP server and send the email
-        if config.use_tls:
+        # Port 465 = implicit SSL; port 587 (or use_tls=True) = STARTTLS
+        if config.port == 465 or not config.use_tls:
+            server = smtplib.SMTP_SSL(config.host, config.port)
+        else:
             server = smtplib.SMTP(config.host, config.port)
             server.starttls()
-        else:
-            server = smtplib.SMTP_SSL(config.host, config.port)
 
         server.login(config.username, config.password)
         server.send_message(msg)
@@ -237,11 +237,11 @@ def test_smtp_template(
         msg["Subject"] = subject
         msg.attach(MIMEText(html_body, "html"))
 
-        if config.use_tls:
+        if config.port == 465 or not config.use_tls:
+            server = smtplib.SMTP_SSL(config.host, config.port)
+        else:
             server = smtplib.SMTP(config.host, config.port)
             server.starttls()
-        else:
-            server = smtplib.SMTP_SSL(config.host, config.port)
 
         server.login(config.username, config.password)
         server.send_message(msg)

--- a/backend/src/services/mail.py
+++ b/backend/src/services/mail.py
@@ -57,13 +57,14 @@ def _send_sync(config: SMTPConfig, msg: MIMEMultipart) -> None:
         recipients.extend([email.strip() for email in msg["Cc"].split(",")])
 
     try:
-        if config.use_tls:
-            with smtplib.SMTP(config.host, config.port, timeout=10) as server:
-                server.starttls()
+        # Port 465 = implicit SSL; port 587 (or use_tls=True) = STARTTLS
+        if config.port == 465 or not config.use_tls:
+            with smtplib.SMTP_SSL(config.host, config.port, timeout=10) as server:
                 server.login(config.username, config.password)
                 server.send_message(msg, to_addrs=recipients)
         else:
-            with smtplib.SMTP_SSL(config.host, config.port, timeout=10) as server:
+            with smtplib.SMTP(config.host, config.port, timeout=10) as server:
+                server.starttls()
                 server.login(config.username, config.password)
                 server.send_message(msg, to_addrs=recipients)
     except Exception:


### PR DESCRIPTION
## Problem

Port 465 requires an **immediate SSL handshake** (`SMTP_SSL`), but the logic was inverted — `use_tls=True` was opening a plain `SMTP` connection and calling `starttls()`, causing timeouts when connecting to port 465.

## Changes

- `backend/src/api/routes/smtp.py` — fixed `/test` and `/test-template` endpoints
- `backend/src/services/mail.py` — fixed `_send_sync()`

## Fix

Replaced the `use_tls` boolean check with port-based detection:
- Port `465` → `SMTP_SSL` (implicit SSL)
- Port `587` + `use_tls=True` → plain `SMTP` + `starttls()`