### PR TITLE
feat(B1): stamp invoices and payments with active FY, soft warn on date outside FY

### DIFF
--- a/backend/migrations/20260410000003_add_financial_year_id_to_invoices_payments.py
+++ b/backend/migrations/20260410000003_add_financial_year_id_to_invoices_payments.py
@@ -1,0 +1,25 @@
+"""
+Add financial_year_id FK to invoices and payments tables.
+Existing rows remain NULL (backward compatible).
+"""
+
+from sqlalchemy import text
+
+
+def up(conn) -> None:
+    conn.execute(text("""
+        ALTER TABLE invoices
+            ADD COLUMN IF NOT EXISTS financial_year_id INTEGER
+                REFERENCES financial_years(id)
+    """))
+
+    conn.execute(text("""
+        ALTER TABLE payments
+            ADD COLUMN IF NOT EXISTS financial_year_id INTEGER
+                REFERENCES financial_years(id)
+    """))
+
+
+def down(conn) -> None:
+    conn.execute(text("ALTER TABLE invoices DROP COLUMN IF EXISTS financial_year_id"))
+    conn.execute(text("ALTER TABLE payments DROP COLUMN IF EXISTS financial_year_id"))

--- a/backend/src/api/routes/invoices.py
+++ b/backend/src/api/routes/invoices.py
@@ -22,6 +22,7 @@ from src.models.user import User
 from src.schemas.invoice import InvoiceCreate, InvoiceOut, PaginatedInvoiceOut
 from src.api.deps import get_current_user
 from src.services.series import generate_next_number
+from src.services.financial_year import get_active_fy
 
 router = APIRouter()
 
@@ -36,8 +37,8 @@ def _is_interstate_supply(company_gst: str | None, ledger_gst: str | None) -> bo
     return company_gst[:2] != ledger_gst[:2]
 
 
-def _generate_next_number(db: Session, voucher_type: str) -> str:
-    return generate_next_number(db, voucher_type)
+def _generate_next_number(db: Session, voucher_type: str, financial_year_id: int | None = None) -> str:
+    return generate_next_number(db, voucher_type, financial_year_id)
 
 
 def _require_ledger(db: Session, ledger_id: int) -> Ledger:
@@ -75,6 +76,7 @@ def _apply_payload_to_invoice(
     invoice: Invoice,
     payload: InvoiceCreate,
     created_by: int | None = None,
+    financial_year_id: int | None = None,
 ) -> None:
     ledger = _require_ledger(db, payload.ledger_id)
     company = db.query(CompanyProfile).order_by(CompanyProfile.id.asc()).first()
