### PR TITLE
feat(sidebar): convert app-shell to two-column CSS grid layout

### DIFF
--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -70,9 +70,29 @@ textarea {
 }
 
 .app-shell {
-  position: relative;
+  display: grid;
+  grid-template-columns: var(--sidebar-width) 1fr;
+  grid-template-rows: 1fr;
+  grid-template-areas: "sidebar main";
   min-height: 100vh;
-  padding: 32px clamp(20px, 4vw, 48px) 48px;
+}
+
+.app-shell__sidebar {
+  /* left column — sidebar lives here */
+  grid-area: sidebar;
+  grid-column: 1;
+  grid-row: 1;
+}
+
+.app-shell__main {
+  /* right column — topbar + page content */
+  grid-area: main;
+  grid-column: 2;
+  grid-row: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  padding: 0;               /* padding moves to inner elements */
 }
 
 .app-shell__backdrop {
@@ -319,6 +339,7 @@ textarea {
 .page-frame {
   display: grid;
   gap: 20px;
+  padding: 32px clamp(20px, 4vw, 48px) 48px;
 }
 
 .page-hero {
@@ -1274,6 +1295,20 @@ textarea {
   }
 
   .app-shell {
+    grid-template-columns: 1fr;
+    grid-template-areas: "main";
+  }
+
+  .app-shell__sidebar {
+    display: none;
+  }
+
+  .app-shell__main {
+    grid-column: 1;
+    grid-area: main;
+  }
+
+  .page-frame {
     padding: 20px 14px 32px;
   }
 


### PR DESCRIPTION
## Summary

Converts `.app-shell` from a single-column vertical stack to a two-column CSS grid so the sidebar occupies the left rail and main content fills the rest. Also adds `.app-shell__sidebar` and `.app-shell__main` subclasses, moves breathing room padding to `.page-frame`, and collapses to single column on mobile (≤720px).

## Type of change
- [x] New feature (non-breaking)

## How to test
1. At 1280px+ viewport, verify the left rail (240px) and main content are side by side.
2. Verify backdrop blur blobs do not bleed visually into the sidebar column.
3. Verify `.page-frame` has equivalent breathing room as before.
4. At ≤720px, sidebar column collapses and main takes full width.

## Checklist
- [x] Two-column grid at 1280px+ without overflow
- [x] `.page-frame` has equivalent padding breathing room
- [x] Mobile responsive rule updated
- [x] No existing selectors changed

Closes #225