### PR TITLE
feat: invoice/payment creation FY date warning

### DIFF
--- a/frontend/e2e/fy-date-warning.spec.ts
+++ b/frontend/e2e/fy-date-warning.spec.ts
@@ -1,0 +1,211 @@
+import { test, expect, uniqueGstin, expectSuccess } from './fixtures';
+
+/**
+ * Financial year used for all warning tests.
+ * Using a far-future year to avoid collisions with real / other test data.
+ */
+const TEST_FY_START_YEAR = 2031;
+const TEST_FY_LABEL = '2031-32';
+const DATE_INSIDE_FY = '2031-08-15';         // within 2031-04-01 … 2032-03-31
+const DATE_OUTSIDE_FY_BEFORE = '2031-01-01'; // before FY start
+const DATE_OUTSIDE_FY_AFTER = '2032-06-01';  // after FY end
+
+/**
+ * Ensure the test FY exists and is the active FY.
+ * Creates it if missing, then clicks it in the nav switcher to activate it.
+ */
+async function activateTestFY(page: import('@playwright/test').Page) {
+  const fyButton = page.locator('button[aria-haspopup="listbox"]');
+  await fyButton.click();
+  const listbox = page.locator('[role="listbox"]');
+  await expect(listbox).toBeVisible({ timeout: 5_000 });
+
+  const existingOption = listbox.locator(`button:has-text("${TEST_FY_LABEL}")`).first();
+  if (!(await existingOption.isVisible())) {
+    // Create the FY
+    await listbox.locator('button:has-text("+ New FY")').click();
+    const dialog = page.locator('[role="dialog"][aria-label="Create new financial year"]');
+    await expect(dialog).toBeVisible({ timeout: 5_000 });
+    await dialog.locator('input[type="number"]').fill(String(TEST_FY_START_YEAR));
+    await dialog.locator('button:has-text("Create")').click();
+    await expect(dialog).not.toBeVisible({ timeout: 10_000 });
+    // Reopen dropdown to activate
+    await fyButton.click();
+    await expect(listbox).toBeVisible({ timeout: 5_000 });
+  }
+
+  // Click the FY button to activate it
+  await listbox.locator(`button:has-text("${TEST_FY_LABEL}")`).first().click();
+  // Dismiss dropdown if still open
+  if (await listbox.isVisible()) {
+    await page.locator('h1').first().click();
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Invoice form on InvoicesPage
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.describe('FY Date Warning — InvoicesPage invoice form', () => {
+  test('shows warning when invoice date is before active FY start', async ({ authedPage: page }) => {
+    await activateTestFY(page);
+    await page.click('[href="/invoices"]');
+    await page.waitForTimeout(500);
+
+    await page.fill('#invoice-date', DATE_OUTSIDE_FY_BEFORE);
+
+    const warning = page.locator('.field-warning');
+    await expect(warning).toBeVisible({ timeout: 3_000 });
+    await expect(warning).toContainText('outside the active financial year');
+    await expect(warning).toContainText(TEST_FY_LABEL);
+  });
+
+  test('shows warning when invoice date is after active FY end', async ({ authedPage: page }) => {
+    await activateTestFY(page);
+    await page.click('[href="/invoices"]');
+    await page.waitForTimeout(500);
+
+    await page.fill('#invoice-date', DATE_OUTSIDE_FY_AFTER);
+
+    await expect(page.locator('.field-warning')).toBeVisible({ timeout: 3_000 });
+    await expect(page.locator('.field-warning')).toContainText('outside the active financial year');
+  });
+
+  test('warning disappears when invoice date is moved inside active FY', async ({ authedPage: page }) => {
+    await activateTestFY(page);
+    await page.click('[href="/invoices"]');
+    await page.waitForTimeout(500);
+
+    // Trigger warning
+    await page.fill('#invoice-date', DATE_OUTSIDE_FY_BEFORE);
+    await expect(page.locator('.field-warning')).toBeVisible({ timeout: 3_000 });
+
+    // Move inside FY — warning should vanish
+    await page.fill('#invoice-date', DATE_INSIDE_FY);
+    await expect(page.locator('.field-warning')).not.toBeVisible({ timeout: 3_000 });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Create Invoice modal on LedgerViewPage
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.describe('FY Date Warning — CreateInvoiceModal (LedgerView)', () => {
+  async function seedLedgerAndNavigate(page: import('@playwright/test').Page) {
+    const ledgerName = `FYWarnInv-${Date.now().toString(36)}`;
+    await page.click('[href="/ledgers"]');
+    await page.click('button:has-text("Create ledger")');
+    await expect(page.locator('h1')).toContainText('Create ledger', { timeout: 10_000 });
+    await page.fill('#ledger-name', ledgerName);
+    await page.fill('#ledger-address', '1 FY Warn Ln');
+    await page.fill('#ledger-gst', uniqueGstin());
+    await page.fill('#ledger-phone', '+91 2222222222');
+    await page.click('button:has-text("Create ledger")');
+    await expect(page.locator('h1')).toContainText('Ledger master', { timeout: 10_000 });
+    await expectSuccess(page, 'Ledger created');
+
+    await page.fill('#ledger-search', ledgerName);
+    await page.waitForTimeout(500);
+    const row = page.locator('.table-row', { hasText: ledgerName });
+    await expect(row).toBeVisible({ timeout: 10_000 });
+    await row.locator('[aria-label^="View ledger"]').click();
+    await expect(page.locator('h1')).toContainText(ledgerName, { timeout: 10_000 });
+  }
+
+  test('shows warning when invoice date is outside active FY', async ({ authedPage: page }) => {
+    await activateTestFY(page);
+    await seedLedgerAndNavigate(page);
+
+    await page.click('[aria-label="More ledger actions"]');
+    await page.click('[role="menuitem"][aria-label="Create Invoice"]');
+    const modal = page.locator('.modal-overlay');
+    await expect(modal).toBeVisible({ timeout: 5_000 });
+
+    await modal.locator('#modal-inv-date').fill(DATE_OUTSIDE_FY_BEFORE);
+
+    await expect(modal.locator('.field-warning')).toBeVisible({ timeout: 3_000 });
+    await expect(modal.locator('.field-warning')).toContainText('outside the active financial year');
+    await expect(modal.locator('.field-warning')).toContainText(TEST_FY_LABEL);
+  });
+
+  test('warning disappears when invoice modal date is moved inside FY', async ({ authedPage: page }) => {
+    await activateTestFY(page);
+    await seedLedgerAndNavigate(page);
+
+    await page.click('[aria-label="More ledger actions"]');
+    await page.click('[role="menuitem"][aria-label="Create Invoice"]');
+    const modal = page.locator('.modal-overlay');
+    await expect(modal).toBeVisible({ timeout: 5_000 });
+
+    await modal.locator('#modal-inv-date').fill(DATE_OUTSIDE_FY_BEFORE);
+    await expect(modal.locator('.field-warning')).toBeVisible({ timeout: 3_000 });
+
+    await modal.locator('#modal-inv-date').fill(DATE_INSIDE_FY);
+    await expect(modal.locator('.field-warning')).not.toBeVisible({ timeout: 3_000 });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Record Payment modal on LedgerViewPage
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.describe('FY Date Warning — Payment form (LedgerView)', () => {
+  async function seedLedgerAndOpenPaymentModal(page: import('@playwright/test').Page) {
+    const ledgerName = `FYWarnPay-${Date.now().toString(36)}`;
+    await page.click('[href="/ledgers"]');
+    await page.click('button:has-text("Create ledger")');
+    await expect(page.locator('h1')).toContainText('Create ledger', { timeout: 10_000 });
+    await page.fill('#ledger-name', ledgerName);
+    await page.fill('#ledger-address', '2 FY Pay Ave');
+    await page.fill('#ledger-gst', uniqueGstin());
+    await page.fill('#ledger-phone', '+91 5555555555');
+    await page.click('button:has-text("Create ledger")');
+    await expect(page.locator('h1')).toContainText('Ledger master', { timeout: 10_000 });
+    await expectSuccess(page, 'Ledger created');
+
+    await page.fill('#ledger-search', ledgerName);
+    await page.waitForTimeout(500);
+    const row = page.locator('.table-row', { hasText: ledgerName });
+    await expect(row).toBeVisible({ timeout: 10_000 });
+    await row.locator('[aria-label^="View ledger"]').click();
+    await expect(page.locator('h1')).toContainText(ledgerName, { timeout: 10_000 });
+
+    await page.click('button:has-text("Record Receipt / Payment")');
+    const modal = page.locator('.modal-overlay');
+    await expect(modal).toBeVisible({ timeout: 5_000 });
+    return modal;
+  }
+
+  test('shows warning when payment date is before active FY start', async ({ authedPage: page }) => {
+    await activateTestFY(page);
+    const modal = await seedLedgerAndOpenPaymentModal(page);
+
+    // datetime-local format: YYYY-MM-DDTHH:MM
+    await modal.locator('#pay-date').fill(`${DATE_OUTSIDE_FY_BEFORE}T10:00`);
+
+    await expect(modal.locator('.field-warning')).toBeVisible({ timeout: 3_000 });
+    await expect(modal.locator('.field-warning')).toContainText('outside the active financial year');
+    await expect(modal.locator('.field-warning')).toContainText(TEST_FY_LABEL);
+  });
+
+  test('shows warning when payment date is after active FY end', async ({ authedPage: page }) => {
+    await activateTestFY(page);
+    const modal = await seedLedgerAndOpenPaymentModal(page);
+
+    await modal.locator('#pay-date').fill(`${DATE_OUTSIDE_FY_AFTER}T10:00`);
+
+    await expect(modal.locator('.field-warning')).toBeVisible({ timeout: 3_000 });
+    await expect(modal.locator('.field-warning')).toContainText('outside the active financial year');
+  });
+
+  test('warning disappears when payment date is moved inside FY', async ({ authedPage: page }) => {
+    await activateTestFY(page);
+    const modal = await seedLedgerAndOpenPaymentModal(page);
+
+    await modal.locator('#pay-date').fill(`${DATE_OUTSIDE_FY_BEFORE}T10:00`);
+    await expect(modal.locator('.field-warning')).toBeVisible({ timeout: 3_000 });
+
+    await modal.locator('#pay-date').fill(`${DATE_INSIDE_FY}T10:00`);
+    await expect(modal.locator('.field-warning')).not.toBeVisible({ timeout: 3_000 });
+  });
+});

--- a/frontend/src/components/CreateInvoiceModal.tsx
+++ b/frontend/src/components/CreateInvoiceModal.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react';
 import { useEscapeClose } from '../hooks/useEscapeClose';
 import api, { getApiErrorMessage } from '../api/client';
-import type { InvoiceCreate, Ledger, Product } from '../types/api';
+import type { InvoiceCreate, Invoice, Ledger, Product } from '../types/api';
+import { useFY } from '../context/FYContext';
 import formatCurrency from '../utils/formatting';
 import ProductCombobox from './ProductCombobox';
 import LedgerCombobox from './LedgerCombobox';
@@ -23,8 +24,8 @@ type CreateInvoiceModalProps = {
   /** Pre-selected voucher type */
   preselectedVoucherType?: 'sales' | 'purchase';
   onClose: () => void;
-  /** Called after a successful invoice creation with a success message */
-  onCreated: (message: string) => void;
+  /** Called after a successful invoice creation with a success message and optional FY warning */
+  onCreated: (message: string, warningMessage?: string) => void;
   onError: (message: string) => void;
 };
 
@@ -35,6 +36,7 @@ export default function CreateInvoiceModal({
   onCreated,
   onError,
 }: CreateInvoiceModalProps) {
+  const { activeFY } = useFY();
   const [products, setProducts] = useState<Product[]>([]);
   const [ledgers, setLedgers] = useState<Ledger[]>([]);
   const [selectedLedgerId, setSelectedLedgerId] = useState(preselectedLedgerId ? String(preselectedLedgerId) : '');
@@ -102,6 +104,11 @@ export default function CreateInvoiceModal({
     setItems((c) => c.map((i) => (i.id === id ? { ...i, [key]: value } : i)));
   }
 
+  const isDateOutsideFY =
+    activeFY !== null &&
+    invoiceDate !== '' &&
+    (invoiceDate < activeFY.start_date || invoiceDate > activeFY.end_date);
+
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     try {
@@ -116,11 +123,15 @@ export default function CreateInvoiceModal({
           unit_price: item.unit_price ? Number(item.unit_price) : undefined,
         })),
       };
-      await api.post('/invoices/', payload);
+      const res = await api.post<Invoice>('/invoices/', payload);
       const msg = voucherType === 'sales'
         ? 'Sales invoice created. Inventory has been reduced.'
         : 'Purchase invoice created. Inventory has been increased.';
-      onCreated(msg);
+      const warningMsg =
+        res.data.warnings?.includes('invoice_date_outside_fy') && activeFY
+          ? `⚠️ This date is outside the active financial year (${activeFY.label}). The invoice was still created.`
+          : undefined;
+      onCreated(msg, warningMsg);
     } catch (err) {
       onError(getApiErrorMessage(err, 'Unable to create invoice'));
     } finally {
@@ -184,6 +195,11 @@ export default function CreateInvoiceModal({
                   onChange={(e) => setInvoiceDate(e.target.value)}
                   required
                 />
+                {isDateOutsideFY && activeFY ? (
+                  <p className="field-warning">
+                    ⚠️ This date is outside the active financial year ({activeFY.label}). The invoice will still be created.
+                  </p>
+                ) : null}
               </div>
             </div>
 

--- a/frontend/src/pages/InvoicesPage.tsx
+++ b/frontend/src/pages/InvoicesPage.tsx
@@ -9,6 +9,7 @@ import ProductCombobox from '../components/ProductCombobox';
 import LedgerCombobox from '../components/LedgerCombobox';
 import { useEscapeClose } from '../hooks/useEscapeClose';
 import formatCurrency from '../utils/formatting';
+import { useFY } from '../context/FYContext';
 
 type InvoiceFormItem = {
   id: number;
@@ -27,6 +28,7 @@ function createItem(id: number, productId = '', unitPrice = ''): InvoiceFormItem
 }
 
 export default function InvoicesPage() {
+  const { activeFY } = useFY();
   const [products, setProducts] = useState<Product[]>([]);
   const [ledgers, setLedgers] = useState<Ledger[]>([]);
   const [invoices, setInvoices] = useState<Invoice[]>([]);
@@ -277,12 +279,16 @@ export default function InvoicesPage() {
         await api.put<Invoice>(`/invoices/${editingInvoiceId}`, payload);
         setSuccess('Invoice updated successfully. Inventory has been recalculated.');
       } else {
-        await api.post<Invoice>('/invoices/', payload);
-        setSuccess(
+        const res = await api.post<Invoice>('/invoices/', payload);
+        const baseMsg =
           voucherType === 'sales'
             ? 'Sales invoice created. Inventory has been reduced.'
-            : 'Purchase invoice created. Inventory has been increased.'
-        );
+            : 'Purchase invoice created. Inventory has been increased.';
+        const warningNote =
+          res.data.warnings?.includes('invoice_date_outside_fy') && activeFY
+            ? ` ⚠️ Date is outside the active financial year (${activeFY.label}).`
+            : '';
+        setSuccess(baseMsg + warningNote);
       }
 
       resetInvoiceForm();
@@ -561,6 +567,13 @@ export default function InvoicesPage() {
                   onChange={(event) => setInvoiceDate(event.target.value)}
                   required
                 />
+                {activeFY !== null &&
+                  invoiceDate !== '' &&
+                  (invoiceDate < activeFY.start_date || invoiceDate > activeFY.end_date) ? (
+                  <p className="field-warning">
+                    ⚠️ This date is outside the active financial year ({activeFY.label}). The invoice will still be created.
+                  </p>
+                ) : null}
               </div>
 
               {voucherType === 'purchase' ? (

--- a/frontend/src/pages/LedgerViewPage.tsx
+++ b/frontend/src/pages/LedgerViewPage.tsx
@@ -2,13 +2,14 @@ import { useEffect, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { ArrowLeft, ChevronDown, FileText, FilePlus, Mail, Pencil, ReceiptText } from 'lucide-react';
 import api, { getApiErrorMessage } from '../api/client';
-import type { CompanyProfile, Invoice, Ledger, LedgerStatement, PaymentCreate, Product } from '../types/api';
+import type { CompanyProfile, Invoice, Ledger, LedgerStatement, Payment, PaymentCreate, Product } from '../types/api';
 import InvoicePreview from '../components/InvoicePreview';
 import StatementPreview from '../components/StatementPreview';
 import StatusToasts from '../components/StatusToasts';
 import CreateInvoiceModal from '../components/CreateInvoiceModal';
 import SendEmailModal from '../components/SendEmailModal';
 import formatCurrency from '../utils/formatting';
+import { useFY } from '../context/FYContext';
 
 function defaultDateRange() {
   const today = new Date();
@@ -21,6 +22,7 @@ export default function LedgerViewPage() {
   const { id } = useParams<{ id: string }>();
   const ledgerId = Number(id);
   const navigate = useNavigate();
+  const { activeFY } = useFY();
 
   const [ledger, setLedger] = useState<Ledger | null>(null);
   const [statement, setStatement] = useState<LedgerStatement | null>(null);
@@ -30,6 +32,7 @@ export default function LedgerViewPage() {
   const [loadingLedger, setLoadingLedger] = useState(true);
   const [loadingStatement, setLoadingStatement] = useState(false);
   const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
   const [period, setPeriod] = useState(defaultDateRange);
   const [refreshKey, setRefreshKey] = useState(0);
   const [showPaymentForm, setShowPaymentForm] = useState(false);
@@ -127,7 +130,7 @@ export default function LedgerViewPage() {
     try {
       setSubmittingPayment(true);
       setError('');
-      await api.post('/payments/', paymentForm);
+      const res = await api.post<Payment>('/payments/', paymentForm);
       setShowPaymentForm(false);
       setPaymentForm({
         ledger_id: ledgerId,
@@ -140,6 +143,11 @@ export default function LedgerViewPage() {
       });
       // Refresh statement
       setRefreshKey((k) => k + 1);
+      if (res.data.warnings?.includes('invoice_date_outside_fy') && activeFY) {
+        setSuccess(
+          `⚠️ This date is outside the active financial year (${activeFY.label}). The payment was still recorded.`,
+        );
+      }
     } catch (err) {
       setError(getApiErrorMessage(err, 'Unable to record payment'));
     } finally {
@@ -250,7 +258,12 @@ export default function LedgerViewPage() {
         </div>
       </section>
 
-      <StatusToasts error={error} onClearError={() => setError('')} onClearSuccess={() => {}} />
+      <StatusToasts
+        error={error}
+        success={success}
+        onClearError={() => setError('')}
+        onClearSuccess={() => setSuccess('')}
+      />
 
       <section className="content-grid">
         <article className="panel stack">
@@ -424,6 +437,14 @@ export default function LedgerViewPage() {
                     value={paymentForm.date}
                     onChange={(e) => setPaymentForm((f) => ({ ...f, date: e.target.value }))}
                   />
+                  {activeFY !== null && paymentForm.date && (
+                    paymentForm.date.slice(0, 10) < activeFY.start_date ||
+                    paymentForm.date.slice(0, 10) > activeFY.end_date
+                  ) ? (
+                    <p className="field-warning">
+                      ⚠️ This date is outside the active financial year ({activeFY.label}). The payment will still be recorded.
+                    </p>
+                  ) : null}
                 </div>
                 <div className="field">
                   <label htmlFor="pay-mode">Mode</label>
@@ -484,10 +505,11 @@ export default function LedgerViewPage() {
         <CreateInvoiceModal
           preselectedLedgerId={ledgerId}
           onClose={() => setShowInvoiceModal(false)}
-          onCreated={(msg) => {
+          onCreated={(_msg, warningMsg) => {
             setShowInvoiceModal(false);
             setRefreshKey((k) => k + 1);
             setError('');
+            if (warningMsg) setSuccess(warningMsg);
           }}
           onError={(msg) => setError(msg)}
         />

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -140,6 +140,20 @@ textarea {
   margin: 12px 0;
 }
 
+.field-warning {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 10px 14px;
+  border-radius: 10px;
+  background: rgba(246, 214, 123, 0.15);
+  border: 1px solid rgba(246, 214, 123, 0.4);
+  color: #f6d67b;
+  font-size: 0.84rem;
+  line-height: 1.45;
+  margin-top: 6px;
+}
+
 .topbar__subtitle {
   margin: 8px 0 0;
 }

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -153,6 +153,7 @@ export type Invoice = {
   due_date: string | null;
   created_at: string;
   items: InvoiceItem[];
+  warnings?: string[];
 };
 
 export type InvoiceItem = {
@@ -239,6 +240,7 @@ export type Payment = {
   notes: string | null;
   created_by: number;
   created_at: string;
+  warnings?: string[];
 };
 
 export type PaymentCreate = {


### PR DESCRIPTION
## Summary

Shows an inline yellow warning banner in the invoice creation form (both `InvoicesPage` and `CreateInvoiceModal`) and the payment recording modal in `LedgerViewPage` when the selected date falls outside the active financial year's date range. Also surfaces the backend-returned `warnings: ["invoice_date_outside_fy"]` field in the success toast after creation.

**Changes:**
- `CreateInvoiceModal.tsx` — reads `activeFY` from `useFY()`, shows `.field-warning` banner below invoice date input when date is outside active FY; passes a warning message back via `onCreated(msg, warningMsg?)` callback
- `InvoicesPage.tsx` — same inline warning on the invoice date field; appends FY warning note to success toast when backend returns `warnings`
- `LedgerViewPage.tsx` — inline warning on payment datetime-local input; surfaces payment FY warning as toast after successful record; wires `success` state to `StatusToasts`
- `types/api.ts` — adds optional `warnings?: string[]` to `Invoice` and `Payment` types
- `styles.css` — adds `.field-warning` class (yellow-tinted inline banner)
- `e2e/fy-date-warning.spec.ts` — 8 new Playwright tests covering all three form locations

## Type of change

- [x] feat (new feature)
- [x] test (tests)

## How to test

1. Create a financial year (e.g. 2031-32) and make it active via the nav FY switcher
2. Go to **Invoices** and set a date before `2031-04-01` or after `2032-03-31` — yellow banner should appear under the date field
3. Change the date to one inside the FY — banner disappears
4. Go to any ledger → **More actions → Create Invoice** — same inline warning on the modal date field
5. Go to any ledger → **Record Receipt / Payment** — same warning on the datetime-local input
6. Creation/recording is never blocked by the warning

## Checklist

- [x] My code follows the project style and conventions
- [x] I added/updated tests where appropriate
- [x] I ran relevant checks locally
- [x] I verified this does not break existing behavior
- [x] TypeScript: no `any` types

## Screenshots (if UI changes)

Yellow `.field-warning` banner appears inline under the date field when the chosen date is outside the active FY. Disappears immediately when a valid date is selected.

## Related issue

Closes #209