### PR TITLE
feat [Phase 1/3][3/5]: Pydantic schemas for user shortcuts

### DIFF
--- a/backend/src/schemas/user_shortcut.py
+++ b/backend/src/schemas/user_shortcut.py
@@ -1,0 +1,17 @@
+from pydantic import BaseModel, Field
+
+
+class UserShortcutUpdate(BaseModel):
+    shortcut_key: str = Field(min_length=1)
+
+
+class UserShortcutResponse(BaseModel):
+    action_key: str
+    shortcut_key: str
+
+    class Config:
+        from_attributes = True
+
+
+class UserShortcutsListResponse(BaseModel):
+    shortcuts: list[UserShortcutResponse]


### PR DESCRIPTION
Closes #121\n\n## Changes\n\nAdds Pydantic schemas for user shortcuts:\n\n- `UserShortcutUpdate` — payload for updating a shortcut key\n- `UserShortcutResponse` — response model with ORM mode enabled\n- `UserShortcutsListResponse` — wrapper for listing all shortcuts\n\n## Part of\n\nPhase 1 #116 → Epic #115. Depends on #120 (model).