### PR TITLE
feat(C1): FY Switcher UI (Context + Nav Control)

### DIFF
--- a/frontend/e2e/financial-years.spec.ts
+++ b/frontend/e2e/financial-years.spec.ts
@@ -1,0 +1,176 @@
+import { test, expect } from './fixtures';
+
+test.describe('Financial Year Switcher', () => {
+  test('FY switcher section is visible in the nav panel', async ({ authedPage: page }) => {
+    await expect(page.getByText('Financial Year')).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('FY switcher dropdown button shows active FY label or fallback', async ({ authedPage: page }) => {
+    const fyButton = page.locator('button[aria-haspopup="listbox"]');
+    await expect(fyButton).toBeVisible({ timeout: 10_000 });
+    // Button must have some text (either a FY label or "No active FY")
+    const text = await fyButton.textContent();
+    expect(text?.trim().length).toBeGreaterThan(0);
+  });
+
+  test('FY dropdown opens and shows FY list or empty state', async ({ authedPage: page }) => {
+    const fyButton = page.locator('button[aria-haspopup="listbox"]');
+    await fyButton.click();
+
+    // The dropdown listbox should be visible
+    const listbox = page.locator('[role="listbox"]');
+    await expect(listbox).toBeVisible({ timeout: 5_000 });
+  });
+
+  test('FY dropdown shows "+ New FY" button', async ({ authedPage: page }) => {
+    const fyButton = page.locator('button[aria-haspopup="listbox"]');
+    await fyButton.click();
+
+    const listbox = page.locator('[role="listbox"]');
+    await expect(listbox).toBeVisible({ timeout: 5_000 });
+    await expect(listbox.locator('button:has-text("+ New FY")')).toBeVisible({ timeout: 5_000 });
+  });
+
+  test('clicking outside FY dropdown closes it', async ({ authedPage: page }) => {
+    const fyButton = page.locator('button[aria-haspopup="listbox"]');
+    await fyButton.click();
+
+    const listbox = page.locator('[role="listbox"]');
+    await expect(listbox).toBeVisible({ timeout: 5_000 });
+
+    // Click somewhere else on the page
+    await page.locator('h1').first().click();
+    await expect(listbox).not.toBeVisible({ timeout: 3_000 });
+  });
+
+  test('New FY modal opens with all required fields', async ({ authedPage: page }) => {
+    const fyButton = page.locator('button[aria-haspopup="listbox"]');
+    await fyButton.click();
+
+    const listbox = page.locator('[role="listbox"]');
+    await expect(listbox).toBeVisible({ timeout: 5_000 });
+    await listbox.locator('button:has-text("+ New FY")').click();
+
+    const dialog = page.locator('[role="dialog"][aria-label="Create new financial year"]');
+    await expect(dialog).toBeVisible({ timeout: 5_000 });
+
+    // Label input
+    await expect(dialog.locator('input[placeholder="2025-26"]')).toBeVisible();
+    // Start date
+    const dateInputs = dialog.locator('input[type="date"]');
+    await expect(dateInputs).toHaveCount(2);
+    // Cancel button
+    await expect(dialog.locator('button:has-text("Cancel")')).toBeVisible();
+    // Create button
+    await expect(dialog.locator('button:has-text("Create")')).toBeVisible();
+  });
+
+  test('New FY modal can be cancelled', async ({ authedPage: page }) => {
+    const fyButton = page.locator('button[aria-haspopup="listbox"]');
+    await fyButton.click();
+    const listbox = page.locator('[role="listbox"]');
+    await expect(listbox).toBeVisible({ timeout: 5_000 });
+    await listbox.locator('button:has-text("+ New FY")').click();
+
+    const dialog = page.locator('[role="dialog"][aria-label="Create new financial year"]');
+    await expect(dialog).toBeVisible({ timeout: 5_000 });
+
+    await dialog.locator('button:has-text("Cancel")').click();
+    await expect(dialog).not.toBeVisible({ timeout: 3_000 });
+  });
+
+  test('New FY modal validates required fields', async ({ authedPage: page }) => {
+    const fyButton = page.locator('button[aria-haspopup="listbox"]');
+    await fyButton.click();
+    const listbox = page.locator('[role="listbox"]');
+    await expect(listbox).toBeVisible({ timeout: 5_000 });
+    await listbox.locator('button:has-text("+ New FY")').click();
+
+    const dialog = page.locator('[role="dialog"][aria-label="Create new financial year"]');
+    await expect(dialog).toBeVisible({ timeout: 5_000 });
+
+    // Submit with empty fields
+    await dialog.locator('button:has-text("Create")').click();
+    await expect(dialog.locator('text=All fields are required.')).toBeVisible({ timeout: 3_000 });
+  });
+
+  test('can create a new financial year', async ({ authedPage: page }) => {
+    const fyLabel = `E2E-FY-${Date.now().toString(36).toUpperCase()}`;
+
+    const fyButton = page.locator('button[aria-haspopup="listbox"]');
+    await fyButton.click();
+    const listbox = page.locator('[role="listbox"]');
+    await expect(listbox).toBeVisible({ timeout: 5_000 });
+    await listbox.locator('button:has-text("+ New FY")').click();
+
+    const dialog = page.locator('[role="dialog"][aria-label="Create new financial year"]');
+    await expect(dialog).toBeVisible({ timeout: 5_000 });
+
+    await dialog.locator('input[placeholder="2025-26"]').fill(fyLabel);
+    const dateInputs = dialog.locator('input[type="date"]');
+    await dateInputs.first().fill('2030-04-01');
+    await dateInputs.last().fill('2031-03-31');
+
+    await dialog.locator('button:has-text("Create")').click();
+
+    // Modal should close
+    await expect(dialog).not.toBeVisible({ timeout: 10_000 });
+
+    // New FY should appear in the dropdown
+    await fyButton.click();
+    await expect(page.locator(`[role="listbox"] button:has-text("${fyLabel}")`)).toBeVisible({ timeout: 5_000 });
+  });
+
+  test('can switch the active financial year', async ({ authedPage: page }) => {
+    // First ensure at least two FYs exist — create a second if needed
+    const fyButton = page.locator('button[aria-haspopup="listbox"]');
+    await fyButton.click();
+
+    const listbox = page.locator('[role="listbox"]');
+    await expect(listbox).toBeVisible({ timeout: 5_000 });
+
+    const fyOptions = listbox.locator('[role="option"]');
+    const count = await fyOptions.count();
+
+    if (count < 2) {
+      // Create a second FY
+      await listbox.locator('button:has-text("+ New FY")').click();
+      const dialog = page.locator('[role="dialog"][aria-label="Create new financial year"]');
+      await expect(dialog).toBeVisible({ timeout: 5_000 });
+      await dialog.locator('input[placeholder="2025-26"]').fill(`SW-${Date.now().toString(36)}`);
+      const dateInputs = dialog.locator('input[type="date"]');
+      await dateInputs.first().fill('2032-04-01');
+      await dateInputs.last().fill('2033-03-31');
+      await dialog.locator('button:has-text("Create")').click();
+      await expect(dialog).not.toBeVisible({ timeout: 10_000 });
+
+      // Re-open dropdown
+      await fyButton.click();
+      await expect(listbox).toBeVisible({ timeout: 5_000 });
+    }
+
+    // Click the first non-active FY
+    const allOptions = listbox.locator('[role="option"]');
+    const optCount = await allOptions.count();
+    let switched = false;
+    for (let i = 0; i < optCount; i++) {
+      const opt = allOptions.nth(i);
+      const selected = await opt.getAttribute('aria-selected');
+      if (selected !== 'true') {
+        const label = await opt.textContent();
+        await opt.click();
+        // Dropdown should close and button label should update
+        await expect(listbox).not.toBeVisible({ timeout: 3_000 });
+        const newLabel = await fyButton.textContent();
+        expect(newLabel?.trim()).toContain(label?.trim().replace('✓', '').trim());
+        switched = true;
+        break;
+      }
+    }
+
+    if (!switched) {
+      // Only one FY exists and it's active — that's fine
+      await page.locator('h1').first().click();
+    }
+  });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { Navigate, Route, Routes } from 'react-router-dom';
 import { AuthProvider, useAuth } from './context/AuthContext';
+import { FYProvider } from './context/FYContext';
 import { ShortcutsProvider } from './context/ShortcutsContext';
 import LoginPage from './pages/LoginPage';
 import DashboardPage from './pages/DashboardPage';
@@ -76,9 +77,11 @@ function AppRoutes() {
 export default function App() {
   return (
     <AuthProvider>
-      <ShortcutsProvider>
-        <AppRoutes />
-      </ShortcutsProvider>
+      <FYProvider>
+        <ShortcutsProvider>
+          <AppRoutes />
+        </ShortcutsProvider>
+      </FYProvider>
     </AuthProvider>
   );
 }

--- a/frontend/src/api/financialYears.ts
+++ b/frontend/src/api/financialYears.ts
@@ -1,0 +1,29 @@
+import api from './client';
+
+export interface FinancialYear {
+  id: number;
+  label: string;
+  start_date: string;
+  end_date: string;
+  is_active: boolean;
+  created_at?: string | null;
+}
+
+export async function getFinancialYears(): Promise<FinancialYear[]> {
+  const res = await api.get<FinancialYear[]>('/financial-years/');
+  return res.data;
+}
+
+export async function createFinancialYear(data: {
+  label: string;
+  start_date: string;
+  end_date: string;
+}): Promise<FinancialYear> {
+  const res = await api.post<FinancialYear>('/financial-years/', data);
+  return res.data;
+}
+
+export async function activateFinancialYear(id: number): Promise<FinancialYear> {
+  const res = await api.put<FinancialYear>(`/financial-years/${id}/activate`);
+  return res.data;
+}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,16 +1,37 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { Link, NavLink, useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
+import { useFY } from '../context/FYContext';
 import { useShortcuts } from '../context/ShortcutsContext';
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   const { logout, userEmail, isAdmin } = useAuth();
+  const { activeFY, fyList, switchFY, createFY } = useFY();
   const location = useLocation();
   const { registerAction } = useShortcuts();
   const navigate = useNavigate();
 
   const [drawerOpen, setDrawerOpen] = useState(false);
+  const [fyDropdownOpen, setFyDropdownOpen] = useState(false);
+  const [newFYModalOpen, setNewFYModalOpen] = useState(false);
+  const [newFYLabel, setNewFYLabel] = useState('');
+  const [newFYStart, setNewFYStart] = useState('');
+  const [newFYEnd, setNewFYEnd] = useState('');
+  const [newFYError, setNewFYError] = useState('');
+  const [newFYSubmitting, setNewFYSubmitting] = useState(false);
+  const fyDropdownRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!fyDropdownOpen) return;
+    const onClickOutside = (e: MouseEvent) => {
+      if (fyDropdownRef.current && !fyDropdownRef.current.contains(e.target as Node)) {
+        setFyDropdownOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', onClickOutside);
+    return () => document.removeEventListener('mousedown', onClickOutside);
+  }, [fyDropdownOpen]);
 
   useEffect(() => {
     const cleanups = [
@@ -95,7 +116,191 @@ export default function Layout({ children }: { children: React.ReactNode }) {
             </NavLink>
           ))}
         </div>
+
+        {/* FY Switcher */}
+        <div style={{ marginTop: '1.5rem' }}>
+          <p className="eyebrow" style={{ marginBottom: '0.5rem' }}>Financial Year</p>
+          <div ref={fyDropdownRef} style={{ position: 'relative' }}>
+            <button
+              className="button button--ghost"
+              style={{ width: '100%', textAlign: 'left', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}
+              onClick={() => setFyDropdownOpen((v) => !v)}
+              aria-haspopup="listbox"
+              aria-expanded={fyDropdownOpen}
+            >
+              <span>{activeFY ? activeFY.label : 'No active FY'}</span>
+              <span style={{ fontSize: '0.75rem', opacity: 0.6 }}>▾</span>
+            </button>
+            {fyDropdownOpen && (
+              <div
+                role="listbox"
+                style={{
+                  position: 'absolute',
+                  left: 0,
+                  right: 0,
+                  top: 'calc(100% + 4px)',
+                  background: 'var(--bg-card-strong)',
+                  border: '1px solid var(--line-strong)',
+                  borderRadius: '0.5rem',
+                  boxShadow: '0 4px 24px rgba(0,0,0,0.45)',
+                  zIndex: 100,
+                  overflow: 'hidden',
+                  color: 'var(--text)',
+                }}
+              >
+                {fyList.length === 0 && (
+                  <p style={{ padding: '0.5rem 0.75rem', fontSize: '0.85rem', opacity: 0.6 }}>No financial years</p>
+                )}
+                {fyList.map((fy) => (
+                  <button
+                    key={fy.id}
+                    role="option"
+                    aria-selected={fy.is_active}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: '0.5rem',
+                      width: '100%',
+                      textAlign: 'left',
+                      padding: '0.5rem 0.75rem',
+                      background: 'none',
+                      border: 'none',
+                      cursor: 'pointer',
+                      fontWeight: fy.is_active ? 700 : 400,
+                      fontSize: '0.875rem',
+                      color: 'inherit',
+                    }}
+                    onClick={() => {
+                      switchFY(fy.id);
+                      setFyDropdownOpen(false);
+                    }}
+                  >
+                    <span style={{ width: '1rem' }}>{fy.is_active ? '✓' : ''}</span>
+                    {fy.label}
+                  </button>
+                ))}
+                <hr style={{ margin: '0.25rem 0', border: 'none', borderTop: '1px solid var(--line)' }} />
+                <button
+                  style={{
+                    display: 'block',
+                    width: '100%',
+                    textAlign: 'left',
+                    padding: '0.5rem 0.75rem',
+                    background: 'none',
+                    border: 'none',
+                    cursor: 'pointer',
+                    fontSize: '0.875rem',
+                    color: 'inherit',
+                    fontWeight: 500,
+                  }}
+                  onClick={() => {
+                    setFyDropdownOpen(false);
+                    setNewFYLabel('');
+                    setNewFYStart('');
+                    setNewFYEnd('');
+                    setNewFYError('');
+                    setNewFYModalOpen(true);
+                  }}
+                >
+                  + New FY
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
       </nav>
+
+      {/* New FY Modal */}
+      <AnimatePresence>
+        {newFYModalOpen && (
+          <motion.div
+            className="modal-overlay"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            onClick={(e) => { if (e.target === e.currentTarget) setNewFYModalOpen(false); }}
+          >
+            <motion.div
+              className="modal-panel"
+              role="dialog"
+              aria-modal="true"
+              aria-label="Create new financial year"
+              initial={{ scale: 0.95, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              exit={{ scale: 0.95, opacity: 0 }}
+              transition={{ duration: 0.2 }}
+              style={{ maxWidth: '28rem' }}
+            >
+              <h2 style={{ marginBottom: '1.25rem', fontSize: '1.125rem', fontWeight: 700 }}>New Financial Year</h2>
+              <form
+                onSubmit={async (e) => {
+                  e.preventDefault();
+                  if (!newFYLabel.trim() || !newFYStart || !newFYEnd) {
+                    setNewFYError('All fields are required.');
+                    return;
+                  }
+                  if (newFYStart >= newFYEnd) {
+                    setNewFYError('Start date must be before end date.');
+                    return;
+                  }
+                  setNewFYError('');
+                  setNewFYSubmitting(true);
+                  try {
+                    await createFY(newFYLabel.trim(), newFYStart, newFYEnd);
+                    setNewFYModalOpen(false);
+                  } catch {
+                    setNewFYError('Failed to create financial year. Please try again.');
+                  } finally {
+                    setNewFYSubmitting(false);
+                  }
+                }}
+              >
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+                  <label style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem', fontSize: '0.875rem', fontWeight: 500 }}>
+                    Label (e.g. 2025-26)
+                    <input
+                      className="input"
+                      type="text"
+                      value={newFYLabel}
+                      onChange={(e) => setNewFYLabel(e.target.value)}
+                      placeholder="2025-26"
+                      autoFocus
+                    />
+                  </label>
+                  <label style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem', fontSize: '0.875rem', fontWeight: 500 }}>
+                    Start Date
+                    <input
+                      className="input"
+                      type="date"
+                      value={newFYStart}
+                      onChange={(e) => setNewFYStart(e.target.value)}
+                    />
+                  </label>
+                  <label style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem', fontSize: '0.875rem', fontWeight: 500 }}>
+                    End Date
+                    <input
+                      className="input"
+                      type="date"
+                      value={newFYEnd}
+                      onChange={(e) => setNewFYEnd(e.target.value)}
+                    />
+                  </label>
+                  {newFYError && <p style={{ color: 'var(--error, #ef4444)', fontSize: '0.85rem' }}>{newFYError}</p>}
+                  <div style={{ display: 'flex', gap: '0.75rem', justifyContent: 'flex-end', marginTop: '0.5rem' }}>
+                    <button type="button" className="button button--ghost" onClick={() => setNewFYModalOpen(false)}>
+                      Cancel
+                    </button>
+                    <button type="submit" className="button" disabled={newFYSubmitting}>
+                      {newFYSubmitting ? 'Creating…' : 'Create'}
+                    </button>
+                  </div>
+                </div>
+              </form>
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
 
       <AnimatePresence>
         {drawerOpen && (

--- a/frontend/src/context/FYContext.tsx
+++ b/frontend/src/context/FYContext.tsx
@@ -1,0 +1,80 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { activateFinancialYear, createFinancialYear, getFinancialYears, type FinancialYear } from '../api/financialYears';
+import { useAuth } from './AuthContext';
+
+type FYContextType = {
+  activeFY: FinancialYear | null;
+  fyList: FinancialYear[];
+  loading: boolean;
+  switchFY: (id: number) => Promise<void>;
+  createFY: (label: string, startDate: string, endDate: string) => Promise<void>;
+  refreshFYList: () => Promise<void>;
+};
+
+const FYContext = createContext<FYContextType | undefined>(undefined);
+
+export function FYProvider({ children }: { children: React.ReactNode }) {
+  const { isAuthenticated } = useAuth();
+  const [fyList, setFyList] = useState<FinancialYear[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const refreshFYList = useCallback(async () => {
+    setLoading(true);
+    try {
+      const list = await getFinancialYears();
+      setFyList(list);
+    } catch {
+      // leave existing list on error
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      refreshFYList();
+    } else {
+      setFyList([]);
+    }
+  }, [isAuthenticated, refreshFYList]);
+
+  const activeFY = useMemo(
+    () => fyList.find((fy) => fy.is_active) ?? null,
+    [fyList],
+  );
+
+  const switchFY = useCallback(async (id: number) => {
+    // Optimistic update
+    setFyList((prev) =>
+      prev.map((fy) => ({ ...fy, is_active: fy.id === id })),
+    );
+    try {
+      await activateFinancialYear(id);
+      await refreshFYList();
+    } catch {
+      // Roll back optimistic update
+      await refreshFYList();
+    }
+  }, [refreshFYList]);
+
+  const createFY = useCallback(
+    async (label: string, startDate: string, endDate: string) => {
+      await createFinancialYear({ label, start_date: startDate, end_date: endDate });
+      await refreshFYList();
+    },
+    [refreshFYList],
+  );
+
+  const value = useMemo(
+    () => ({ activeFY, fyList, loading, switchFY, createFY, refreshFYList }),
+    [activeFY, fyList, loading, switchFY, createFY, refreshFYList],
+  );
+
+  return <FYContext.Provider value={value}>{children}</FYContext.Provider>;
+}
+
+export function useFY(): FYContextType {
+  const ctx = useContext(FYContext);
+  if (!ctx) throw new Error('useFY must be used inside <FYProvider>');
+  return ctx;
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -88,10 +88,16 @@ textarea {
 
 .topbar,
 .page-frame,
-.nav-panel,
 .section-card {
   position: relative;
   z-index: 1;
+}
+
+/* nav-panel needs a higher stacking context so dropdowns inside it
+   float above the page-frame (which is later in the DOM). */
+.nav-panel {
+  position: relative;
+  z-index: 2;
 }
 
 .topbar {

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -202,6 +202,8 @@ export type LedgerStatement = {
   period_credit: number;
   closing_balance: number;
   entries: LedgerStatementEntry[];
+  fy_label: string | null;
+  financial_year_id: number | null;
 };
 
 export type DayBookEntry = {
@@ -221,6 +223,8 @@ export type DayBook = {
   total_debit: number;
   total_credit: number;
   entries: DayBookEntry[];
+  fy_label: string | null;
+  financial_year_id: number | null;
 };
 
 export type Payment = {


### PR DESCRIPTION
## Summary

Adds a React context (`FYContext`) that tracks the active financial year app-wide, and a nav-level FY switcher control so users can view, switch, and create financial years from anywhere in the app.

**Changes:**
- `frontend/src/api/financialYears.ts` — typed API client (`getFinancialYears`, `createFinancialYear`, `activateFinancialYear`) with `FinancialYear` TypeScript interface
- `frontend/src/context/FYContext.tsx` — `FYProvider` / `useFY` hook with `activeFY`, `fyList`, `switchFY`, `createFY`, `refreshFYList`; fetches on auth; optimistic switch with rollback
- `frontend/src/App.tsx` — wrap app root with `<FYProvider>`
- `frontend/src/components/Layout.tsx` — FY switcher dropdown in nav panel + "New FY" modal with validation; z-index fix so dropdown floats above page-frame
- `frontend/src/styles.css` — `nav-panel` elevated to `z-index: 2` over `page-frame`; dropdown uses dark theme CSS vars (`--bg-card-strong`, `--line-strong`, `--text`)
- `frontend/src/types/api.ts` — add `fy_label` / `financial_year_id` fields to `LedgerStatement` and `DayBook` types
- `frontend/e2e/financial-years.spec.ts` — 10 e2e tests covering: switcher visibility, dropdown open/close, New FY modal (open, cancel, validation, create), and FY switching

## Type of change

- [x] feat (new feature)

## How to test

1. Log in — the nav panel now shows a "Financial Year" section below the nav links
2. Click the FY button — dropdown lists all FYs with a checkmark on the active one
3. Click a different FY — it switches immediately (optimistic) and confirms from backend
4. Click "+ New FY" — modal appears; fill label + dates and submit; new FY appears in dropdown
5. Submit the modal with empty fields — shows "All fields are required." inline error
6. Run `npx playwright test e2e/financial-years.spec.ts` — all 10 tests pass

## Checklist

- [x] My code follows the project style and conventions
- [x] I added/updated tests where appropriate
- [x] I ran relevant checks locally
- [x] I verified this does not break existing behavior
- [x] TypeScript: no `any` types

## Related issue

Closes #207