### PR TITLE
fix(invoices): separate purchase PDF layout — supplier left, company right, no bank details

### DIFF
--- a/backend/src/api/routes/invoices.py
+++ b/backend/src/api/routes/invoices.py
@@ -358,7 +358,276 @@ def _e(text: str | None) -> str:
     return escape(text or "")
 
 
+def _build_purchase_invoice_html(invoice: Invoice, products: list[Product]) -> str:
+    """Generate HTML for a purchase invoice (supplier at top-left, your company top-right,
+    no bank details in footer, optional supplier ref row)."""
+    currency = invoice.company_currency_code or "USD"
+    inv_number = invoice.invoice_number or f"#{invoice.id}"
+    inv_date = invoice.invoice_date.strftime("%d %b %Y") if invoice.invoice_date else (invoice.created_at.strftime("%d %b %Y") if invoice.created_at else "N/A")
+
+    product_map = {p.id: p for p in products}
+
+    item_rows = ""
+    for idx, item in enumerate(invoice.items or [], start=1):
+        prod = product_map.get(item.product_id)
+        product_name = _e(prod.name) if prod else f"Product #{item.product_id}"
+        sku = _e(prod.sku) if prod else "N/A"
+        hsn = _e(item.hsn_sac or (prod.hsn_sac if prod else None) or "N/A")
+        gst_rate = float(item.gst_rate or 0)
+        taxable_amt = float(item.taxable_amount or (float(item.unit_price) * item.quantity))
+        tax_amt = float(item.tax_amount or (taxable_amt * gst_rate / 100))
+
+        item_rows += f"""
+        <tr>
+          <td>{idx}</td>
+          <td>{product_name}</td>
+          <td>{sku}</td>
+          <td>{hsn}</td>
+          <td class="right">{item.quantity}</td>
+          <td class="right">{_fmt_currency(float(item.unit_price), currency)}</td>
+          <td class="right">{gst_rate:.2f}%</td>
+          <td class="right">{_fmt_currency(tax_amt, currency)}</td>
+          <td class="right">{_fmt_currency(float(item.line_total), currency)}</td>
+        </tr>"""
+
+    # Supplier details are stored as ledger_* (buyer_* in DB) on purchase invoices
+    supplier_detail_parts = []
+    if invoice.ledger_gst:
+        supplier_detail_parts.append(f"GST: {_e(invoice.ledger_gst)}")
+    if invoice.ledger_phone:
+        supplier_detail_parts.append(f"Phone: {_e(invoice.ledger_phone)}")
+    supplier_details = " &middot; ".join(supplier_detail_parts)
+
+    # Your company (receiving / bill-to party)
+    company_detail_parts = []
+    if invoice.company_gst:
+        company_detail_parts.append(f"GST: {_e(invoice.company_gst)}")
+    company_details = " &middot; ".join(company_detail_parts)
+
+    # Optional supplier reference row
+    supplier_ref_html = ""
+    if invoice.supplier_invoice_number:
+        supplier_ref_html = f"""
+  <section class="invoice-sheet__supplierref">
+    <span class="eyebrow">Supplier Ref:</span>
+    <span class="invoice-sheet__supplierref-value">{_e(invoice.supplier_invoice_number)}</span>
+  </section>"""
+
+    html = f"""<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+  @page {{
+    size: A4;
+    margin: 15mm 18mm;
+  }}
+  * {{ margin: 0; padding: 0; box-sizing: border-box; }}
+  body {{
+    font-family: -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+    font-size: 10px;
+    color: #1f2937;
+    line-height: 1.5;
+  }}
+  .eyebrow {{
+    font-size: 8px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: #6b7280;
+    margin-bottom: 2px;
+  }}
+  .invoice-sheet {{
+    width: 100%;
+  }}
+  .invoice-sheet__header {{
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    padding-bottom: 16px;
+    border-bottom: 2px solid #e5e7eb;
+    margin-bottom: 12px;
+  }}
+  .invoice-sheet__header h3 {{
+    font-size: 16px;
+    font-weight: 700;
+    margin-bottom: 4px;
+  }}
+  .invoice-sheet__header p {{
+    font-size: 9px;
+    color: #6b7280;
+    margin-bottom: 1px;
+  }}
+  .invoice-sheet__header-right {{
+    text-align: right;
+  }}
+  .invoice-sheet__header-right h3 {{
+    font-size: 14px;
+  }}
+  .invoice-sheet__titleblock {{
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 16px;
+    padding: 10px 14px;
+    background: #f9fafb;
+    border: 1px solid #e5e7eb;
+    border-radius: 6px;
+  }}
+  .invoice-sheet__titleblock h2 {{
+    font-size: 14px;
+    font-weight: 700;
+  }}
+  .invoice-sheet__titleblock p {{
+    font-size: 9px;
+    color: #6b7280;
+    margin-left: auto;
+  }}
+  .invoice-badge {{
+    display: inline-block;
+    padding: 3px 10px;
+    border-radius: 4px;
+    font-size: 9px;
+    font-weight: 600;
+    color: #065f46;
+    background: #ecfdf5;
+  }}
+  .invoice-sheet__supplierref {{
+    margin-bottom: 12px;
+    font-size: 9px;
+    color: #374151;
+  }}
+  .invoice-sheet__supplierref-value {{
+    font-size: 9px;
+    font-weight: 600;
+    color: #1f2937;
+    margin-left: 4px;
+  }}
+  .invoice-sheet__table {{
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 16px;
+    font-size: 9px;
+  }}
+  .invoice-sheet__table thead th {{
+    background: #f3f4f6;
+    color: #374151;
+    font-weight: 600;
+    font-size: 8px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    padding: 7px 8px;
+    border-bottom: 2px solid #d1d5db;
+    text-align: left;
+  }}
+  .invoice-sheet__table thead th.right {{
+    text-align: right;
+  }}
+  .invoice-sheet__table tbody td {{
+    padding: 6px 8px;
+    border-bottom: 1px solid #e5e7eb;
+    vertical-align: middle;
+  }}
+  .invoice-sheet__table tbody td.right {{
+    text-align: right;
+  }}
+  .invoice-sheet__table tbody tr:last-child td {{
+    border-bottom: 2px solid #d1d5db;
+  }}
+  .invoice-sheet__footer {{
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 8px;
+  }}
+  .invoice-sheet__totals {{
+    text-align: right;
+    min-width: 220px;
+  }}
+  .invoice-sheet__totals p {{
+    font-size: 9px;
+    color: #4b5563;
+    margin-bottom: 1px;
+  }}
+  .invoice-sheet__total-value {{
+    font-size: 20px !important;
+    font-weight: 700;
+    color: #1a56db !important;
+    margin-top: 4px;
+    margin-bottom: 4px;
+  }}
+  .muted-text {{
+    font-size: 8px;
+    color: #9ca3af;
+  }}
+</style>
+</head>
+<body>
+<div class="invoice-sheet">
+  <header class="invoice-sheet__header">
+    <div>
+      <p class="eyebrow">Supplier</p>
+      <h3>{_e(invoice.ledger_name) or 'Unknown supplier'}</h3>
+      <p>{_e(invoice.ledger_address) or 'Address not provided'}</p>
+      <p>{supplier_details}</p>
+    </div>
+    <div class="invoice-sheet__header-right">
+      <p class="eyebrow">Bill To</p>
+      <h3>{_e(invoice.company_name) or 'Your company'}</h3>
+      <p>{_e(invoice.company_address) or 'Address not provided'}</p>
+      <p>{company_details}</p>
+    </div>
+  </header>
+
+  <div class="invoice-sheet__titleblock">
+    <span class="invoice-badge">Purchase Invoice</span>
+    <h2>Invoice {_e(inv_number)}</h2>
+    <p>Date: {inv_date} &nbsp;&middot;&nbsp; Currency: {_e(currency)}</p>
+  </div>
+{supplier_ref_html}
+  <section>
+    <table class="invoice-sheet__table">
+      <thead>
+        <tr>
+          <th>#</th>
+          <th>Item</th>
+          <th>SKU</th>
+          <th>HSN/SAC</th>
+          <th class="right">Qty</th>
+          <th class="right">Unit Price</th>
+          <th class="right">GST %</th>
+          <th class="right">Tax</th>
+          <th class="right">Amount</th>
+        </tr>
+      </thead>
+      <tbody>
+        {item_rows}
+      </tbody>
+    </table>
+  </section>
+
+  <section class="invoice-sheet__footer">
+    <div class="invoice-sheet__totals">
+      <p class="eyebrow">Tax breakup</p>
+      <p>Taxable: {_fmt_currency(float(invoice.taxable_amount or 0), currency)}</p>
+      <p>CGST: {_fmt_currency(float(invoice.cgst_amount or 0), currency)}</p>
+      <p>SGST: {_fmt_currency(float(invoice.sgst_amount or 0), currency)}</p>
+      <p>IGST: {_fmt_currency(float(invoice.igst_amount or 0), currency)}</p>
+      <p>Total tax: {_fmt_currency(float(invoice.total_tax_amount or 0), currency)}</p>
+      <p class="eyebrow" style="margin-top: 10px;">Total due</p>
+      <p class="invoice-sheet__total-value">{_fmt_currency(float(invoice.total_amount), currency)}</p>
+      <p class="muted-text">Received by {_e(invoice.company_name) or 'Your company'}</p>
+    </div>
+  </section>
+</div>
+</body>
+</html>"""
+    return html
+
+
 def _build_invoice_html(invoice: Invoice, products: list[Product]) -> str:
