### PR TITLE
fix: use useShallow in useShortcuts to prevent infinite render loop

### DIFF
--- a/frontend/src/context/ShortcutsContext.tsx
+++ b/frontend/src/context/ShortcutsContext.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { create } from 'zustand';
+import { useShallow } from 'zustand/shallow';
 import api from '../api/client';
 import { useAuth } from './AuthContext';
 import { ACTION_KEYS, DEFAULT_SHORTCUTS, type ActionKey } from '../utils/shortcutDefaults';
@@ -92,9 +93,9 @@ export function ShortcutsProvider({ children }: { children: React.ReactNode }) {
 }
 
 export function useShortcuts() {
-  return useShortcutsStore((s) => ({
+  return useShortcutsStore(useShallow((s) => ({
     shortcutFor: s.shortcutFor,
     registerAction: s.registerAction,
     refetchShortcuts: s.refetchShortcuts,
-  }));
+  })));
 }


### PR DESCRIPTION
## Problem

The app was crashing with `Maximum update depth exceeded` in the `Layout` component.

**Root cause:** `useShortcuts()` used a Zustand selector returning a plain object literal:

```ts
return useShortcutsStore((s) => ({
  shortcutFor: s.shortcutFor,
  registerAction: s.registerAction,
  refetchShortcuts: s.refetchShortcuts,
}));
```

Zustand compares selector output with `Object.is`. A new object reference is created on every call, so Zustand always sees a "state change" → calls `forceStoreRerender` → triggers another render → new object → infinite loop.

## Fix

Wrap the selector with `useShallow` from `zustand/shallow`, which does shallow property comparison. Since `shortcutFor`, `registerAction`, and `refetchShortcuts` are stable function references defined once in the store's `create()` call, the shallow comparison returns equal on every render and the loop is broken.

```ts
return useShortcutsStore(useShallow((s) => ({
  shortcutFor: s.shortcutFor,
  registerAction: s.registerAction,
  refetchShortcuts: s.refetchShortcuts,
})));
```