### PR TITLE
feat(sidebar): add navigation groups with active-state links to Sidebar.tsx

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,4 +1,29 @@
+import { NavLink } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+
+type NavItem = { to: string; label: string; end?: boolean };
+
+const mainGroup: NavItem[] = [
+  { to: '/', label: 'Overview', end: true },
+  { to: '/invoices', label: 'Invoices' },
+  { to: '/day-book', label: 'Day Book' },
+];
+
+const managementGroup: NavItem[] = [
+  { to: '/products', label: 'Products' },
+  { to: '/inventory', label: 'Inventory' },
+  { to: '/ledgers', label: 'Ledgers' },
+  { to: '/company', label: 'Company' },
+];
+
+const settingsGroup = (isAdmin: boolean): NavItem[] => [
+  ...(isAdmin ? [{ to: '/smtp-settings', label: 'SMTP Settings' }] : []),
+  { to: '/shortcuts', label: 'Keyboard Shortcuts' },
+];
+
 export default function Sidebar() {
+  const { isAdmin } = useAuth();
+
   return (
     <aside className="sidebar">
       <div className="sidebar__header">
@@ -10,8 +35,59 @@ export default function Sidebar() {
           </div>
         </div>
       </div>
-      {/* nav groups added in B-2 */}
+
+      <nav className="sidebar__nav" aria-label="Sidebar navigation">
+        {/* Main group — no label */}
+        <div className="sidebar__group">
+          {mainGroup.map((item) => (
+            <NavLink
+              key={item.to}
+              to={item.to}
+              end={item.end}
+              className={({ isActive }) =>
+                `sidebar__link${isActive ? ' sidebar__link--active' : ''}`
+              }
+            >
+              {item.label}
+            </NavLink>
+          ))}
+        </div>
+
+        {/* Management group */}
+        <div className="sidebar__group">
+          <p className="sidebar__group-label">Management</p>
+          {managementGroup.map((item) => (
+            <NavLink
+              key={item.to}
+              to={item.to}
+              className={({ isActive }) =>
+                `sidebar__link${isActive ? ' sidebar__link--active' : ''}`
+              }
+            >
+              {item.label}
+            </NavLink>
+          ))}
+        </div>
+
+        {/* Settings group */}
+        <div className="sidebar__group">
+          <p className="sidebar__group-label">Settings</p>
+          {settingsGroup(isAdmin).map((item) => (
+            <NavLink
+              key={item.to}
+              to={item.to}
+              className={({ isActive }) =>
+                `sidebar__link${isActive ? ' sidebar__link--active' : ''}`
+              }
+            >
+              {item.label}
+            </NavLink>
+          ))}
+        </div>
+      </nav>
+
       {/* footer added in B-3 */}
     </aside>
   );
 }
+

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -135,6 +135,53 @@ textarea {
   display: block;
 }
 
+.sidebar__nav {
+  flex: 1;
+  padding: 12px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.sidebar__group {
+  margin-bottom: 8px;
+}
+
+.sidebar__group-label {
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--sidebar-section-label);
+  padding: 8px 8px 4px;
+  margin: 0;
+}
+
+.sidebar__link {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 10px;
+  border-radius: 10px;
+  color: var(--sidebar-muted);
+  font-size: 0.875rem;
+  font-weight: 500;
+  border: 1px solid transparent;
+  transition: all 150ms ease;
+}
+
+.sidebar__link:hover {
+  color: var(--sidebar-text);
+  background: var(--sidebar-hover-bg);
+}
+
+.sidebar__link--active {
+  color: var(--sidebar-active-text);
+  background: var(--sidebar-active-bg);
+  border-color: var(--sidebar-active-border);
+  font-weight: 600;
+}
+
 .app-shell__backdrop {
   position: fixed;
   inset: auto;


### PR DESCRIPTION
## Summary

Adds navigation groups (Main, Management, Settings) to `Sidebar.tsx` using `NavLink` from react-router-dom. Active state is driven by `--sidebar-active-*` tokens. Admin-only SMTP Settings link hidden for non-admin users via `isAdmin` from `useAuth`. Nav link CSS added to `styles.css`.

## Type of change
- [x] New feature (non-breaking)

## How to test
1. Navigate between pages — the active link should be visually highlighted in the sidebar.
2. Log in as non-admin user — SMTP Settings link should not appear.
3. Log in as admin — SMTP Settings link appears in Settings group.
4. All existing nav links (`[href="..."]`) still work for e2e tests.

## Checklist
- [x] All nav routes present and functioning
- [x] Active link visually highlighted
- [x] Admin-only SMTP link hidden for non-admin users
- [x] No console errors

Closes #227