### PR TITLE
feat: wrap App with ShortcutsProvider (#117)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { Navigate, Route, Routes } from 'react-router-dom';
 import { AuthProvider, useAuth } from './context/AuthContext';
+import { ShortcutsProvider } from './context/ShortcutsContext';
 import LoginPage from './pages/LoginPage';
 import DashboardPage from './pages/DashboardPage';
 import ProductsPage from './pages/ProductsPage';
@@ -73,7 +74,9 @@ function AppRoutes() {
 export default function App() {
   return (
     <AuthProvider>
-      <AppRoutes />
+      <ShortcutsProvider>
+        <AppRoutes />
+      </ShortcutsProvider>
     </AuthProvider>
   );
 }


### PR DESCRIPTION
## Summary

Wraps `AppRoutes` with `ShortcutsProvider` in `App.tsx` so the global `keydown` listener is active for the full lifetime of the app.

Without this wrapper the listener was never attached, meaning no keyboard shortcut ever fired.

## Verification (from #117)
1. `Alt+I` → navigates to `/invoices` ✅
2. `Alt+L` → navigates to `/ledgers` ✅
3. `Ctrl+Shift+C` → navigates to `/ledgers/new` ✅
4. Unregistered combos do not fire ✅
5. DB-overridden shortcuts take effect after login ✅

Closes #117