+    if invoice.voucher_type == "purchase":
+        return _build_purchase_invoice_html(invoice, products)
+
     currency = invoice.company_currency_code or "USD"
     voucher_label = "Sales" if invoice.voucher_type == "sales" else "Purchase"
     inv_number = invoice.invoice_number or f"#{invoice.id}"

--- a/frontend/e2e/invoices.spec.ts
+++ b/frontend/e2e/invoices.spec.ts
@@ -482,4 +482,211 @@ test.describe('Invoices', () => {
     await page.waitForTimeout(500);
     await expect(page.locator('#invoice-tax-inclusive')).not.toBeChecked();
   });
+
+  // ---------------------------------------------------------------------------
+  // Purchase invoice PDF layout (#186)
+  // ---------------------------------------------------------------------------
+
+  test('purchase invoice preview shows supplier on left and company on right', async ({ authedPage: page }) => {
+    const { sku, ledgerName } = await seedInvoiceData(page);
+
+    await page.click('[href="/invoices"]');
+    await page.waitForTimeout(500);
+
+    await page.selectOption('#invoice-voucher-type', 'purchase');
+    await selectComboboxOption(page, 'invoice-ledger', ledgerName);
+    const productInputId = (await page.locator('[id^="invoice-product-"]').first().getAttribute('id')) || 'invoice-product-1';
+    await selectComboboxOption(page, productInputId, sku);
+    await page.locator('[id^="invoice-quantity-"]').first().fill('1');
+    await page.click('button:has-text("Create invoice")');
+    await expectSuccess(page, 'Purchase invoice created');
+
+    const invoiceRow = page.locator('.invoice-row', { hasText: ledgerName }).first();
+    await invoiceRow.locator('[aria-label^="Preview invoice"]').click();
+
+    const modal = page.locator('[role="dialog"]');
+    await expect(modal).toBeVisible();
+
+    // Left column: Supplier eyebrow + ledger name as supplier name
+    await expect(modal.locator('.invoice-sheet__header .eyebrow').first()).toContainText('Supplier');
+    await expect(modal.locator('.invoice-sheet__header h3').first()).toContainText(ledgerName);
+
+    // Right column: "Bill To" eyebrow
+    await expect(modal.locator('.invoice-sheet__header-right .eyebrow')).toContainText('Bill To');
+
+    // Purchase-specific title block with green badge
+    await expect(modal.locator('.invoice-badge--purchase')).toBeVisible();
+    await expect(modal.locator('.invoice-badge--purchase')).toContainText('Purchase Invoice');
+
+    // Sales-specific header must NOT appear
+    await expect(modal.locator('.eyebrow:text("Billed by")')).not.toBeVisible();
+  });
+
+  test('purchase invoice preview shows supplier ref when provided', async ({ authedPage: page }) => {
+    const { sku, ledgerName } = await seedInvoiceData(page);
+    const supplierRef = `SP-${Date.now().toString(36).toUpperCase()}`;
+
+    await page.click('[href="/invoices"]');
+    await page.waitForTimeout(500);
+
+    await page.selectOption('#invoice-voucher-type', 'purchase');
+    await selectComboboxOption(page, 'invoice-ledger', ledgerName);
+    const productInputId = (await page.locator('[id^="invoice-product-"]').first().getAttribute('id')) || 'invoice-product-1';
+    await selectComboboxOption(page, productInputId, sku);
+    await page.locator('[id^="invoice-quantity-"]').first().fill('1');
+    await page.fill('#invoice-supplier-ref', supplierRef);
+    await page.click('button:has-text("Create invoice")');
+    await expectSuccess(page, 'Purchase invoice created');
+
+    const invoiceRow = page.locator('.invoice-row', { hasText: ledgerName }).first();
+    await invoiceRow.locator('[aria-label^="Preview invoice"]').click();
+
+    const modal = page.locator('[role="dialog"]');
+    await expect(modal).toBeVisible();
+
+    const supplierRefSection = modal.locator('.invoice-sheet__supplierref');
+    await expect(supplierRefSection).toBeVisible();
+    await expect(supplierRefSection).toContainText('Supplier Ref:');
+    await expect(supplierRefSection).toContainText(supplierRef);
+  });
+
+  test('purchase invoice preview without supplier ref hides supplier ref row', async ({ authedPage: page }) => {
+    const { sku, ledgerName } = await seedInvoiceData(page);
+
+    await page.click('[href="/invoices"]');
+    await page.waitForTimeout(500);
+
+    await page.selectOption('#invoice-voucher-type', 'purchase');
+    await selectComboboxOption(page, 'invoice-ledger', ledgerName);
+    const productInputId = (await page.locator('[id^="invoice-product-"]').first().getAttribute('id')) || 'invoice-product-1';
+    await selectComboboxOption(page, productInputId, sku);
+    await page.locator('[id^="invoice-quantity-"]').first().fill('1');
+    // No supplier ref filled
+    await page.click('button:has-text("Create invoice")');
+    await expectSuccess(page, 'Purchase invoice created');
+
+    const invoiceRow = page.locator('.invoice-row', { hasText: ledgerName }).first();
+    await invoiceRow.locator('[aria-label^="Preview invoice"]').click();
+
+    const modal = page.locator('[role="dialog"]');
+    await expect(modal).toBeVisible();
+    await expect(modal.locator('.invoice-sheet__supplierref')).not.toBeVisible();
+  });
+
+  test('purchase invoice preview has no bank details and shows tax breakup', async ({ authedPage: page }) => {
+    const { sku, ledgerName } = await seedInvoiceData(page);
+
+    await page.click('[href="/invoices"]');
+    await page.waitForTimeout(500);
+
+    await page.selectOption('#invoice-voucher-type', 'purchase');
+    await selectComboboxOption(page, 'invoice-ledger', ledgerName);
+    const productInputId = (await page.locator('[id^="invoice-product-"]').first().getAttribute('id')) || 'invoice-product-1';
+    await selectComboboxOption(page, productInputId, sku);
+    await page.locator('[id^="invoice-quantity-"]').first().fill('1');
+    await page.click('button:has-text("Create invoice")');
+    await expectSuccess(page, 'Purchase invoice created');
+
+    const invoiceRow = page.locator('.invoice-row', { hasText: ledgerName }).first();
+    await invoiceRow.locator('[aria-label^="Preview invoice"]').click();
+
+    const modal = page.locator('[role="dialog"]');
+    await expect(modal).toBeVisible();
+
+    // No bank/payment details section
+    await expect(modal.locator('.invoice-sheet__bank')).not.toBeVisible();
+
+    // Tax breakup still present
+    await expect(modal.locator('.invoice-sheet__totals')).toBeVisible();
+    await expect(modal.locator('.invoice-sheet__totals')).toContainText('Tax breakup');
+  });
+
+  test('sales invoice preview layout is unchanged', async ({ authedPage: page }) => {
+    const { sku, ledgerName } = await seedInvoiceData(page);
+
+    await page.click('[href="/invoices"]');
+    await page.waitForTimeout(500);
+
+    await page.selectOption('#invoice-voucher-type', 'sales');
+    await selectComboboxOption(page, 'invoice-ledger', ledgerName);
+    const productInputId = (await page.locator('[id^="invoice-product-"]').first().getAttribute('id')) || 'invoice-product-1';
+    await selectComboboxOption(page, productInputId, sku);
+    await page.locator('[id^="invoice-quantity-"]').first().fill('1');
+    await page.click('button:has-text("Create invoice")');
+    await expectSuccess(page, 'Sales invoice created');
+
+    const invoiceRow = page.locator('.invoice-row', { hasText: ledgerName }).first();
+    await invoiceRow.locator('[aria-label^="Preview invoice"]').click();
+
+    const modal = page.locator('[role="dialog"]');
+    await expect(modal).toBeVisible();
+
+    // Sales layout: "Billed by" on the left
+    await expect(modal.locator('.invoice-sheet__header .eyebrow').first()).toContainText('Billed by');
+
+    // Bank / payment details block present
+    await expect(modal.locator('.invoice-sheet__bank')).toBeVisible();
+    await expect(modal.locator('.invoice-sheet__bank')).toContainText('Payment details');
+
+    // No purchase-specific badge
+    await expect(modal.locator('.invoice-badge--purchase')).not.toBeVisible();
+  });
+
+  test('purchase invoice PDF endpoint returns 200 and application/pdf', async ({ authedPage: page }) => {
+    const { sku, ledgerName } = await seedInvoiceData(page);
+
+    await page.click('[href="/invoices"]');
+    await page.waitForTimeout(500);
+
+    await page.selectOption('#invoice-voucher-type', 'purchase');
+    await selectComboboxOption(page, 'invoice-ledger', ledgerName);
+    const productInputId = (await page.locator('[id^="invoice-product-"]').first().getAttribute('id')) || 'invoice-product-1';
+    await selectComboboxOption(page, productInputId, sku);
+    await page.locator('[id^="invoice-quantity-"]').first().fill('1');
+    await page.fill('#invoice-supplier-ref', 'SP-E2E-PDF');
+    await page.click('button:has-text("Create invoice")');
+    await expectSuccess(page, 'Purchase invoice created');
+
+    // Open preview and click Download PDF — intercept the network request
+    const invoiceRow = page.locator('.invoice-row', { hasText: ledgerName }).first();
+    await invoiceRow.locator('[aria-label^="Preview invoice"]').click();
+
+    const modal = page.locator('[role="dialog"]');
+    await expect(modal).toBeVisible();
+
+    const [pdfResponse] = await Promise.all([
+      page.waitForResponse(res => res.url().includes('/invoices/') && res.url().endsWith('/pdf')),
+      modal.locator('[aria-label="Download invoice PDF"]').click(),
+    ]);
+    expect(pdfResponse.status()).toBe(200);
+    expect(pdfResponse.headers()['content-type']).toContain('application/pdf');
+  });
+
+  test('sales invoice PDF endpoint returns 200 and application/pdf', async ({ authedPage: page }) => {
+    const { sku, ledgerName } = await seedInvoiceData(page);
+
+    await page.click('[href="/invoices"]');
+    await page.waitForTimeout(500);
+
+    await page.selectOption('#invoice-voucher-type', 'sales');
+    await selectComboboxOption(page, 'invoice-ledger', ledgerName);
+    const productInputId = (await page.locator('[id^="invoice-product-"]').first().getAttribute('id')) || 'invoice-product-1';
+    await selectComboboxOption(page, productInputId, sku);
+    await page.locator('[id^="invoice-quantity-"]').first().fill('1');
+    await page.click('button:has-text("Create invoice")');
+    await expectSuccess(page, 'Sales invoice created');
+
+    const invoiceRow = page.locator('.invoice-row', { hasText: ledgerName }).first();
+    await invoiceRow.locator('[aria-label^="Preview invoice"]').click();
+
+    const modal = page.locator('[role="dialog"]');
+    await expect(modal).toBeVisible();
+
+    const [pdfResponse] = await Promise.all([
+      page.waitForResponse(res => res.url().includes('/invoices/') && res.url().endsWith('/pdf')),
+      modal.locator('[aria-label="Download invoice PDF"]').click(),
+    ]);
+    expect(pdfResponse.status()).toBe(200);
+    expect(pdfResponse.headers()['content-type']).toContain('application/pdf');
+  });
 });

