### PR TITLE
feat(A2): FY-scoped invoice series with FY year_format

### DIFF
--- a/backend/migrations/20260410000002_fy_scope_invoice_series.py
+++ b/backend/migrations/20260410000002_fy_scope_invoice_series.py
@@ -1,0 +1,57 @@
+"""
+Extend invoice_series with financial_year_id FK.
+- Add financial_year_id INTEGER NULLABLE FK -> financial_years.id
+- Drop old UNIQUE(voucher_type) constraint
+- Add UNIQUE(voucher_type, financial_year_id) constraint
+- Backfill existing rows to the default active FY (2025-26)
+"""
+
+from sqlalchemy import text
+
+
+def up(conn) -> None:
+    # Add financial_year_id column
+    conn.execute(text("""
+        ALTER TABLE invoice_series
+            ADD COLUMN IF NOT EXISTS financial_year_id INTEGER
+                REFERENCES financial_years(id)
+    """))
+
+    # Drop old unique constraint on voucher_type alone
+    conn.execute(text("""
+        ALTER TABLE invoice_series
+            DROP CONSTRAINT IF EXISTS invoice_series_voucher_type_key
+    """))
+
+    # Add new unique constraint on (voucher_type, financial_year_id)
+    conn.execute(text("""
+        ALTER TABLE invoice_series
+            ADD CONSTRAINT IF NOT EXISTS uq_invoice_series_voucher_fy
+                UNIQUE (voucher_type, financial_year_id)
+    """))
+
+    # Backfill existing 3 rows to the active FY
+    conn.execute(text("""
+        UPDATE invoice_series
+           SET financial_year_id = (
+               SELECT id FROM financial_years WHERE is_active = TRUE LIMIT 1
+           )
+         WHERE financial_year_id IS NULL
+    """))
+
+
+def down(conn) -> None:
+    conn.execute(text("""
+        ALTER TABLE invoice_series
+            DROP CONSTRAINT IF EXISTS uq_invoice_series_voucher_fy
+    """))
+    conn.execute(text("""
+        ALTER TABLE invoice_series
+            DROP COLUMN IF EXISTS financial_year_id
+    """))
+    # Re-add the original unique constraint
+    conn.execute(text("""
+        ALTER TABLE invoice_series
+            ADD CONSTRAINT invoice_series_voucher_type_key
+                UNIQUE (voucher_type)
+    """))

--- a/backend/src/api/routes/financial_years.py
+++ b/backend/src/api/routes/financial_years.py
@@ -4,11 +4,52 @@ from sqlalchemy.orm import Session
 from src.api.deps import get_current_user
 from src.db.session import get_db
 from src.models.financial_year import FinancialYear
+from src.models.invoice_series import InvoiceSeries
 from src.models.user import User
 from src.schemas.financial_year import FinancialYearCreate, FinancialYearOut
-from src.services.financial_year import activate_fy
+from src.services.financial_year import activate_fy, get_active_fy
 
 router = APIRouter()
+
+
+def _seed_series_for_fy(db: Session, new_fy_id: int) -> None:
+    """Clone the 3 core series rows from the active FY into the new FY."""
+    active_fy = get_active_fy(db)
+    if active_fy is None:
+        # No active FY to clone from; seed bare defaults
+        for vtype, prefix in [("sales", "INV"), ("purchase", "PINV"), ("payment", "PAY")]:
+            db.add(InvoiceSeries(
+                voucher_type=vtype,
+                financial_year_id=new_fy_id,
+                prefix=prefix,
+                include_year=True,
+                year_format="YYYY",
+                separator="-",
+                next_sequence=1,
+                pad_digits=3,
+            ))
+        return
+
+    source_rows = (
+        db.query(InvoiceSeries)
+        .filter(
+            InvoiceSeries.financial_year_id == active_fy.id,
+            InvoiceSeries.voucher_type.in_(["sales", "purchase", "payment"]),
+        )
+        .all()
+    )
+
+    for src in source_rows:
+        db.add(InvoiceSeries(
+            voucher_type=src.voucher_type,
+            financial_year_id=new_fy_id,
+            prefix=src.prefix,
+            include_year=src.include_year,
+            year_format=src.year_format,
+            separator=src.separator,
+            next_sequence=1,
+            pad_digits=src.pad_digits,
+        ))
 
 
 @router.get("", response_model=list[FinancialYearOut], include_in_schema=False)
@@ -33,6 +74,8 @@ def create_financial_year(
         is_active=False,
     )
     db.add(fy)
+    db.flush()  # get fy.id before committing
+    _seed_series_for_fy(db, fy.id)
     db.commit()
     db.refresh(fy)
     return fy

--- a/backend/src/api/routes/invoice_series.py
+++ b/backend/src/api/routes/invoice_series.py
@@ -1,5 +1,6 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
+from typing import Optional
 
 from src.api.deps import require_roles
 from src.db.session import get_db
@@ -13,10 +14,14 @@ router = APIRouter()
 @router.get("", response_model=list[InvoiceSeriesOut], include_in_schema=False)
 @router.get("/", response_model=list[InvoiceSeriesOut])
 def list_invoice_series(
+    financial_year_id: Optional[int] = Query(default=None),
     db: Session = Depends(get_db),
     _: User = Depends(require_roles(UserRole.admin)),
 ):
-    return db.query(InvoiceSeries).order_by(InvoiceSeries.id.asc()).all()
+    q = db.query(InvoiceSeries)
+    if financial_year_id is not None:
+        q = q.filter(InvoiceSeries.financial_year_id == financial_year_id)
+    return q.order_by(InvoiceSeries.id.asc()).all()
 
 
 @router.put("/{series_id}", response_model=InvoiceSeriesOut)

