### PR TITLE
feat [Phase 2/3][1/4]: Create shortcutDefaults.ts utility

### DIFF
--- a/frontend/src/utils/shortcutDefaults.ts
+++ b/frontend/src/utils/shortcutDefaults.ts
@@ -1,0 +1,33 @@
+export const ACTION_KEYS = [
+  'create_invoice', 'save_invoice', 'open_search', 'open_reports',
+  'new_customer', 'go_invoices', 'go_ledgers', 'go_products',
+  'go_inventory', 'go_day_book',
+] as const;
+
+export type ActionKey = typeof ACTION_KEYS[number];
+
+export const DEFAULT_SHORTCUTS: Record<ActionKey, string> = {
+  create_invoice: 'Ctrl+N',
+  save_invoice:   'Ctrl+S',
+  open_search:    'Ctrl+F',
+  open_reports:   'Ctrl+R',
+  new_customer:   'Ctrl+Shift+C',
+  go_invoices:    'Alt+I',
+  go_ledgers:     'Alt+L',
+  go_products:    'Alt+P',
+  go_inventory:   'Alt+V',
+  go_day_book:    'Alt+D',
+};
+
+export const ACTION_LABELS: Record<ActionKey, string> = {
+  create_invoice: 'New Invoice',
+  save_invoice:   'Save Invoice',
+  open_search:    'Search',
+  open_reports:   'Open Reports',
+  new_customer:   'New Customer',
+  go_invoices:    'Go to Invoices',
+  go_ledgers:     'Go to Ledgers',
+  go_products:    'Go to Products',
+  go_inventory:   'Go to Inventory',
+  go_day_book:    'Go to Day Book',
+};


### PR DESCRIPTION
## Summary

Creates the `shortcutDefaults.ts` utility file as specified in #124.

## Changes
- Add `ACTION_KEYS` const array with 10 action key literals
- Export `ActionKey` type derived from `ACTION_KEYS`
- Add `DEFAULT_SHORTCUTS` record mapping actions to key bindings (Ctrl/Alt combos)
- Add `ACTION_LABELS` record mapping actions to human-readable display labels

Closes #124