@@ -100,6 +102,8 @@ def _apply_payload_to_invoice(
     invoice.supplier_invoice_number = payload.supplier_invoice_number
     if created_by is not None:
         invoice.created_by = created_by
+    if financial_year_id is not None:
+        invoice.financial_year_id = financial_year_id
 
     if payload.invoice_date is not None:
         invoice.invoice_date = datetime.combine(payload.invoice_date, datetime.min.time())
@@ -108,7 +112,7 @@ def _apply_payload_to_invoice(
         invoice.due_date = datetime.combine(payload.due_date, datetime.min.time())
 
     invoice.tax_inclusive = payload.tax_inclusive
-    invoice.invoice_number = _generate_next_number(db, invoice.voucher_type)
+    invoice.invoice_number = _generate_next_number(db, invoice.voucher_type, financial_year_id)
 
     if not invoice.company_gst or not invoice.ledger_gst:
         raise HTTPException(
@@ -207,16 +211,32 @@ def create_invoice(
     current_user: User = Depends(get_current_user),
 ):
     try:
+        active_fy = get_active_fy(db)
+        fy_id = active_fy.id if active_fy else None
+
         invoice = Invoice(
             total_amount=0,
             created_by=current_user.id,
         )
         db.add(invoice)
         db.flush()
-        _apply_payload_to_invoice(db, invoice, payload, created_by=current_user.id)
+        _apply_payload_to_invoice(
+            db, invoice, payload,
+            created_by=current_user.id,
+            financial_year_id=fy_id,
+        )
         db.commit()
         db.refresh(invoice)
-        return invoice
+
+        warnings: list[str] = []
+        if active_fy and payload.invoice_date:
+            inv_date = payload.invoice_date
+            if not (active_fy.start_date <= inv_date <= active_fy.end_date):
+                warnings.append("invoice_date_outside_fy")
+
+        result = InvoiceOut.model_validate(invoice)
+        result.warnings = warnings
+        return result
     except HTTPException:
         db.rollback()
         raise

--- a/backend/src/api/routes/payments.py
+++ b/backend/src/api/routes/payments.py
@@ -10,6 +10,7 @@ from src.models.payment import Payment
 from src.models.user import User, UserRole
 from src.schemas.payment import PaymentCreate, PaymentOut
 from src.services.series import generate_next_number
+from src.services.financial_year import get_active_fy
 
 router = APIRouter()
 
@@ -25,23 +26,38 @@ def create_payment(
     if not ledger:
         raise HTTPException(status_code=404, detail="Ledger not found")
 
-    payment_number = generate_next_number(db, payload.voucher_type)
+    active_fy = get_active_fy(db)
+    fy_id = active_fy.id if active_fy else None
+
+    payment_number = generate_next_number(db, payload.voucher_type, fy_id)
+
+    payment_date = payload.date or datetime.utcnow()
 
     payment = Payment(
         ledger_id=payload.ledger_id,
         voucher_type=payload.voucher_type,
         amount=payload.amount,
-        date=payload.date or datetime.utcnow(),
+        date=payment_date,
         mode=payload.mode.strip() if payload.mode else None,
         reference=payload.reference.strip() if payload.reference else None,
         notes=payload.notes.strip() if payload.notes else None,
         payment_number=payment_number,
+        financial_year_id=fy_id,
         created_by=current_user.id,
     )
     db.add(payment)
     db.commit()
     db.refresh(payment)
-    return payment
+
+    warnings: list[str] = []
+    if active_fy:
+        pdate = payment_date.date() if hasattr(payment_date, "date") else payment_date
+        if not (active_fy.start_date <= pdate <= active_fy.end_date):
+            warnings.append("invoice_date_outside_fy")
+
+    result = PaymentOut.model_validate(payment)
+    result.warnings = warnings
+    return result
 
 
 @router.get("", response_model=list[PaymentOut], include_in_schema=False)

--- a/backend/src/models/invoice.py
+++ b/backend/src/models/invoice.py
@@ -39,6 +39,7 @@ class Invoice(Base):
     invoice_date = Column(DateTime, nullable=False, default=datetime.utcnow)
     due_date = Column(DateTime, nullable=True)
     tax_inclusive = Column(Boolean, nullable=False, default=False)
+    financial_year_id = Column(Integer, ForeignKey("financial_years.id"), nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow)
 
     ledger = relationship("Buyer", back_populates="invoices")

--- a/backend/src/models/payment.py
+++ b/backend/src/models/payment.py
@@ -16,6 +16,7 @@ class Payment(Base):
     mode = Column(String, nullable=True)  # cash, bank, upi, cheque
     reference = Column(String, nullable=True)  # cheque no, txn id
     notes = Column(String, nullable=True)
+    financial_year_id = Column(Integer, ForeignKey("financial_years.id"), nullable=True)
     created_by = Column(Integer, ForeignKey("users.id"), nullable=False)
     created_at = Column(DateTime, default=datetime.utcnow)
 

--- a/backend/src/schemas/invoice.py
+++ b/backend/src/schemas/invoice.py
@@ -68,6 +68,8 @@ class InvoiceOut(BaseModel):
     invoice_date: datetime
     due_date: datetime | None = None
     tax_inclusive: bool = False
+    financial_year_id: Optional[int] = None
+    warnings: List[str] = Field(default_factory=list)
     created_at: datetime
     items: list[InvoiceItemOut] = Field(default_factory=list)
 

--- a/backend/src/schemas/payment.py
+++ b/backend/src/schemas/payment.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from pydantic import BaseModel, field_validator
+from typing import List, Optional
 
 
 class PaymentCreate(BaseModel):
@@ -36,6 +37,8 @@ class PaymentOut(BaseModel):
     mode: str | None = None
     reference: str | None = None
     notes: str | None = None
+    financial_year_id: Optional[int] = None
+    warnings: List[str] = []
     created_by: int
     created_at: datetime
 


### PR DESCRIPTION
## Summary

Stamps every newly created invoice and payment with the currently active financial year ID, and passes it through to `generate_next_number()` for FY-scoped series lookup.

- Migration `20260410000003_add_financial_year_id_to_invoices_payments.py` — adds nullable `financial_year_id` FK to `invoices` and `payments` (existing rows remain NULL)
- `src/models/invoice.py` — adds `financial_year_id` nullable FK field
- `src/models/payment.py` — adds `financial_year_id` nullable FK field
- `src/schemas/invoice.py` — `InvoiceOut` exposes `financial_year_id` and `warnings: List[str]`
- `src/schemas/payment.py` — `PaymentOut` exposes `financial_year_id` and `warnings: List[str]`
- `src/api/routes/invoices.py` — `POST /` calls `get_active_fy()`, stamps FY, passes to `generate_next_number`, emits `"invoice_date_outside_fy"` soft warning (HTTP 201 still returned)
- `src/api/routes/payments.py` — same behaviour for payment creation

Closes #205