### PR TITLE
feat [Phase 3/3][1/4]: Add UserShortcut types to api.ts

### DIFF
--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -283,3 +283,12 @@ export type SmtpConfigUpdate = {
   from_name?: string;
   use_tls?: boolean;
 };
+
+export type UserShortcut = {
+  action_key: string;
+  shortcut_key: string;
+};
+
+export type UserShortcutsResponse = {
+  shortcuts: UserShortcut[];
+};


### PR DESCRIPTION
Closes #128\n\nAdds `UserShortcut` and `UserShortcutsResponse` types to `frontend/src/types/api.ts`.