--- a/backend/src/models/invoice_series.py
+++ b/backend/src/models/invoice_series.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Boolean, DateTime
+from sqlalchemy import Column, Integer, String, Boolean, DateTime, ForeignKey
 from datetime import datetime
 from src.db.base import Base
 
@@ -7,7 +7,8 @@ class InvoiceSeries(Base):
     __tablename__ = "invoice_series"
 
     id = Column(Integer, primary_key=True, index=True)
-    voucher_type = Column(String, nullable=False, unique=True)  # sales | purchase | payment
+    voucher_type = Column(String, nullable=False)  # sales | purchase | payment
+    financial_year_id = Column(Integer, ForeignKey("financial_years.id"), nullable=True)
     prefix = Column(String, nullable=False)
     include_year = Column(Boolean, default=True, nullable=False)
     year_format = Column(String, default="YYYY", nullable=False)  # 'YYYY' or 'MM-YYYY'

--- a/backend/src/schemas/invoice_series.py
+++ b/backend/src/schemas/invoice_series.py
@@ -6,6 +6,7 @@ from typing import Literal, Optional
 class InvoiceSeriesOut(BaseModel):
     id: int
     voucher_type: str
+    financial_year_id: Optional[int] = None
     prefix: str
     include_year: bool
     year_format: str
@@ -21,6 +22,6 @@ class InvoiceSeriesOut(BaseModel):
 class InvoiceSeriesUpdate(BaseModel):
     prefix: str
     include_year: bool = True
-    year_format: Literal["YYYY", "MM-YYYY"] = "YYYY"
+    year_format: Literal["YYYY", "MM-YYYY", "FY"] = "YYYY"
     separator: str = "-"
     pad_digits: Literal[2, 3, 4] = 3

--- a/backend/src/services/series.py
+++ b/backend/src/services/series.py
@@ -1,18 +1,46 @@
 from datetime import datetime
+from typing import Optional
 
 from sqlalchemy.orm import Session
 
+from src.models.financial_year import FinancialYear
 from src.models.invoice_series import InvoiceSeries
 
 
-def generate_next_number(db: Session, voucher_type: str) -> str:
-    """Atomically increment the series counter and return the formatted number."""
-    series = (
-        db.query(InvoiceSeries)
-        .filter(InvoiceSeries.voucher_type == voucher_type)
-        .with_for_update()
-        .first()
-    )
+def generate_next_number(
+    db: Session, voucher_type: str, financial_year_id: Optional[int] = None
+) -> str:
+    """Atomically increment the series counter and return the formatted number.
+
+    Lookup order:
+    1. Exact match on (voucher_type, financial_year_id) if provided.
+    2. Fall back to a row with NULL financial_year_id for backward compatibility.
+    """
+    series = None
+
+    if financial_year_id is not None:
+        series = (
+            db.query(InvoiceSeries)
+            .filter(
+                InvoiceSeries.voucher_type == voucher_type,
+                InvoiceSeries.financial_year_id == financial_year_id,
+            )
+            .with_for_update()
+            .first()
+        )
+
+    if series is None:
+        # Fallback: NULL financial_year_id row (legacy / backward compat)
+        series = (
+            db.query(InvoiceSeries)
+            .filter(
+                InvoiceSeries.voucher_type == voucher_type,
+                InvoiceSeries.financial_year_id.is_(None),
+            )
+            .with_for_update()
+            .first()
+        )
+
     if not series:
         return "INV-000000"
 
@@ -23,11 +51,19 @@ def generate_next_number(db: Session, voucher_type: str) -> str:
     seq_str = str(seq).zfill(series.pad_digits)
 
     if series.include_year:
-        now = datetime.utcnow()
-        if series.year_format == "MM-YYYY":
+        if series.year_format == "FY":
+            # Use the label from the linked financial_year row
+            fy = None
+            if series.financial_year_id is not None:
+                fy = db.query(FinancialYear).filter(
+                    FinancialYear.id == series.financial_year_id
+                ).first()
+            year_part = fy.label if fy else "FY"
+        elif series.year_format == "MM-YYYY":
+            now = datetime.utcnow()
             year_part = now.strftime("%m") + sep + str(now.year)
         else:
-            year_part = str(now.year)
+            year_part = str(datetime.utcnow().year)
         return f"{series.prefix}{sep}{year_part}{sep}{seq_str}"
     else:
         return f"{series.prefix}{sep}{seq_str}"


### PR DESCRIPTION
## Summary

Extends `invoice_series` so each row is scoped to a specific financial year and adds `"FY"` as a new `year_format` option.

- Migration `20260410000002_fy_scope_invoice_series.py` — adds `financial_year_id` FK, drops old `UNIQUE(voucher_type)`, adds `UNIQUE(voucher_type, financial_year_id)`, backfills existing rows to active FY
- `src/models/invoice_series.py` — adds `financial_year_id` FK field
- `src/schemas/invoice_series.py` — `InvoiceSeriesOut` exposes `financial_year_id`; `InvoiceSeriesUpdate` accepts `year_format="FY"`
- `src/services/series.py` — `generate_next_number(db, voucher_type, financial_year_id=None)` with FY-scoped lookup and fallback; `"FY"` format renders the FY label (e.g. `INV-2025-26-001`)
- `src/api/routes/invoice_series.py` — `GET /api/invoice-series/?financial_year_id=` optional filter
- `src/api/routes/financial_years.py` — `POST /api/financial-years/` auto-seeds 3 series rows (sales, purchase, payment) cloned from the active FY

Closes #204