### PR TITLE
feat(invoices): add supplier invoice number field on purchase invoices

### DIFF
--- a/backend/src/api/routes/invoices.py
+++ b/backend/src/api/routes/invoices.py
@@ -122,6 +122,7 @@ def _apply_payload_to_invoice(
     invoice.company_account_number = company.account_number if company else None
     invoice.company_ifsc_code = company.ifsc_code if company else None
     invoice.voucher_type = payload.voucher_type
+    invoice.supplier_invoice_number = payload.supplier_invoice_number
     if created_by is not None:
         invoice.created_by = created_by
 

--- a/backend/src/models/invoice.py
+++ b/backend/src/models/invoice.py
@@ -27,6 +27,7 @@ class Invoice(Base):
     company_account_number = Column(String, nullable=True)
     company_ifsc_code = Column(String, nullable=True)
     voucher_type = Column(String, nullable=False, default="sales")
+    supplier_invoice_number = Column(String, nullable=True)
     created_by = Column(Integer, ForeignKey("users.id"), nullable=False)
     taxable_amount = Column(Numeric(10, 2), nullable=False, default=0)
     total_tax_amount = Column(Numeric(10, 2), nullable=False, default=0)

--- a/backend/src/schemas/invoice.py
+++ b/backend/src/schemas/invoice.py
@@ -15,6 +15,7 @@ class InvoiceCreate(BaseModel):
     voucher_type: Literal["sales", "purchase"] = "sales"
     invoice_date: Optional[date] = None
     due_date: Optional[date] = None
+    supplier_invoice_number: str | None = None
     items: List[InvoiceItemCreate]
 
 
@@ -54,6 +55,7 @@ class InvoiceOut(BaseModel):
     company_account_number: str | None = None
     company_ifsc_code: str | None = None
     voucher_type: str
+    supplier_invoice_number: str | None = None
     ledger: LedgerOut | None = None
     taxable_amount: float
     total_tax_amount: float

--- a/frontend/e2e/invoices.spec.ts
+++ b/frontend/e2e/invoices.spec.ts
@@ -271,4 +271,86 @@ test.describe('Invoices', () => {
     await ctaButton.click();
     await expect(page.locator('#invoice-voucher-type')).toBeFocused();
   });
+
+  test('supplier invoice # field is hidden for sales invoices', async ({ authedPage: page }) => {
+    await page.click('[href="/invoices"]');
+    await page.waitForTimeout(500);
+
+    await page.selectOption('#invoice-voucher-type', 'sales');
+    await expect(page.locator('#invoice-supplier-ref')).not.toBeVisible();
+  });
+
+  test('supplier invoice # field is visible for purchase invoices', async ({ authedPage: page }) => {
+    await page.click('[href="/invoices"]');
+    await page.waitForTimeout(500);
+
+    await page.selectOption('#invoice-voucher-type', 'purchase');
+    await expect(page.locator('#invoice-supplier-ref')).toBeVisible();
+  });
+
+  test('creates a purchase invoice with supplier invoice number and shows it in the list', async ({ authedPage: page }) => {
+    const { sku, ledgerName } = await seedInvoiceData(page);
+    const supplierRef = `SUP-${Date.now().toString(36).toUpperCase()}`;
+
+    await page.click('[href="/invoices"]');
+    await page.waitForTimeout(500);
+
+    await page.selectOption('#invoice-voucher-type', 'purchase');
+
+    await selectComboboxOption(page, 'invoice-ledger', ledgerName);
+
+    const productInputId = (await page.locator('[id^="invoice-product-"]').first().getAttribute('id')) || 'invoice-product-1';
+    await selectComboboxOption(page, productInputId, sku);
+    await page.locator('[id^="invoice-quantity-"]').first().fill('3');
+
+    await page.fill('#invoice-supplier-ref', supplierRef);
+
+    await page.click('button:has-text("Create invoice")');
+    await expectSuccess(page, 'Purchase invoice created');
+
+    // Verify supplier ref appears in the invoice list row
+    const invoiceRow = page.locator('.invoice-row', { hasText: ledgerName }).first();
+    await expect(invoiceRow).toContainText(`Supplier Ref: ${supplierRef}`);
+  });
+
+  test('supplier invoice # field clears when switching from purchase to sales', async ({ authedPage: page }) => {
+    await page.click('[href="/invoices"]');
+    await page.waitForTimeout(500);
+
+    await page.selectOption('#invoice-voucher-type', 'purchase');
+    await page.fill('#invoice-supplier-ref', 'TEMP-REF-123');
+
+    // Switch to sales — field should disappear
+    await page.selectOption('#invoice-voucher-type', 'sales');
+    await expect(page.locator('#invoice-supplier-ref')).not.toBeVisible();
+
+    // Switch back to purchase — field should appear empty (state preserved but not visible)
+    await page.selectOption('#invoice-voucher-type', 'purchase');
+    await expect(page.locator('#invoice-supplier-ref')).toBeVisible();
+  });
+
+  test('edit preserves supplier invoice number for purchase invoice', async ({ authedPage: page }) => {
+    const { sku, ledgerName } = await seedInvoiceData(page);
+    const supplierRef = `EDIT-${Date.now().toString(36).toUpperCase()}`;
+
+    await page.click('[href="/invoices"]');
+    await page.waitForTimeout(500);
+
+    // Create purchase invoice with supplier ref
+    await page.selectOption('#invoice-voucher-type', 'purchase');
+    await selectComboboxOption(page, 'invoice-ledger', ledgerName);
+    const productInputId = (await page.locator('[id^="invoice-product-"]').first().getAttribute('id')) || 'invoice-product-1';
+    await selectComboboxOption(page, productInputId, sku);
+    await page.locator('[id^="invoice-quantity-"]').first().fill('2');
+    await page.fill('#invoice-supplier-ref', supplierRef);
+    await page.click('button:has-text("Create invoice")');
+    await expectSuccess(page, 'Purchase invoice created');
+
+    // Click edit on that invoice
+    const invoiceRow = page.locator('.invoice-row', { hasText: ledgerName }).first();
+    await invoiceRow.locator('[aria-label^="Edit invoice"]').click();
+
+    // Supplier ref field should be populated
+    await expect(page.locator('#invoice-supplier-ref')).toHaveValue(supplierRef);
+  });
 });

