### PR TITLE
feat [Phase 2/3][2/4]: ShortcutsContext with Zustand store and global keydown listener

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,7 +13,8 @@
         "lucide-react": "^1.7.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-router-dom": "^6.26.2"
+        "react-router-dom": "^6.26.2",
+        "zustand": "^5.0.12"
       },
       "devDependencies": {
         "@playwright/test": "^1.58.2",
@@ -71,6 +72,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1239,15 +1241,16 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1425,6 +1428,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1567,7 +1571,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -2059,6 +2063,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -2404,6 +2409,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -2579,6 +2585,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -2591,6 +2598,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -2932,6 +2940,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3023,6 +3032,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -3083,6 +3093,35 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/zustand": {
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.12.tgz",
+      "integrity": "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
+      }
     }
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,8 @@
     "lucide-react": "^1.7.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.26.2"
+    "react-router-dom": "^6.26.2",
+    "zustand": "^5.0.12"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",

--- a/frontend/src/context/ShortcutsContext.tsx
+++ b/frontend/src/context/ShortcutsContext.tsx
@@ -1,0 +1,100 @@
+import { useEffect } from 'react';
+import { create } from 'zustand';
+import api from '../api/client';
+import { useAuth } from './AuthContext';
+import { ACTION_KEYS, DEFAULT_SHORTCUTS, type ActionKey } from '../utils/shortcutDefaults';
+
+type ShortcutEntry = {
+  action_key: string;
+  shortcut_key: string;
+};
+
+type ShortcutsListResponse = {
+  shortcuts: ShortcutEntry[];
+};
+
+type ShortcutsStore = {
+  shortcutsMap: Record<ActionKey, string>;
+  handlers: Map<ActionKey, () => void>;
+  shortcutFor: (key: ActionKey) => string;
+  registerAction: (key: ActionKey, handler: () => void) => () => void;
+  refetchShortcuts: () => Promise<void>;
+};
+
+const useShortcutsStore = create<ShortcutsStore>((set, get) => ({
+  shortcutsMap: { ...DEFAULT_SHORTCUTS },
+  handlers: new Map(),
+
+  shortcutFor: (key) => get().shortcutsMap[key] ?? DEFAULT_SHORTCUTS[key],
+
+  registerAction: (key, handler) => {
+    get().handlers.set(key, handler);
+    return () => {
+      get().handlers.delete(key);
+    };
+  },
+
+  refetchShortcuts: async () => {
+    try {
+      const res = await api.get<ShortcutsListResponse>('/shortcuts/');
+      const merged: Record<ActionKey, string> = { ...DEFAULT_SHORTCUTS };
+      for (const { action_key, shortcut_key } of res.data.shortcuts) {
+        if (ACTION_KEYS.includes(action_key as ActionKey)) {
+          merged[action_key as ActionKey] = shortcut_key;
+        }
+      }
+      set({ shortcutsMap: merged });
+    } catch {
+      // keep existing map on error
+    }
+  },
+}));
+
+function normalizeCombo(e: KeyboardEvent): string {
+  const parts: string[] = [];
+  if (e.ctrlKey) parts.push('Ctrl');
+  if (e.shiftKey) parts.push('Shift');
+  if (e.altKey) parts.push('Alt');
+  if (e.metaKey) parts.push('Meta');
+  const key = e.key.length === 1 ? e.key.toUpperCase() : e.key;
+  parts.push(key);
+  return parts.join('+');
+}
+
+export function ShortcutsProvider({ children }: { children: React.ReactNode }) {
+  const { isAuthenticated } = useAuth();
+  const refetchShortcuts = useShortcutsStore((s) => s.refetchShortcuts);
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      refetchShortcuts();
+    }
+  }, [isAuthenticated, refetchShortcuts]);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const { shortcutsMap, handlers } = useShortcutsStore.getState();
+      const combo = normalizeCombo(e);
+      const action = (Object.keys(shortcutsMap) as ActionKey[]).find(
+        (k) => shortcutsMap[k] === combo,
+      );
+      if (!action) return;
+      const handler = handlers.get(action);
+      if (!handler) return;
+      e.preventDefault();
+      handler();
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, []);
+
+  return <>{children}</>;
+}
+
+export function useShortcuts() {
+  return useShortcutsStore((s) => ({
+    shortcutFor: s.shortcutFor,
+    registerAction: s.registerAction,
+    refetchShortcuts: s.refetchShortcuts,
+  }));
+}

--- a/frontend/src/utils/shortcutDefaults.ts
+++ b/frontend/src/utils/shortcutDefaults.ts
@@ -1,0 +1,33 @@
+export const ACTION_KEYS = [
+  'create_invoice', 'save_invoice', 'open_search', 'open_reports',
+  'new_customer', 'go_invoices', 'go_ledgers', 'go_products',
+  'go_inventory', 'go_day_book',
+] as const;
+
+export type ActionKey = typeof ACTION_KEYS[number];
+
+export const DEFAULT_SHORTCUTS: Record<ActionKey, string> = {
+  create_invoice: 'Ctrl+N',
+  save_invoice:   'Ctrl+S',
+  open_search:    'Ctrl+F',
+  open_reports:   'Ctrl+R',
+  new_customer:   'Ctrl+Shift+C',
+  go_invoices:    'Alt+I',
+  go_ledgers:     'Alt+L',
+  go_products:    'Alt+P',
+  go_inventory:   'Alt+V',
+  go_day_book:    'Alt+D',
+};
+
+export const ACTION_LABELS: Record<ActionKey, string> = {
+  create_invoice: 'New Invoice',
+  save_invoice:   'Save Invoice',
+  open_search:    'Search',
+  open_reports:   'Open Reports',
+  new_customer:   'New Customer',
+  go_invoices:    'Go to Invoices',
+  go_ledgers:     'Go to Ledgers',
+  go_products:    'Go to Products',
+  go_inventory:   'Go to Inventory',
+  go_day_book:    'Go to Day Book',
+};


### PR DESCRIPTION
Closes #125

## Changes

- **`frontend/src/utils/shortcutDefaults.ts`** — `ACTION_KEYS`, `ActionKey`, `DEFAULT_SHORTCUTS`, and `ACTION_LABELS` constants
- **`frontend/src/context/ShortcutsContext.tsx`** — Zustand-backed store with:
  - `shortcutsMap` initialised from `DEFAULT_SHORTCUTS`, merged with API response on mount
  - `registerAction(key, handler)` stores handler in a mutable `Map`, returns cleanup function
  - Global `keydown` listener normalises events to combo strings (`Ctrl+Shift+N` etc.) and dispatches to registered handlers; reads state via `getState()` so it never needs re-registration
  - `refetchShortcuts()` re-fetches `GET /api/shortcuts/` and rebuilds the map
  - Exports `ShortcutsProvider` and `useShortcuts()` hook
- Install `zustand` dependency