### PR TITLE
feat(sidebar): add sticky user/logout footer to Sidebar.tsx

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -35,7 +35,7 @@ function fyFromStartYear(year: number) {
 }
 
 export default function Sidebar() {
-  const { isAdmin } = useAuth();
+  const { isAdmin, userEmail, logout } = useAuth();
   const { activeFY, fyList, switchFY, createFY } = useFY();
 
   const [fyDropdownOpen, setFyDropdownOpen] = useState(false);
@@ -207,6 +207,21 @@ export default function Sidebar() {
               </div>
             )}
           </div>
+        </div>
+
+        <div className="sidebar__footer">
+          <div className="sidebar__user">
+            <div className="sidebar__user-avatar">
+              {userEmail ? userEmail[0].toUpperCase() : 'U'}
+            </div>
+            <div>
+              <span className="sidebar__user-email">{userEmail ?? 'Active user'}</span>
+              <span className="sidebar__user-role">{isAdmin ? 'Admin' : 'User'}</span>
+            </div>
+          </div>
+          <button className="button button--ghost" onClick={logout}>
+            Logout
+          </button>
         </div>
       </aside>
 

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -182,6 +182,50 @@ textarea {
   font-weight: 600;
 }
 
+.sidebar__footer {
+  margin-top: auto;
+  padding: 12px 16px;
+  border-top: 1px solid var(--sidebar-border);
+  background: var(--sidebar-footer-bg);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.sidebar__user {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.sidebar__user-avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: var(--sidebar-active-bg);
+  border: 1px solid var(--sidebar-active-border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: var(--sidebar-active-text);
+  flex-shrink: 0;
+}
+
+.sidebar__user-email {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--sidebar-text);
+  display: block;
+}
+
+.sidebar__user-role {
+  font-size: 0.68rem;
+  color: var(--sidebar-muted);
+  display: block;
+}
+
 .app-shell__backdrop {
   position: fixed;
   inset: auto;


### PR DESCRIPTION
## Summary\n\nAdds a sticky user/logout footer to the bottom of `Sidebar.tsx` as part of the Sidebar Navigation Redesign epic (Phase B-4).\n\n## Changes\n\n### `Sidebar.tsx`\n- Destructure `userEmail` and `logout` from `useAuth()`\n- Add `.sidebar__footer` section pinned to the bottom of the sidebar (`margin-top: auto`) with:\n  - User avatar circle showing the first letter of the email\n  - User email and role (Admin/User) display\n  - Logout button\n\n### `styles.css`\n- Add `.sidebar__footer`, `.sidebar__user`, `.sidebar__user-avatar`, `.sidebar__user-email`, `.sidebar__user-role` CSS rules\n\n## Type of change\n- [x] New feature\n\n## How to test\n1. Log in as admin — sidebar footer shows email initial in avatar, email address, \"Admin\" role, and Logout button\n2. Click Logout — redirects to `/login`\n3. Footer stays pinned to the bottom even with few nav items\n\n## Checklist\n- [x] TypeScript compilation clean (`tsc --noEmit`)\n- [x] No breaking changes to existing tests\n\nCloses #229