### PR TITLE
feat [Phase 2/3][4/4]: Wire navigation shortcuts in Layout.tsx

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,10 +1,27 @@
+import { useEffect } from 'react';
 import { motion } from 'framer-motion';
-import { Link, NavLink, useLocation } from 'react-router-dom';
+import { Link, NavLink, useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
+import { useShortcuts } from '../context/ShortcutsContext';
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   const { logout, userEmail, isAdmin } = useAuth();
   const location = useLocation();
+  const { registerAction } = useShortcuts();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const cleanups = [
+      registerAction('go_invoices',  () => navigate('/invoices')),
+      registerAction('go_ledgers',   () => navigate('/ledgers')),
+      registerAction('go_products',  () => navigate('/products')),
+      registerAction('go_inventory', () => navigate('/inventory')),
+      registerAction('go_day_book',  () => navigate('/day-book')),
+      registerAction('open_reports', () => navigate('/day-book')),
+      registerAction('new_customer', () => navigate('/ledgers/new')),
+    ];
+    return () => cleanups.forEach(fn => fn());
+  }, [registerAction, navigate]);
 
   const navItems = [
     { to: '/', label: 'Overview' },


### PR DESCRIPTION
## Summary

Wires navigation shortcuts in `Layout.tsx` as part of Phase 2 (#117) → Epic #115. Depends on #126 (ShortcutsProvider in App).

## Changes

- Import `useShortcuts` from `../context/ShortcutsContext`
- Import `useNavigate` from `react-router-dom`
- Register navigation shortcuts via `useEffect` with cleanup:
  - `go_invoices` → `/invoices`
  - `go_ledgers` → `/ledgers`
  - `go_products` → `/products`
  - `go_inventory` → `/inventory`
  - `go_day_book` → `/day-book`
  - `open_reports` → `/day-book`
  - `new_customer` → `/ledgers/new`

Closes #127