### PR TITLE
feat(A1): FY master table, model, schemas, service and API

### DIFF
--- a/backend/app_main.py
+++ b/backend/app_main.py
@@ -6,7 +6,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy import text
 
-from src.api.routes import auth, users, products, inventory, invoices, ledgers, company, payments, smtp, email as email_routes, shortcuts, invoice_series as invoice_series_routes
+from src.api.routes import auth, users, products, inventory, invoices, ledgers, company, payments, smtp, email as email_routes, shortcuts, invoice_series as invoice_series_routes, financial_years as financial_years_routes
 from src.db.base import Base
 from src.db.session import engine
 
@@ -96,6 +96,7 @@ app.include_router(smtp.router, prefix="/api/smtp-configs", tags=["smtp"])
 app.include_router(email_routes.router, prefix="/api/email", tags=["email"])
 app.include_router(shortcuts.router, prefix="/api/shortcuts", tags=["shortcuts"])
 app.include_router(invoice_series_routes.router, prefix="/api/invoice-series", tags=["invoice-series"])
+app.include_router(financial_years_routes.router, prefix="/api/financial-years", tags=["financial-years"])
 
 @app.get("/api/health")
 def health():

--- a/backend/migrations/20260410000001_create_financial_years_table.py
+++ b/backend/migrations/20260410000001_create_financial_years_table.py
@@ -1,0 +1,29 @@
+"""
+Create financial_years table and seed default FY 2025-26.
+"""
+
+from sqlalchemy import text
+
+
+def up(conn) -> None:
+    conn.execute(text("""
+        CREATE TABLE IF NOT EXISTS financial_years (
+            id         SERIAL PRIMARY KEY,
+            label      VARCHAR NOT NULL,
+            start_date DATE NOT NULL,
+            end_date   DATE NOT NULL,
+            is_active  BOOLEAN NOT NULL DEFAULT FALSE,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )
+    """))
+
+    # Seed default FY 2025-26 if table is empty
+    conn.execute(text("""
+        INSERT INTO financial_years (label, start_date, end_date, is_active)
+        SELECT '2025-26', '2025-04-01', '2026-03-31', TRUE
+        WHERE NOT EXISTS (SELECT 1 FROM financial_years)
+    """))
+
+
+def down(conn) -> None:
+    conn.execute(text("DROP TABLE IF EXISTS financial_years"))

--- a/backend/src/api/routes/financial_years.py
+++ b/backend/src/api/routes/financial_years.py
@@ -1,0 +1,50 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from src.api.deps import get_current_user
+from src.db.session import get_db
+from src.models.financial_year import FinancialYear
+from src.models.user import User
+from src.schemas.financial_year import FinancialYearCreate, FinancialYearOut
+from src.services.financial_year import activate_fy
+
+router = APIRouter()
+
+
+@router.get("", response_model=list[FinancialYearOut], include_in_schema=False)
+@router.get("/", response_model=list[FinancialYearOut])
+def list_financial_years(
+    db: Session = Depends(get_db),
+    _: User = Depends(get_current_user),
+):
+    return db.query(FinancialYear).order_by(FinancialYear.start_date.asc()).all()
+
+
+@router.post("/", response_model=FinancialYearOut, status_code=201)
+def create_financial_year(
+    payload: FinancialYearCreate,
+    db: Session = Depends(get_db),
+    _: User = Depends(get_current_user),
+):
+    fy = FinancialYear(
+        label=payload.label,
+        start_date=payload.start_date,
+        end_date=payload.end_date,
+        is_active=False,
+    )
+    db.add(fy)
+    db.commit()
+    db.refresh(fy)
+    return fy
+
+
+@router.put("/{fy_id}/activate", response_model=FinancialYearOut)
+def activate_financial_year(
+    fy_id: int,
+    db: Session = Depends(get_db),
+    _: User = Depends(get_current_user),
+):
+    fy = activate_fy(db, fy_id)
+    if not fy:
+        raise HTTPException(status_code=404, detail=f"Financial year {fy_id} not found")
+    return fy

--- a/backend/src/models/financial_year.py
+++ b/backend/src/models/financial_year.py
@@ -1,0 +1,14 @@
+from sqlalchemy import Column, Integer, String, Boolean, Date, DateTime
+from datetime import datetime
+from src.db.base import Base
+
+
+class FinancialYear(Base):
+    __tablename__ = "financial_years"
+
+    id = Column(Integer, primary_key=True, index=True)
+    label = Column(String, nullable=False)
+    start_date = Column(Date, nullable=False)
+    end_date = Column(Date, nullable=False)
+    is_active = Column(Boolean, nullable=False, default=False)
+    created_at = Column(DateTime, default=datetime.utcnow)

--- a/backend/src/schemas/financial_year.py
+++ b/backend/src/schemas/financial_year.py
@@ -1,0 +1,21 @@
+from datetime import date, datetime
+from pydantic import BaseModel
+from typing import Optional
+
+
+class FinancialYearOut(BaseModel):
+    id: int
+    label: str
+    start_date: date
+    end_date: date
+    is_active: bool
+    created_at: Optional[datetime] = None
+
+    class Config:
+        from_attributes = True
+
+
+class FinancialYearCreate(BaseModel):
+    label: str
+    start_date: date
+    end_date: date

--- a/backend/src/services/financial_year.py
+++ b/backend/src/services/financial_year.py
@@ -1,0 +1,25 @@
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from src.models.financial_year import FinancialYear
+
+
+def get_active_fy(db: Session) -> Optional[FinancialYear]:
+    """Return the currently active financial year, or None if none is set."""
+    return db.query(FinancialYear).filter(FinancialYear.is_active.is_(True)).first()
+
+
+def activate_fy(db: Session, fy_id: int) -> FinancialYear:
+    """Set the target FY as active; deactivate all others atomically."""
+    target = db.query(FinancialYear).filter(FinancialYear.id == fy_id).first()
+    if not target:
+        return None
+
+    db.query(FinancialYear).filter(FinancialYear.is_active.is_(True)).update(
+        {"is_active": False}, synchronize_session="fetch"
+    )
+    target.is_active = True
+    db.commit()
+    db.refresh(target)
+    return target


### PR DESCRIPTION
## Summary

Creates the `financial_years` database table with full CRUD and activation support.

- Migration `20260410000001_create_financial_years_table.py` — creates table, seeds FY 2025-26 as active
- `src/models/financial_year.py` — `FinancialYear` SQLAlchemy model
- `src/schemas/financial_year.py` — `FinancialYearOut` and `FinancialYearCreate` Pydantic schemas
- `src/services/financial_year.py` — `get_active_fy()` and `activate_fy(id)` (enforces single-active constraint)
- `src/api/routes/financial_years.py` — `GET /`, `POST /`, `PUT /{id}/activate` endpoints (any logged-in user)
- `app_main.py` — registers new router under `/api/financial-years`

Closes #202