### PR TITLE
fix(migration): use DO $$ block for idempotent ADD CONSTRAINT in migration 0002

### DIFF
--- a/backend/migrations/20260410000002_fy_scope_invoice_series.py
+++ b/backend/migrations/20260410000002_fy_scope_invoice_series.py
@@ -25,9 +25,18 @@ def up(conn) -> None:
 
     # Add new unique constraint on (voucher_type, financial_year_id)
     conn.execute(text("""
-        ALTER TABLE invoice_series
-            ADD CONSTRAINT IF NOT EXISTS uq_invoice_series_voucher_fy
-                UNIQUE (voucher_type, financial_year_id)
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'uq_invoice_series_voucher_fy'
+            ) THEN
+                ALTER TABLE invoice_series
+                    ADD CONSTRAINT uq_invoice_series_voucher_fy
+                        UNIQUE (voucher_type, financial_year_id);
+            END IF;
+        END
+        $$
     """))
 
     # Backfill existing 3 rows to the active FY


### PR DESCRIPTION
## Summary

`ADD CONSTRAINT IF NOT EXISTS` is not valid PostgreSQL syntax — `IF NOT EXISTS` is only supported for `ADD COLUMN`. The backend was crashing on startup with:

```
sqlalchemy.exc.ProgrammingError: syntax error at or near "NOT"
LINE 3: ADD CONSTRAINT IF NOT EXISTS uq_invoice_series_voucher_fy
```

Replaced with a `DO $$ BEGIN ... IF NOT EXISTS ... END $$` PL/pgSQL block which is the correct idiomatic way to add a constraint conditionally in Postgres.