--- a/frontend/src/pages/InvoicesPage.tsx
+++ b/frontend/src/pages/InvoicesPage.tsx
@@ -33,6 +33,7 @@ export default function InvoicesPage() {
   const [company, setCompany] = useState<CompanyProfile | null>(null);
   const [selectedLedgerId, setSelectedLedgerId] = useState('');
   const [voucherType, setVoucherType] = useState<'sales' | 'purchase'>('sales');
+  const [supplierInvoiceNumber, setSupplierInvoiceNumber] = useState('');
   const [invoiceDate, setInvoiceDate] = useState(new Date().toISOString().slice(0, 10));
   const [showLedgerModal, setShowLedgerModal] = useState(false);
   const [showProductModal, setShowProductModal] = useState(false);
@@ -153,6 +154,7 @@ export default function InvoicesPage() {
 
   function resetInvoiceForm() {
     setEditingInvoiceId(null);
+    setSupplierInvoiceNumber('');
     const defaultProduct = products[0];
     setItems([createItem(1, String(defaultProduct?.id ?? ''), String(defaultProduct?.price ?? ''))]);
     setNextItemId(2);
@@ -174,6 +176,7 @@ export default function InvoicesPage() {
     setSuccess('');
     setEditingInvoiceId(invoice.id);
     setVoucherType(invoice.voucher_type);
+    setSupplierInvoiceNumber(invoice.supplier_invoice_number ?? '');
     setSelectedLedgerId(String(invoice.ledger_id));
     setInvoiceDate(invoice.invoice_date ? invoice.invoice_date.slice(0, 10) : new Date().toISOString().slice(0, 10));
 
@@ -200,6 +203,7 @@ export default function InvoicesPage() {
         ledger_id: Number(selectedLedgerId),
         voucher_type: voucherType,
         invoice_date: invoiceDate,
+        supplier_invoice_number: voucherType === 'purchase' ? (supplierInvoiceNumber.trim() || null) : null,
         items: items.map((item) => ({
           product_id: Number(item.productId),
           quantity: Number(item.quantity),
@@ -447,6 +451,20 @@ export default function InvoicesPage() {
                 />
               </div>
 
+              {voucherType === 'purchase' ? (
+                <div className="field">
+                  <label htmlFor="invoice-supplier-ref">Supplier Invoice #</label>
+                  <input
+                    id="invoice-supplier-ref"
+                    className="input"
+                    type="text"
+                    value={supplierInvoiceNumber}
+                    onChange={(event) => setSupplierInvoiceNumber(event.target.value)}
+                    placeholder="Supplier's invoice number"
+                  />
+                </div>
+              ) : null}
+
               <div className="button-row">
                 <button type="button" className="button button--secondary" onClick={() => setShowLedgerModal(true)} title="Add ledger" aria-label="Add ledger">
                   Add ledger
@@ -603,6 +621,9 @@ export default function InvoicesPage() {
                         <div className="invoice-row__identity">
                           <strong className="invoice-row__ledger-name">{invoice.ledger?.name || invoice.ledger_name || 'Unknown ledger'}</strong>
                           <span className="invoice-row__invoice-id">Invoice {invoice.invoice_number || `#${invoice.id}`}</span>
+                          {invoice.voucher_type === 'purchase' && invoice.supplier_invoice_number ? (
+                            <span className="invoice-row__invoice-id">Supplier Ref: {invoice.supplier_invoice_number}</span>
+                          ) : null}
                         </div>
                         <span className={`invoice-type-badge invoice-type-badge--${invoice.voucher_type}`}>
                           {invoice.voucher_type === 'sales' ? 'Sales' : 'Purchase'}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -139,6 +139,7 @@ export type Invoice = {
   company_account_number: string | null;
   company_ifsc_code: string | null;
   voucher_type: 'sales' | 'purchase';
+  supplier_invoice_number?: string | null;
   ledger: Ledger | null;
   taxable_amount: number;
   total_tax_amount: number;
@@ -175,6 +176,7 @@ export type InvoiceCreate = {
   ledger_id: number;
   invoice_date?: string;
   due_date?: string;
+  supplier_invoice_number?: string | null;
   items: InvoiceItemInput[];
 };
 


### PR DESCRIPTION
## Summary

Adds a **Supplier Invoice #** field to purchase invoices, allowing users to record the supplier's own invoice number for ledger reconciliation. The field is visible only on purchase invoices (hidden for sales), stored in the database, shown in the invoice list, and populated when editing an existing purchase invoice.

## Type of change

- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs (documentation)
- [x] test (tests)
- [ ] chore/refactor

## How to test

1. Start the app (`docker-compose up`)
2. Go to **Invoices**
3. Select **Purchase** as the voucher type → verify the "Supplier Invoice #" field appears
4. Switch to **Sales** → verify the field is hidden
5. Fill in a supplier ref, select a ledger & product, and create the invoice
6. Verify the invoice list row shows "Supplier Ref: <value>" for that purchase invoice
7. Click **Edit** on the invoice → verify the supplier ref field is pre-populated
8. Run e2e: `cd frontend && npx playwright test e2e/invoices.spec.ts`

## Checklist

- [x] My code follows the project style and conventions
- [x] I added/updated tests where appropriate
- [ ] I updated docs where needed
- [x] I ran relevant checks locally
- [x] I verified this does not break existing behavior

## Screenshots (if UI changes)

Field visible on purchase invoice form; hidden on sales invoice form. "Supplier Ref:" label shown in the invoice list row.

## Related issue

Closes #183