### PR TITLE
feat(sidebar): replace topbar with slim sticky page-header in content column

### DIFF
--- a/frontend/e2e/navigation.spec.ts
+++ b/frontend/e2e/navigation.spec.ts
@@ -29,11 +29,11 @@ test.describe('Navigation', () => {
   test('brand link navigates to dashboard', async ({ authedPage: page }) => {
     await page.click('[href="/products"]');
     await expect(page.locator('h1')).toContainText('Catalog intake');
-    await page.locator('.brand-mark').click();
+    await page.locator('a.sidebar__brand').click();
     await expect(page.locator('h1')).toContainText('Operations dashboard');
   });
 
-  test('shows "Signed in as" in header', async ({ authedPage: page }) => {
-    await expect(page.getByText('Signed in as')).toBeVisible();
+  test('shows user info in sidebar footer', async ({ authedPage: page }) => {
+    await expect(page.locator('.sidebar__user-email')).toBeVisible();
   });
 });

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -6,7 +6,7 @@ import { useShortcuts } from '../context/ShortcutsContext';
 import Sidebar from './Sidebar';
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  const { logout, userEmail, isAdmin } = useAuth();
+  const { isAdmin } = useAuth();
   const location = useLocation();
   const { registerAction } = useShortcuts();
   const navigate = useNavigate();
@@ -53,32 +53,9 @@ export default function Layout({ children }: { children: React.ReactNode }) {
       <div className="app-shell__main">
       <div className="app-shell__backdrop app-shell__backdrop--left" />
       <div className="app-shell__backdrop app-shell__backdrop--right" />
-      <header className="topbar">
-        <div className="topbar__top">
-          <div>
-            <Link to="/" className="brand-mark">Simple Invoicing</Link>
-            <p className="topbar__subtitle">
-              Stock, billing, and operator workflows in one place.
-            </p>
-          </div>
-          <button
-            className="burger-btn"
-            onClick={() => setDrawerOpen(true)}
-            aria-label="Open navigation"
-          >
-            <span className="burger-btn__bar" />
-            <span className="burger-btn__bar" />
-            <span className="burger-btn__bar" />
-          </button>
-        </div>
-        <div className="topbar__session">
-          <div>
-            <p className="eyebrow">Signed in as</p>
-            <p className="session-email">{userEmail ?? 'Active user'}</p>
-          </div>
-          <button className="button button--ghost" onClick={logout} title="Logout" aria-label="Logout">
-            Logout
-          </button>
+      <header className="page-header">
+        <div className="page-header__shortcut-hint">
+          Press <kbd>?</kbd> for shortcuts
         </div>
       </header>
 

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import axios from 'axios';
 import { AnimatePresence, motion } from 'framer-motion';
-import { NavLink } from 'react-router-dom';
+import { Link, NavLink } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import { useFY } from '../context/FYContext';
 
@@ -60,13 +60,13 @@ export default function Sidebar() {
     <>
       <aside className="sidebar">
         <div className="sidebar__header">
-          <div className="sidebar__brand">
+          <Link to="/" className="sidebar__brand">
             <span>⚡</span>
             <div>
               <span className="sidebar__brand-name">Simple Invoicing</span>
               <span className="sidebar__brand-tagline">Stock &amp; billing</span>
             </div>
-          </div>
+          </Link>
         </div>
 
         <nav className="sidebar__nav" aria-label="Sidebar navigation">

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -249,6 +249,33 @@ textarea {
   background: rgba(79, 125, 255, 0.18);
 }
 
+.page-header {
+  height: 52px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding: 0 clamp(16px, 3vw, 36px);
+  border-bottom: 1px solid var(--line);
+  background: rgba(8, 17, 31, 0.75);
+  backdrop-filter: blur(12px);
+  position: sticky;
+  top: 0;
+  z-index: 5;
+}
+
+.page-header__shortcut-hint {
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+.page-header__shortcut-hint kbd {
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  padding: 1px 5px;
+  font-size: 0.7rem;
+}
+
 .topbar,
 .page-frame,
 .section-card {


### PR DESCRIPTION
## Summary\n\nReplaces the full-width `.topbar` (brand + session + burger) with a slim sticky `.page-header` bar that sits above the page content column only (Phase C-1 of Sidebar Navigation Redesign).\n\n## Changes\n\n### `Layout.tsx`\n- Remove topbar JSX (`<header className=\"topbar\">` with brand-mark, topbar__session, logout button, burger)\n- Add slim `<header className=\"page-header\">` with keyboard shortcut hint\n- Remove `logout` and `userEmail` from `useAuth()` (now handled by `Sidebar.tsx`)\n\n### `Sidebar.tsx`\n- Wrap `.sidebar__brand` in `<Link to=\"/\">` so clicking the brand navigates home\n- Import `Link` from `react-router-dom`\n\n### `styles.css`\n- Add `.page-header` (height 52px, sticky top, blurred background)\n- Add `.page-header__shortcut-hint` and `kbd` styling\n\n### `e2e/navigation.spec.ts`\n- Update brand-link test: `.brand-mark` → `a.sidebar__brand`\n- Update session test: `'Signed in as'` → user email visible in `.sidebar__user-email`\n\n## Type of change\n- [x] New feature\n\n## How to test\n1. Log in — slim page header visible at top of content column with \"Press ? for shortcuts\" hint\n2. Click the sidebar brand (⚡ Simple Invoicing) — navigates to dashboard\n3. Old topbar is gone\n\n## Checklist\n- [x] TypeScript compilation clean (`tsc --noEmit`)\n- [x] Updated e2e navigation tests\n\nCloses #230