### PR TITLE
feat(sidebar): create Sidebar.tsx component shell with brand header

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -5,6 +5,7 @@ import { Link, NavLink, useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import { useFY } from '../context/FYContext';
 import { useShortcuts } from '../context/ShortcutsContext';
+import Sidebar from './Sidebar';
 
 function fyFromStartYear(year: number) {
   const end = year + 1;
@@ -75,6 +76,10 @@ export default function Layout({ children }: { children: React.ReactNode }) {
 
   return (
     <div className="app-shell">
+      <div className="app-shell__sidebar">
+        <Sidebar />
+      </div>
+      <div className="app-shell__main">
       <div className="app-shell__backdrop app-shell__backdrop--left" />
       <div className="app-shell__backdrop app-shell__backdrop--right" />
       <header className="topbar">
@@ -368,6 +373,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
       >
         {children}
       </motion.main>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,0 +1,17 @@
+export default function Sidebar() {
+  return (
+    <aside className="sidebar">
+      <div className="sidebar__header">
+        <div className="sidebar__brand">
+          <span>⚡</span>
+          <div>
+            <span className="sidebar__brand-name">Simple Invoicing</span>
+            <span className="sidebar__brand-tagline">Stock &amp; billing</span>
+          </div>
+        </div>
+      </div>
+      {/* nav groups added in B-2 */}
+      {/* footer added in B-3 */}
+    </aside>
+  );
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -95,6 +95,46 @@ textarea {
   padding: 0;               /* padding moves to inner elements */
 }
 
+/* ── Sidebar ──────────────────────────────────────────────────────── */
+.sidebar {
+  grid-area: sidebar;
+  width: var(--sidebar-width);
+  height: 100vh;
+  position: sticky;
+  top: 0;
+  background: var(--sidebar-bg);
+  border-right: 1px solid var(--sidebar-border);
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  z-index: 10;
+}
+
+.sidebar__header {
+  padding: 20px 16px 16px;
+  border-bottom: 1px solid var(--sidebar-border);
+}
+
+.sidebar__brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.sidebar__brand-name {
+  font-family: 'Space Grotesk', sans-serif;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--sidebar-text);
+  display: block;
+}
+
+.sidebar__brand-tagline {
+  font-size: 0.7rem;
+  color: var(--sidebar-muted);
+  display: block;
+}
+
 .app-shell__backdrop {
   position: fixed;
   inset: auto;


### PR DESCRIPTION
## Summary

Creates the `Sidebar.tsx` component shell with brand header. Adds `.sidebar`, `.sidebar__header`, `.sidebar__brand`, `.sidebar__brand-name`, and `.sidebar__brand-tagline` CSS classes. Updates `Layout.tsx` to use the two-column grid structure with `.app-shell__sidebar` and `.app-shell__main` wrappers.

## Type of change
- [x] New feature (non-breaking)

## How to test
1. Load any authenticated page — "Simple Invoicing / Stock & billing" brand should appear in the left rail.
2. Verify no existing navigation or visual tests are broken.

## Checklist
- [x] `Sidebar.tsx` file exists and renders without errors
- [x] Brand logo/name visible in the left rail
- [x] `Layout.tsx` uses grid wrappers

Closes #226