### PR TITLE
feat(payments): create payment vouchers from invoices page with auto-numbered PAY series (#187)

### DIFF
--- a/backend/src/api/routes/invoices.py
+++ b/backend/src/api/routes/invoices.py
@@ -17,11 +17,11 @@ from src.models.buyer import Buyer as Ledger
 from src.models.company import CompanyProfile
 from src.models.invoice import Invoice, InvoiceItem
 from src.models.inventory import Inventory
-from src.models.invoice_series import InvoiceSeries
 from src.models.product import Product
 from src.models.user import User
 from src.schemas.invoice import InvoiceCreate, InvoiceOut, PaginatedInvoiceOut
 from src.api.deps import get_current_user
+from src.services.series import generate_next_number
 
 router = APIRouter()
 
@@ -37,32 +37,7 @@ def _is_interstate_supply(company_gst: str | None, ledger_gst: str | None) -> bo
 
 
 def _generate_next_number(db: Session, voucher_type: str) -> str:
-    """Atomically increment the series counter and return the formatted number."""
-    series = (
-        db.query(InvoiceSeries)
-        .filter(InvoiceSeries.voucher_type == voucher_type)
-        .with_for_update()
-        .first()
-    )
-    if not series:
-        # Fallback: no series configured, use legacy format
-        return f"INV-000000"
-
-    seq = series.next_sequence
-    series.next_sequence = seq + 1
-
-    sep = series.separator
-    seq_str = str(seq).zfill(series.pad_digits)
-
-    if series.include_year:
-        now = datetime.utcnow()
-        if series.year_format == "MM-YYYY":
-            year_part = now.strftime("%m") + sep + str(now.year)
-        else:
-            year_part = str(now.year)
-        return f"{series.prefix}{sep}{year_part}{sep}{seq_str}"
-    else:
-        return f"{series.prefix}{sep}{seq_str}"
+    return generate_next_number(db, voucher_type)
 
 
 def _require_ledger(db: Session, ledger_id: int) -> Ledger:

--- a/backend/src/api/routes/payments.py
+++ b/backend/src/api/routes/payments.py
@@ -9,6 +9,7 @@ from src.models.buyer import Buyer as Ledger
 from src.models.payment import Payment
 from src.models.user import User, UserRole
 from src.schemas.payment import PaymentCreate, PaymentOut
+from src.services.series import generate_next_number
 
 router = APIRouter()
 
@@ -24,6 +25,8 @@ def create_payment(
     if not ledger:
         raise HTTPException(status_code=404, detail="Ledger not found")
 
+    payment_number = generate_next_number(db, payload.voucher_type)
+
     payment = Payment(
         ledger_id=payload.ledger_id,
         voucher_type=payload.voucher_type,
@@ -32,6 +35,7 @@ def create_payment(
         mode=payload.mode.strip() if payload.mode else None,
         reference=payload.reference.strip() if payload.reference else None,
         notes=payload.notes.strip() if payload.notes else None,
+        payment_number=payment_number,
         created_by=current_user.id,
     )
     db.add(payment)

--- a/backend/src/models/payment.py
+++ b/backend/src/models/payment.py
@@ -12,6 +12,7 @@ class Payment(Base):
     voucher_type = Column(String, nullable=False)  # "receipt" or "payment"
     amount = Column(Numeric(10, 2), nullable=False)
     date = Column(DateTime, nullable=False, default=datetime.utcnow)
+    payment_number = Column(String, nullable=True)  # e.g. PAY-2026-001
     mode = Column(String, nullable=True)  # cash, bank, upi, cheque
     reference = Column(String, nullable=True)  # cheque no, txn id
     notes = Column(String, nullable=True)

--- a/backend/src/schemas/payment.py
+++ b/backend/src/schemas/payment.py
@@ -32,6 +32,7 @@ class PaymentOut(BaseModel):
     voucher_type: str
     amount: float
     date: datetime
+    payment_number: str | None = None
     mode: str | None = None
     reference: str | None = None
     notes: str | None = None

--- a/backend/src/services/series.py
+++ b/backend/src/services/series.py
@@ -1,0 +1,33 @@
+from datetime import datetime
+
+from sqlalchemy.orm import Session
+
+from src.models.invoice_series import InvoiceSeries
+
+
+def generate_next_number(db: Session, voucher_type: str) -> str:
+    """Atomically increment the series counter and return the formatted number."""
+    series = (
+        db.query(InvoiceSeries)
+        .filter(InvoiceSeries.voucher_type == voucher_type)
+        .with_for_update()
+        .first()
+    )
+    if not series:
+        return "INV-000000"
+
+    seq = series.next_sequence
+    series.next_sequence = seq + 1
+
+    sep = series.separator
+    seq_str = str(seq).zfill(series.pad_digits)
+
+    if series.include_year:
+        now = datetime.utcnow()
+        if series.year_format == "MM-YYYY":
+            year_part = now.strftime("%m") + sep + str(now.year)
+        else:
+            year_part = str(now.year)
+        return f"{series.prefix}{sep}{year_part}{sep}{seq_str}"
+    else:
+        return f"{series.prefix}{sep}{seq_str}"

--- a/frontend/e2e/payment-vouchers.spec.ts
+++ b/frontend/e2e/payment-vouchers.spec.ts
@@ -1,0 +1,168 @@
+import { test, expect, expectSuccess, uniqueGstin, selectComboboxOption } from './fixtures';
+
+test.describe('Payment Vouchers from Invoices Page', () => {
+  /**
+   * Helper: create a ledger and return its name.
+   */
+  async function createLedger(page: import('@playwright/test').Page, suffix = '') {
+    const ledgerName = `PVLedger-${Date.now().toString(36)}${suffix}`;
+    await page.click('[href="/ledgers"]');
+    await page.click('button:has-text("Create ledger")');
+    await expect(page.locator('h1')).toContainText('Create ledger', { timeout: 10_000 });
+    await page.fill('#ledger-name', ledgerName);
+    await page.fill('#ledger-address', '1 Payment Street');
+    await page.fill('#ledger-gst', uniqueGstin());
+    await page.fill('#ledger-phone', '+91 6666666666');
+    await page.click('button:has-text("Create ledger")');
+    await expectSuccess(page, 'Ledger created');
+    return ledgerName;
+  }
+
+  test('Payment option appears in voucher type dropdown', async ({ authedPage: page }) => {
+    await page.click('[href="/invoices"]');
+    await expect(page.locator('h1')).toContainText('Invoice composer', { timeout: 10_000 });
+    const select = page.locator('#invoice-voucher-type');
+    await expect(select.locator('option[value="payment"]')).toHaveCount(1);
+  });
+
+  test('selecting Payment type shows payment sub-form instead of line items', async ({ authedPage: page }) => {
+    await page.click('[href="/invoices"]');
+    await expect(page.locator('h1')).toContainText('Invoice composer', { timeout: 10_000 });
+
+    // Before selecting payment, line items should be present
+    await expect(page.locator('[id^="invoice-product-"]').first()).toBeVisible({ timeout: 5_000 });
+
+    await page.selectOption('#invoice-voucher-type', 'payment');
+
+    // Line items should disappear
+    await expect(page.locator('[id^="invoice-product-"]')).toHaveCount(0);
+
+    // Payment sub-form fields should appear
+    await expect(page.locator('#payment-mode')).toBeVisible();
+    await expect(page.locator('#payment-amount')).toBeVisible();
+    await expect(page.locator('#payment-reference')).toBeVisible();
+
+    // Tax-inclusive checkbox should be hidden for payment type
+    await expect(page.locator('#invoice-tax-inclusive')).toHaveCount(0);
+
+    // Submit button should say "Create payment voucher"
+    await expect(page.locator('button:has-text("Create payment voucher")')).toBeVisible();
+  });
+
+  test('creates a payment voucher and it appears in Payment Vouchers tab', async ({ authedPage: page }) => {
+    const ledgerName = await createLedger(page);
+
+    await page.click('[href="/invoices"]');
+    await expect(page.locator('h1')).toContainText('Invoice composer', { timeout: 10_000 });
+
+    // Select Payment voucher type
+    await page.selectOption('#invoice-voucher-type', 'payment');
+
+    // Select the ledger
+    await selectComboboxOption(page, 'invoice-ledger', ledgerName);
+
+    // Fill payment details
+    await page.selectOption('#payment-mode', 'upi');
+    await page.fill('#payment-reference', 'UPI-PV-E2E-001');
+    await page.fill('#payment-amount', '5000');
+
+    // Submit
+    await page.click('button:has-text("Create payment voucher")');
+    await expectSuccess(page, 'Payment voucher created');
+
+    // Switch to Payment Vouchers tab
+    await page.click('#tab-payments');
+    await page.waitForTimeout(1_000);
+
+    // The payment should appear in the list
+    const paymentRow = page.locator('.invoice-row', { hasText: ledgerName });
+    await expect(paymentRow.first()).toBeVisible({ timeout: 10_000 });
+
+    // It should show a PAY- number
+    await expect(paymentRow.first()).toContainText('PAY-');
+
+    // It should show the mode
+    await expect(paymentRow.first()).toContainText('upi');
+
+    // It should show the reference number
+    await expect(paymentRow.first()).toContainText('UPI-PV-E2E-001');
+
+    // Amount should be displayed
+    await expect(paymentRow.first()).toContainText('5,000');
+  });
+
+  test('payment number is auto-numbered with PAY prefix', async ({ authedPage: page }) => {
+    const ledgerName = await createLedger(page, '-num');
+
+    await page.click('[href="/invoices"]');
+    await expect(page.locator('h1')).toContainText('Invoice composer', { timeout: 10_000 });
+
+    await page.selectOption('#invoice-voucher-type', 'payment');
+    await selectComboboxOption(page, 'invoice-ledger', ledgerName);
+    await page.selectOption('#payment-mode', 'cash');
+    await page.fill('#payment-amount', '1000');
+
+    await page.click('button:has-text("Create payment voucher")');
+    await expectSuccess(page, 'Payment voucher created');
+
+    // Check payment vouchers tab for PAY- prefix
+    await page.click('#tab-payments');
+    await page.waitForTimeout(1_000);
+
+    const paymentRow = page.locator('.invoice-row', { hasText: ledgerName });
+    await expect(paymentRow.first()).toBeVisible({ timeout: 10_000 });
+
+    // Verify PAY- prefix with year and sequence pattern e.g. PAY-2026-001
+    const voucherNumber = paymentRow.first().locator('.invoice-row__invoice-id');
+    await expect(voucherNumber).toContainText(/PAY-\d{4}-\d+/);
+  });
+
+  test('payment amount validation prevents zero amount', async ({ authedPage: page }) => {
+    const ledgerName = await createLedger(page, '-val');
+
+    await page.click('[href="/invoices"]');
+    await expect(page.locator('h1')).toContainText('Invoice composer', { timeout: 10_000 });
+
+    await page.selectOption('#invoice-voucher-type', 'payment');
+    await selectComboboxOption(page, 'invoice-ledger', ledgerName);
+    await page.selectOption('#payment-mode', 'cash');
+    await page.fill('#payment-amount', '0');
+
+    // Try clicking submit — HTML5 min="0.01" validation blocks it
+    await page.click('button:has-text("Create payment voucher")');
+
+    // Form was not submitted — no success toast, form still visible
+    await expect(page.locator('#payment-amount')).toBeVisible();
+    await expect(page.locator('.toast--success')).toHaveCount(0);
+  });
+
+  test('switching back to Sales from Payment restores line items', async ({ authedPage: page }) => {
+    await page.click('[href="/invoices"]');
+    await expect(page.locator('h1')).toContainText('Invoice composer', { timeout: 10_000 });
+
+    // Select Payment
+    await page.selectOption('#invoice-voucher-type', 'payment');
+    await expect(page.locator('#payment-amount')).toBeVisible({ timeout: 3_000 });
+
+    // Switch back to Sales
+    await page.selectOption('#invoice-voucher-type', 'sales');
+
+    // Line items should be back
+    await expect(page.locator('[id^="invoice-product-"]').first()).toBeVisible({ timeout: 3_000 });
+
+    // Payment sub-form should be gone
+    await expect(page.locator('#payment-amount')).toHaveCount(0);
+  });
+
+  test('Invoices tab and Payment Vouchers tab are both visible', async ({ authedPage: page }) => {
+    await page.click('[href="/invoices"]');
+    await expect(page.locator('h1')).toContainText('Invoice composer', { timeout: 10_000 });
+
+    await expect(page.locator('#tab-invoices')).toBeVisible();
+    await expect(page.locator('#tab-payments')).toBeVisible();
+
+    // Invoices tab is active by default
+    const invoicesTab = page.locator('#tab-invoices');
+    await expect(invoicesTab).toHaveClass(/button--primary/);
+  });
+});

--- a/frontend/src/pages/InvoicesPage.tsx
+++ b/frontend/src/pages/InvoicesPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Eye, Pencil, Trash2, RotateCcw } from 'lucide-react';
 import api, { getApiErrorMessage } from '../api/client';
-import type { CompanyProfile, Invoice, InvoiceCreate, Ledger, LedgerCreate, PaginatedInvoices, Product } from '../types/api';
+import type { CompanyProfile, Invoice, InvoiceCreate, Ledger, LedgerCreate, PaginatedInvoices, Payment, PaymentCreate, Product } from '../types/api';
 import InvoicePreview from '../components/InvoicePreview';
 import ConfirmDialog from '../components/ConfirmDialog';
 import StatusToasts from '../components/StatusToasts';
@@ -32,9 +32,15 @@ export default function InvoicesPage() {
   const [invoices, setInvoices] = useState<Invoice[]>([]);
   const [company, setCompany] = useState<CompanyProfile | null>(null);
   const [selectedLedgerId, setSelectedLedgerId] = useState('');
-  const [voucherType, setVoucherType] = useState<'sales' | 'purchase'>('sales');
+  const [voucherType, setVoucherType] = useState<'sales' | 'purchase' | 'payment'>('sales');
   const [taxInclusive, setTaxInclusive] = useState(false);
   const [supplierInvoiceNumber, setSupplierInvoiceNumber] = useState('');
+  const [paymentMode, setPaymentMode] = useState('cash');
+  const [paymentReference, setPaymentReference] = useState('');
+  const [paymentAmount, setPaymentAmount] = useState('');
+  const [payments, setPayments] = useState<Payment[]>([]);
+  const [listTab, setListTab] = useState<'invoices' | 'payments'>('invoices');
+  const [loadingPayments, setLoadingPayments] = useState(false);
   const [invoiceDate, setInvoiceDate] = useState(new Date().toISOString().slice(0, 10));
   const [showLedgerModal, setShowLedgerModal] = useState(false);
   const [showProductModal, setShowProductModal] = useState(false);
@@ -123,6 +129,18 @@ export default function InvoicesPage() {
     }
   }
 
+  async function loadPayments() {
+    try {
+      setLoadingPayments(true);
+      const res = await api.get<Payment[]>('/payments/');
+      setPayments(res.data);
+    } catch (err) {
+      setError(getApiErrorMessage(err, 'Unable to load payment vouchers'));
+    } finally {
+      setLoadingPayments(false);
+    }
+  }
+
   useEffect(() => {
     void loadInvoicePageData();
   }, [invoicePage, invoiceSearch, showCancelled]);
@@ -165,6 +183,9 @@ export default function InvoicesPage() {
     setEditingInvoiceId(null);
     setSupplierInvoiceNumber('');
     setTaxInclusive(false);
+    setPaymentMode('cash');
+    setPaymentReference('');
+    setPaymentAmount('');
     const defaultProduct = products[0];
     setItems([createItem(1, String(defaultProduct?.id ?? ''), String(defaultProduct?.price ?? ''))]);
     setNextItemId(2);
@@ -204,6 +225,35 @@ export default function InvoicesPage() {
 
   async function handleSubmitInvoice(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
+
+    if (voucherType === 'payment') {
+      try {
+        setSubmitting(true);
+        setError('');
+        setSuccess('');
+
+        const payload: PaymentCreate = {
+          ledger_id: Number(selectedLedgerId),
+          voucher_type: 'payment',
+          amount: Number(paymentAmount),
+          date: invoiceDate ? new Date(invoiceDate).toISOString() : undefined,
+          mode: paymentMode || undefined,
+          reference: paymentReference.trim() || undefined,
+        };
+
+        await api.post<Payment>('/payments/', payload);
+        setSuccess('Payment voucher created successfully.');
+        resetInvoiceForm();
+        if (listTab === 'payments') {
+          await loadPayments();
+        }
+      } catch (err) {
+        setError(getApiErrorMessage(err, 'Unable to create payment voucher'));
+      } finally {
+        setSubmitting(false);
+      }
+      return;
+    }
 
     try {
       setSubmitting(true);
@@ -482,10 +532,11 @@ export default function InvoicesPage() {
                   id="invoice-voucher-type"
                   className="select"
                   value={voucherType}
-                  onChange={(event) => setVoucherType(event.target.value as 'sales' | 'purchase')}
+                  onChange={(event) => setVoucherType(event.target.value as 'sales' | 'purchase' | 'payment')}
                 >
                   <option value="sales">Sales</option>
                   <option value="purchase">Purchase</option>
+                  <option value="payment">Payment</option>
                 </select>
               </div>
 
@@ -530,109 +581,169 @@ export default function InvoicesPage() {
                 <button type="button" className="button button--secondary" onClick={() => setShowLedgerModal(true)} title="Add ledger" aria-label="Add ledger">
                   Add ledger
                 </button>
-                <button type="button" className="button button--secondary" onClick={() => setShowProductModal(true)} title="Add product" aria-label="Add product">
-                  Add product
-                </button>
-                <button type="button" className="button button--secondary" onClick={() => setShowStockModal(true)} title="Update stock" aria-label="Update stock">
-                  Update stock
-                </button>
+                {voucherType !== 'payment' ? (
+                  <button type="button" className="button button--secondary" onClick={() => setShowProductModal(true)} title="Add product" aria-label="Add product">
+                    Add product
+                  </button>
+                ) : null}
+                {voucherType !== 'payment' ? (
+                  <button type="button" className="button button--secondary" onClick={() => setShowStockModal(true)} title="Update stock" aria-label="Update stock">
+                    Update stock
+                  </button>
+                ) : null}
               </div>
             </div>
 
-            <div className="field" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-              <input
-                id="invoice-tax-inclusive"
-                type="checkbox"
-                checked={taxInclusive}
-                onChange={(event) => setTaxInclusive(event.target.checked)}
-              />
-              <label htmlFor="invoice-tax-inclusive" style={{ marginBottom: 0, cursor: 'pointer' }}>Prices include GST</label>
-            </div>
+            {voucherType !== 'payment' ? (
+              <div className="field" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                <input
+                  id="invoice-tax-inclusive"
+                  type="checkbox"
+                  checked={taxInclusive}
+                  onChange={(event) => setTaxInclusive(event.target.checked)}
+                />
+                <label htmlFor="invoice-tax-inclusive" style={{ marginBottom: 0, cursor: 'pointer' }}>Prices include GST</label>
+              </div>
+            ) : null}
 
-            <div className="stack">
-              {items.map((item, index) => {
-                const selectedProduct = products.find((product) => product.id === Number(item.productId));
-                const unitPrice = item.unit_price ? Number(item.unit_price) : (selectedProduct?.price || 0);
-                const gstRate = selectedProduct?.gst_rate || 0;
-                let lineTotal: number;
-                let taxAmount: number;
-                if (taxInclusive) {
-                  lineTotal = unitPrice * Number(item.quantity || 0);
-                  taxAmount = lineTotal - lineTotal / (1 + gstRate / 100);
-                } else {
-                  const taxableAmount = unitPrice * Number(item.quantity || 0);
-                  taxAmount = taxableAmount * gstRate / 100;
-                  lineTotal = taxableAmount + taxAmount;
-                }
+            {voucherType === 'payment' ? (
+              <div className="field-grid">
+                <div className="field">
+                  <label htmlFor="payment-mode">Payment mode</label>
+                  <select
+                    id="payment-mode"
+                    className="select"
+                    value={paymentMode}
+                    onChange={(event) => setPaymentMode(event.target.value)}
+                  >
+                    <option value="cash">Cash</option>
+                    <option value="cheque">Cheque</option>
+                    <option value="upi">UPI</option>
+                    <option value="other">Other</option>
+                  </select>
+                </div>
+                <div className="field">
+                  <label htmlFor="payment-reference">Reference #</label>
+                  <input
+                    id="payment-reference"
+                    className="input"
+                    type="text"
+                    value={paymentReference}
+                    onChange={(event) => setPaymentReference(event.target.value)}
+                    placeholder="Cheque no. or UPI transaction ID"
+                  />
+                </div>
+                <div className="field">
+                  <label htmlFor="payment-amount">Amount</label>
+                  <input
+                    id="payment-amount"
+                    className="input"
+                    type="number"
+                    step="0.01"
+                    min="0.01"
+                    value={paymentAmount}
+                    onChange={(event) => setPaymentAmount(event.target.value)}
+                    placeholder="0.00"
+                    required
+                  />
+                </div>
+              </div>
+            ) : null}
 
-                return (
-                  <div key={item.id} className="line-item">
-                    <div className="field">
-                      <label htmlFor={`invoice-product-${item.id}`}>Line {index + 1}</label>
-                      <ProductCombobox
-                        id={`invoice-product-${item.id}`}
-                        products={products}
-                        value={item.productId}
-                        onChange={(productId, newProduct) => {
-                          updateItem(item.id, 'productId', productId);
-                          updateItem(item.id, 'unit_price', String(newProduct.price));
-                        }}
-                        required
-                      />
+            {voucherType !== 'payment' ? (
+              <div className="stack">
+                {items.map((item, index) => {
+                  const selectedProduct = products.find((product) => product.id === Number(item.productId));
+                  const unitPrice = item.unit_price ? Number(item.unit_price) : (selectedProduct?.price || 0);
+                  const gstRate = selectedProduct?.gst_rate || 0;
+                  let lineTotal: number;
+                  let taxAmount: number;
+                  if (taxInclusive) {
+                    lineTotal = unitPrice * Number(item.quantity || 0);
+                    taxAmount = lineTotal - lineTotal / (1 + gstRate / 100);
+                  } else {
+                    const taxableAmount = unitPrice * Number(item.quantity || 0);
+                    taxAmount = taxableAmount * gstRate / 100;
+                    lineTotal = taxableAmount + taxAmount;
+                  }
+
+                  return (
+                    <div key={item.id} className="line-item">
+                      <div className="field">
+                        <label htmlFor={`invoice-product-${item.id}`}>Line {index + 1}</label>
+                        <ProductCombobox
+                          id={`invoice-product-${item.id}`}
+                          products={products}
+                          value={item.productId}
+                          onChange={(productId, newProduct) => {
+                            updateItem(item.id, 'productId', productId);
+                            updateItem(item.id, 'unit_price', String(newProduct.price));
+                          }}
+                          required
+                        />
+                      </div>
+
+                      <div className="field">
+                        <label htmlFor={`invoice-quantity-${item.id}`}>Qty</label>
+                        <input
+                          id={`invoice-quantity-${item.id}`}
+                          className="input"
+                          type="number"
+                          min="1"
+                          step="1"
+                          value={item.quantity}
+                          onChange={(event) => updateItem(item.id, 'quantity', event.target.value)}
+                          required
+                        />
+                      </div>
+
+                      <div className="field">
+                        <label htmlFor={`invoice-price-${item.id}`}>{taxInclusive ? 'Amount (incl. GST)' : 'Price'}</label>
+                        <input
+                          id={`invoice-price-${item.id}`}
+                          className="input"
+                          type="number"
+                          step="0.01"
+                          min="0"
+                          value={item.unit_price}
+                          onChange={(event) => updateItem(item.id, 'unit_price', event.target.value)}
+                          placeholder={selectedProduct ? String(selectedProduct.price) : '0.00'}
+                        />
+                      </div>
+
+                      <div className="line-item__price">
+                        {formatCurrency(lineTotal, activeCurrencyCode)}
+                        <div className="table-subtext">Incl GST {gstRate}% ({formatCurrency(taxAmount, activeCurrencyCode)})</div>
+                      </div>
+                      <button type="button" className="button button--danger" onClick={() => removeItem(item.id)} title={`Remove line item ${index + 1}`} aria-label={`Remove line item ${index + 1}`}>
+                        Remove
+                      </button>
                     </div>
-
-                    <div className="field">
-                      <label htmlFor={`invoice-quantity-${item.id}`}>Qty</label>
-                      <input
-                        id={`invoice-quantity-${item.id}`}
-                        className="input"
-                        type="number"
-                        min="1"
-                        step="1"
-                        value={item.quantity}
-                        onChange={(event) => updateItem(item.id, 'quantity', event.target.value)}
-                        required
-                      />
-                    </div>
-
-                    <div className="field">
-                      <label htmlFor={`invoice-price-${item.id}`}>{taxInclusive ? 'Amount (incl. GST)' : 'Price'}</label>
-                      <input
-                        id={`invoice-price-${item.id}`}
-                        className="input"
-                        type="number"
-                        step="0.01"
-                        min="0"
-                        value={item.unit_price}
-                        onChange={(event) => updateItem(item.id, 'unit_price', event.target.value)}
-                        placeholder={selectedProduct ? String(selectedProduct.price) : '0.00'}
-                      />
-                    </div>
-
-                    <div className="line-item__price">
-                      {formatCurrency(lineTotal, activeCurrencyCode)}
-                      <div className="table-subtext">Incl GST {gstRate}% ({formatCurrency(taxAmount, activeCurrencyCode)})</div>
-                    </div>
-                    <button type="button" className="button button--danger" onClick={() => removeItem(item.id)} title={`Remove line item ${index + 1}`} aria-label={`Remove line item ${index + 1}`}>
-                      Remove
-                    </button>
-                  </div>
-                );
-              })}
-            </div>
+                  );
+                })}
+              </div>
+            ) : null}
 
             <div className="button-row">
-              <button type="button" className="button button--ghost" onClick={addItem} disabled={products.length === 0} title="Add line item" aria-label="Add line item">
-                Add line item
-              </button>
+              {voucherType !== 'payment' ? (
+                <button type="button" className="button button--ghost" onClick={addItem} disabled={products.length === 0} title="Add line item" aria-label="Add line item">
+                  Add line item
+                </button>
+              ) : null}
               {editingInvoiceId ? (
                 <button type="button" className="button button--secondary" onClick={resetInvoiceForm} title="Cancel invoice edit" aria-label="Cancel invoice edit">
                   Cancel edit
                 </button>
               ) : null}
-              <button className="button button--primary" disabled={submitting || products.length === 0 || !selectedLedgerId} title={editingInvoiceId ? "Update invoice" : "Create invoice"} aria-label={editingInvoiceId ? "Update invoice" : "Create invoice"}>
-                {submitting ? (editingInvoiceId ? 'Updating invoice...' : 'Creating invoice...') : editingInvoiceId ? 'Update invoice' : 'Create invoice'}
-              </button>
+              {voucherType === 'payment' ? (
+                <button className="button button--primary" disabled={submitting || !selectedLedgerId || !paymentAmount} title="Create payment voucher" aria-label="Create payment voucher">
+                  {submitting ? 'Creating payment...' : 'Create payment voucher'}
+                </button>
+              ) : (
+                <button className="button button--primary" disabled={submitting || products.length === 0 || !selectedLedgerId} title={editingInvoiceId ? 'Update invoice' : 'Create invoice'} aria-label={editingInvoiceId ? 'Update invoice' : 'Create invoice'}>
+                  {submitting ? (editingInvoiceId ? 'Updating invoice...' : 'Creating invoice...') : editingInvoiceId ? 'Update invoice' : 'Create invoice'}
+                </button>
+              )}
             </div>
           </form>
         </article>
@@ -645,18 +756,41 @@ export default function InvoicesPage() {
             </div>
           </div>
 
-          <div className="summary-box">
-            <p className="eyebrow">Total listed value</p>
-            <p className="summary-box__value">
-              {formatCurrency(invoices.reduce((sum, invoice) => sum + invoice.total_amount, 0), activeCurrencyCode)}
-            </p>
+          <div className="button-row">
+            <button
+              type="button"
+              id="tab-invoices"
+              className={`button ${listTab === 'invoices' ? 'button--primary' : 'button--secondary'}`}
+              onClick={() => setListTab('invoices')}
+              aria-pressed={listTab === 'invoices'}
+            >
+              Invoices
+            </button>
+            <button
+              type="button"
+              id="tab-payments"
+              className={`button ${listTab === 'payments' ? 'button--primary' : 'button--secondary'}`}
+              onClick={() => { setListTab('payments'); void loadPayments(); }}
+              aria-pressed={listTab === 'payments'}
+            >
+              Payment Vouchers
+            </button>
           </div>
 
-          <div className="field">
-            <label htmlFor="invoice-search">Search by ledger name</label>
-            <input
-              id="invoice-search"
-              className="input"
+          {listTab === 'invoices' ? (
+            <>
+              <div className="summary-box">
+                <p className="eyebrow">Total listed value</p>
+                <p className="summary-box__value">
+                  {formatCurrency(invoices.reduce((sum, invoice) => sum + invoice.total_amount, 0), activeCurrencyCode)}
+                </p>
+              </div>
+
+              <div className="field">
+                <label htmlFor="invoice-search">Search by ledger name</label>
+                <input
+                  id="invoice-search"
+                  className="input"
               type="search"
               placeholder="Type to search invoices..."
               value={invoiceSearch}
@@ -845,6 +979,51 @@ export default function InvoicesPage() {
               </button>
             </div>
           ) : null}
+            </>
+          ) : (
+            <>
+              {loadingPayments ? (
+                <div className="empty-state">
+                  <p style={{ fontSize: '0.95rem' }}>Loading payment vouchers...</p>
+                </div>
+              ) : null}
+              {!loadingPayments && payments.length === 0 ? (
+                <div className="empty-state">
+                  <p style={{ fontWeight: 600, marginBottom: '8px' }}>No payment vouchers yet</p>
+                  <p>Select &ldquo;Payment&rdquo; in the voucher type and create one above.</p>
+                </div>
+              ) : null}
+              <div className="invoice-list">
+                {payments.map((payment) => {
+                  const payee = ledgers.find((l) => l.id === payment.ledger_id);
+                  return (
+                    <div key={payment.id} className="invoice-row invoice-row--payment">
+                      <div className="invoice-row__main">
+                        <div className="invoice-row__header">
+                          <div className="invoice-row__identity">
+                            <strong className="invoice-row__ledger-name">{payee?.name ?? `Ledger #${payment.ledger_id}`}</strong>
+                            <span className="invoice-row__invoice-id">{payment.payment_number ?? `PAY-#${payment.id}`}</span>
+                          </div>
+                          <span className="invoice-type-badge">Payment</span>
+                        </div>
+                        <div className="invoice-row__chips">
+                          <span className="invoice-meta-chip">Date {new Date(payment.date).toLocaleDateString()}</span>
+                          {payment.mode ? <span className="invoice-meta-chip">Mode: {payment.mode}</span> : null}
+                          {payment.reference ? <span className="invoice-meta-chip">Ref: {payment.reference}</span> : null}
+                        </div>
+                      </div>
+                      <div className="invoice-row__aside">
+                        <div className="invoice-row__totals">
+                          <span className="invoice-row__amount">Debit</span>
+                          <span className="invoice-row__price">{formatCurrency(payment.amount, activeCurrencyCode)}</span>
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </>
+          )}
         </article>
       </section>
 

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -229,6 +229,7 @@ export type Payment = {
   voucher_type: 'receipt' | 'payment';
   amount: number;
   date: string;
+  payment_number?: string | null;
   mode: string | null;
   reference: string | null;
   notes: string | null;


### PR DESCRIPTION
## Summary

Implements payment voucher creation directly from the Invoices page with an independent auto-numbered `PAY-YYYY-NNN` series. When "Payment" is selected as the voucher type, the line-items section is replaced by a payment sub-form (payee ledger, mode, reference, amount, date). On submit the form POSTs to `/payments/` and the new voucher appears under a "Payment Vouchers" tab in the invoice list panel.

The `_generate_next_number` helper has been extracted from `invoices.py` into a shared `src/services/series.py` so both invoices and payments use the same series engine.

## Type of change

- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs (documentation)
- [x] test (tests)
- [ ] chore/refactor

## How to test

1. Run migrations (the `20260409000004` migration adds `payment_number` + `series_id` to payments and seeds the `PAY` series).
2. Navigate to the Invoices page.
3. Change the voucher type to **Payment**.
4. The line-items section disappears; the payment sub-form appears (Payment mode, Reference, Amount).
5. Select a ledger, fill in the amount, and click **Create payment voucher**.
6. Switch to the **Payment Vouchers** tab — the new row should show with a `PAY-2026-NNN` number, payee name, mode, reference, and amount.
7. The ledger statement for the selected ledger should also show the payment entry as a Debit.

## Checklist

- [x] My code follows the project style and conventions
- [x] I added/updated tests where appropriate
- [x] I updated docs where needed
- [x] I ran relevant checks locally
- [x] I verified this does not break existing behavior

## Screenshots (if UI changes)

Payment sub-form replaces line items when voucher type = Payment. Payment Vouchers toggle tab shows PAY-numbered rows.

## Related issue

Closes #187