--- a/frontend/src/components/InvoicePreview.tsx
+++ b/frontend/src/components/InvoicePreview.tsx
@@ -88,38 +88,75 @@ export default function InvoicePreview({ invoice, products, currencyCode, onClos
         </div>
 
         <article className="invoice-print-root invoice-sheet">
-          <header className="invoice-sheet__header">
-            <div>
-              <p className="eyebrow">Billed by</p>
-              <h3>{invoice.company_name || 'Company not set'}</h3>
-              <p>{invoice.company_address || 'Address not provided'}</p>
-              <p>
-                {invoice.company_gst ? `GST: ${invoice.company_gst}` : ''}
-                {invoice.company_phone ? ` · Phone: ${invoice.company_phone}` : ''}
-              </p>
-              <p>
-                {invoice.company_email ? `Email: ${invoice.company_email}` : ''}
-                {invoice.company_email && invoice.company_website ? ' · ' : ''}
-                {invoice.company_website ? `Web: ${invoice.company_website}` : ''}
-              </p>
-            </div>
-            <div className="invoice-sheet__meta">
-              <span className="invoice-badge">{invoice.voucher_type === 'sales' ? 'Sales' : 'Purchase'}</span>
-              <h2>Invoice {invoice.invoice_number || `#${invoice.id}`}</h2>
-              <p>Date: {new Date(invoice.invoice_date).toLocaleDateString()}</p>
-              <p>Currency: {previewCurrencyCode}</p>
-            </div>
-          </header>
+          {invoice.voucher_type === 'purchase' ? (
+            <>
+              <header className="invoice-sheet__header">
+                <div>
+                  <p className="eyebrow">Supplier</p>
+                  <h3>{invoice.ledger?.name || invoice.ledger_name || 'Unknown supplier'}</h3>
+                  <p>{invoice.ledger?.address || invoice.ledger_address || 'Address not provided'}</p>
+                  <p>
+                    {(invoice.ledger?.gst || invoice.ledger_gst) ? `GST: ${invoice.ledger?.gst || invoice.ledger_gst}` : ''}
+                    {(invoice.ledger?.phone_number || invoice.ledger_phone) ? ` · Phone: ${invoice.ledger?.phone_number || invoice.ledger_phone}` : ''}
+                  </p>
+                </div>
+                <div className="invoice-sheet__header-right">
+                  <p className="eyebrow">Bill To</p>
+                  <h3>{invoice.company_name || 'Your company'}</h3>
+                  <p>{invoice.company_address || 'Address not provided'}</p>
+                  <p>{invoice.company_gst ? `GST: ${invoice.company_gst}` : ''}</p>
+                </div>
+              </header>
 
-          <section className="invoice-sheet__billto">
-            <p className="eyebrow">Bill to</p>
-            <h4>{invoice.ledger?.name || invoice.ledger_name || 'Unknown ledger'}</h4>
-            <p>{invoice.ledger?.address || invoice.ledger_address || 'Address not provided'}</p>
-            <p>
-              {(invoice.ledger?.gst || invoice.ledger_gst) ? `GST: ${invoice.ledger?.gst || invoice.ledger_gst}` : ''}
-              {(invoice.ledger?.phone_number || invoice.ledger_phone) ? ` · Phone: ${invoice.ledger?.phone_number || invoice.ledger_phone}` : ''}
-            </p>
-          </section>
+              <div className="invoice-sheet__titleblock">
+                <span className="invoice-badge invoice-badge--purchase">Purchase Invoice</span>
+                <h2>Invoice {invoice.invoice_number || `#${invoice.id}`}</h2>
+                <p>Date: {new Date(invoice.invoice_date).toLocaleDateString()} &nbsp;·&nbsp; Currency: {previewCurrencyCode}</p>
+              </div>
+
+              {invoice.supplier_invoice_number && (
+                <section className="invoice-sheet__supplierref">
+                  <span className="eyebrow">Supplier Ref:</span>
+                  <span className="invoice-sheet__supplierref-value">{invoice.supplier_invoice_number}</span>
+                </section>
+              )}
+            </>
+          ) : (
+            <>
+              <header className="invoice-sheet__header">
+                <div>
+                  <p className="eyebrow">Billed by</p>
+                  <h3>{invoice.company_name || 'Company not set'}</h3>
+                  <p>{invoice.company_address || 'Address not provided'}</p>
+                  <p>
+                    {invoice.company_gst ? `GST: ${invoice.company_gst}` : ''}
+                    {invoice.company_phone ? ` · Phone: ${invoice.company_phone}` : ''}
+                  </p>
+                  <p>
+                    {invoice.company_email ? `Email: ${invoice.company_email}` : ''}
+                    {invoice.company_email && invoice.company_website ? ' · ' : ''}
+                    {invoice.company_website ? `Web: ${invoice.company_website}` : ''}
+                  </p>
+                </div>
+                <div className="invoice-sheet__meta">
+                  <span className="invoice-badge">{invoice.voucher_type === 'sales' ? 'Sales' : 'Purchase'}</span>
+                  <h2>Invoice {invoice.invoice_number || `#${invoice.id}`}</h2>
+                  <p>Date: {new Date(invoice.invoice_date).toLocaleDateString()}</p>
+                  <p>Currency: {previewCurrencyCode}</p>
+                </div>
+              </header>
+
+              <section className="invoice-sheet__billto">
+                <p className="eyebrow">Bill to</p>
+                <h4>{invoice.ledger?.name || invoice.ledger_name || 'Unknown ledger'}</h4>
+                <p>{invoice.ledger?.address || invoice.ledger_address || 'Address not provided'}</p>
+                <p>
+                  {(invoice.ledger?.gst || invoice.ledger_gst) ? `GST: ${invoice.ledger?.gst || invoice.ledger_gst}` : ''}
+                  {(invoice.ledger?.phone_number || invoice.ledger_phone) ? ` · Phone: ${invoice.ledger?.phone_number || invoice.ledger_phone}` : ''}
+                </p>
+              </section>
+            </>
+          )}
 
           <section className="invoice-sheet__table-wrap">
             <table className="invoice-sheet__table">
@@ -155,14 +192,16 @@ export default function InvoicePreview({ invoice, products, currencyCode, onClos
           </section>
 
           <section className="invoice-sheet__footer">
-            <div className="invoice-sheet__bank">
-              <p className="eyebrow">Payment details</p>
-              <p>Bank: {invoice.company_bank_name || 'N/A'}</p>
-              <p>Branch: {invoice.company_branch_name || 'N/A'}</p>
-              <p>Account: {invoice.company_account_name || 'N/A'}</p>
-              <p>A/C No: {invoice.company_account_number || 'N/A'}</p>
-              <p>IFSC: {invoice.company_ifsc_code || 'N/A'}</p>
-            </div>
+            {invoice.voucher_type !== 'purchase' && (
+              <div className="invoice-sheet__bank">
+                <p className="eyebrow">Payment details</p>
+                <p>Bank: {invoice.company_bank_name || 'N/A'}</p>
+                <p>Branch: {invoice.company_branch_name || 'N/A'}</p>
+                <p>Account: {invoice.company_account_name || 'N/A'}</p>
+                <p>A/C No: {invoice.company_account_number || 'N/A'}</p>
+                <p>IFSC: {invoice.company_ifsc_code || 'N/A'}</p>
+              </div>
+            )}
             <div className="invoice-sheet__totals">
               <p className="eyebrow">Tax breakup</p>
               <p>Taxable: {formatCurrency(invoice.taxable_amount || 0, previewCurrencyCode)}</p>
@@ -174,7 +213,11 @@ export default function InvoicePreview({ invoice, products, currencyCode, onClos
               <p className="invoice-sheet__total-value">
                 {formatCurrency(invoice.total_amount, previewCurrencyCode)}
               </p>
-              <p className="muted-text">Authorized by {invoice.company_name || 'Billing company'}</p>
+              <p className="muted-text">
+                {invoice.voucher_type === 'purchase'
+                  ? `Received by ${invoice.company_name || 'Your company'}`
+                  : `Authorized by ${invoice.company_name || 'Billing company'}`}
+              </p>
             </div>
           </section>
         </article>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1024,6 +1024,44 @@ textarea {
   text-align: right;
 }
 
+.invoice-sheet__header-right {
+  text-align: right;
+}
+
+.invoice-sheet__header-right h3 {
+  margin: 0;
+  font-family: 'Space Grotesk', sans-serif;
+}
+
+.invoice-sheet__titleblock {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  background: white;
+  border: 1px solid #d9e2f2;
+  border-radius: 14px;
+}
+
+.invoice-sheet__titleblock h2 {
+  margin: 0;
+  font-family: 'Space Grotesk', sans-serif;
+}
+
+.invoice-sheet__titleblock p {
+  margin-left: auto;
+}
+
+.invoice-sheet__supplierref {
+  font-size: 0.9rem;
+  color: #374151;
+}
+
+.invoice-sheet__supplierref-value {
+  font-weight: 600;
+  margin-left: 4px;
+}
+
 .invoice-badge {
   display: inline-block;
   padding: 6px 10px;
@@ -1032,6 +1070,12 @@ textarea {
   color: #1d4ed8;
   font-weight: 700;
   margin-bottom: 8px;
+}
+
+.invoice-badge--purchase {
+  background: #d1fae5;
+  color: #065f46;
+  margin-bottom: 0;
 }
 
 .invoice-sheet__billto {


### PR DESCRIPTION
## Summary

Purchase invoice PDFs and previews now use a distinct layout that reflects you are the **buyer**, not the issuer:

- **Header left:** Supplier name, address, GSTIN, phone (stored as `ledger_*` fields)
- **Header right:** "Bill To" — your company name, address, GSTIN
- **Title block:** green "Purchase Invoice" badge + invoice number + date/currency row
- **Supplier Ref row:** appears below the title block when `supplier_invoice_number` is set; absent otherwise
- **Footer:** tax breakup table only — bank/IFSC/UPI/account details removed entirely

Sales invoice PDFs and previews are completely unchanged.

Part of epic #180. Closes #186.

## Type of change

- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] docs (documentation)
- [ ] test (tests)
- [ ] chore/refactor

## How to test

1. Start the dev stack (`make dev`)
2. Create a **purchase** invoice with a ledger, product, and a supplier ref (e.g. `SP-0042`)
3. Click **Preview invoice** → confirm:
   - Left column shows "Supplier" eyebrow + ledger name/address/GST
   - Right column shows "Bill To" + your company
   - Green "Purchase Invoice" badge in title block
   - "Supplier Ref: SP-0042" line visible below title block
   - No bank/IFSC/payment details in the footer
   - Tax breakup and total still visible
4. Create a purchase invoice **without** a supplier ref → confirm the Supplier Ref row is absent
5. Open a **sales** invoice preview → confirm layout is unchanged (Billed by left, bank details present)
6. Click **Download PDF** on both types → confirm PDFs render correctly

Or run the Playwright suite:
```
cd frontend && npx playwright test e2e/invoices.spec.ts --grep "purchase invoice|sales invoice"
```

## Checklist

- [x] My code follows the project style and conventions
- [x] I added/updated tests where appropriate
- [x] I updated docs where needed
- [x] I ran relevant checks locally
- [x] I verified this does not break existing behavior

## Screenshots (if UI changes)

Purchase invoice preview — supplier top-left, Bill To top-right, green badge, supplier ref row, no bank details in footer. Sales layout visually unchanged.

## Related issue

Closes #186