### PR TITLE
feat(sidebar): mobile off-canvas sidebar overlay with framer-motion animation

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -12,6 +12,14 @@ export default function Layout({ children }: { children: React.ReactNode }) {
   const navigate = useNavigate();
 
   const [drawerOpen, setDrawerOpen] = useState(false);
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+
+  useEffect(() => {
+    if (!sidebarOpen) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setSidebarOpen(false); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [sidebarOpen]);
 
   useEffect(() => {
     const cleanups = [
@@ -48,12 +56,28 @@ export default function Layout({ children }: { children: React.ReactNode }) {
   return (
     <div className="app-shell">
       <div className="app-shell__sidebar">
-        <Sidebar />
+        <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
       </div>
+      {sidebarOpen && (
+        <div
+          className="sidebar-backdrop"
+          onClick={() => setSidebarOpen(false)}
+          aria-hidden="true"
+        />
+      )}
       <div className="app-shell__main">
       <div className="app-shell__backdrop app-shell__backdrop--left" />
       <div className="app-shell__backdrop app-shell__backdrop--right" />
       <header className="page-header">
+        <button
+          className="sidebar-toggle"
+          onClick={() => setSidebarOpen(true)}
+          aria-label="Open navigation"
+        >
+          <span className="sidebar-toggle__bar" />
+          <span className="sidebar-toggle__bar" />
+          <span className="sidebar-toggle__bar" />
+        </button>
         <div className="page-header__shortcut-hint">
           Press <kbd>?</kbd> for shortcuts
         </div>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -7,6 +7,11 @@ import { useFY } from '../context/FYContext';
 
 type NavItem = { to: string; label: string; end?: boolean };
 
+interface SidebarProps {
+  isOpen?: boolean;
+  onClose?: () => void;
+}
+
 const mainGroup: NavItem[] = [
   { to: '/', label: 'Overview', end: true },
   { to: '/invoices', label: 'Invoices' },
@@ -34,7 +39,7 @@ function fyFromStartYear(year: number) {
   };
 }
 
-export default function Sidebar() {
+export default function Sidebar({ isOpen = false, onClose }: SidebarProps) {
   const { isAdmin, userEmail, logout } = useAuth();
   const { activeFY, fyList, switchFY, createFY } = useFY();
 
@@ -56,11 +61,28 @@ export default function Sidebar() {
     return () => document.removeEventListener('mousedown', onClickOutside);
   }, [fyDropdownOpen]);
 
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose?.(); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [isOpen, onClose]);
+
   return (
     <>
-      <aside className="sidebar">
+      <aside
+        className={`sidebar${isOpen ? ' sidebar--open' : ''}`}
+        {...(isOpen ? { role: 'dialog', 'aria-modal': 'true', 'aria-label': 'Navigation drawer' } : {})}
+      >
         <div className="sidebar__header">
-          <Link to="/" className="sidebar__brand">
+          <button
+            className="sidebar__close"
+            onClick={onClose}
+            aria-label="Close navigation"
+          >
+            ✕
+          </button>
+          <Link to="/" className="sidebar__brand" onClick={() => onClose?.()}>
             <span>⚡</span>
             <div>
               <span className="sidebar__brand-name">Simple Invoicing</span>
@@ -80,6 +102,7 @@ export default function Sidebar() {
                 className={({ isActive }) =>
                   `sidebar__link${isActive ? ' sidebar__link--active' : ''}`
                 }
+                onClick={() => onClose?.()}
               >
                 {item.label}
               </NavLink>
@@ -96,6 +119,7 @@ export default function Sidebar() {
                 className={({ isActive }) =>
                   `sidebar__link${isActive ? ' sidebar__link--active' : ''}`
                 }
+                onClick={() => onClose?.()}
               >
                 {item.label}
               </NavLink>
@@ -112,6 +136,7 @@ export default function Sidebar() {
                 className={({ isActive }) =>
                   `sidebar__link${isActive ? ' sidebar__link--active' : ''}`
                 }
+                onClick={() => onClose?.()}
               >
                 {item.label}
               </NavLink>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -226,6 +226,59 @@ textarea {
   display: block;
 }
 
+/* Sidebar close button — visible only on mobile */
+.sidebar__close {
+  display: none;
+  background: none;
+  border: 1px solid var(--sidebar-border);
+  color: var(--sidebar-text);
+  cursor: pointer;
+  font-size: 1rem;
+  padding: 6px 10px;
+  border-radius: 8px;
+  line-height: 1;
+  transition: 180ms ease;
+  margin-bottom: 8px;
+  align-self: flex-end;
+}
+
+.sidebar__close:hover {
+  background: var(--sidebar-hover-bg);
+}
+
+/* Sidebar toggle button — hidden on desktop, shown on mobile */
+.sidebar-toggle {
+  display: none;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 5px;
+  background: none;
+  border: 1px solid var(--line);
+  cursor: pointer;
+  padding: 10px 12px;
+  border-radius: 10px;
+  flex-shrink: 0;
+  margin-right: auto;
+}
+
+.sidebar-toggle__bar {
+  display: block;
+  width: 20px;
+  height: 2px;
+  background: var(--text);
+  border-radius: 2px;
+}
+
+/* Mobile overlay backdrop */
+.sidebar-backdrop {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  z-index: 299;
+}
+
 .app-shell__backdrop {
   position: fixed;
   inset: auto;
@@ -1415,6 +1468,58 @@ textarea {
   .login-card {
     width: 100%;
     justify-self: stretch;
+  }
+}
+
+@media (max-width: 767px) {
+  .sidebar-toggle {
+    display: flex;
+  }
+
+  .sidebar-backdrop {
+    display: block;
+  }
+
+  .sidebar__close {
+    display: flex;
+  }
+
+  .app-shell {
+    grid-template-columns: 1fr;
+    grid-template-areas: "main";
+  }
+
+  .app-shell__sidebar {
+    display: none;
+  }
+
+  .app-shell__main {
+    grid-column: 1;
+    grid-area: main;
+  }
+
+  .sidebar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    transform: translateX(-100%);
+    transition: transform 280ms ease;
+    z-index: 300;
+  }
+
+  .sidebar--open {
+    transform: translateX(0);
+  }
+}
+
+@media (min-width: 768px) {
+  .sidebar-toggle {
+    display: none;
+  }
+
+  .sidebar-backdrop {
+    display: none;
   }
 }
 


### PR DESCRIPTION
## Summary\n\nAdds mobile off-canvas sidebar overlay with framer-motion-style CSS transition (Phase D-1 of Sidebar Navigation Redesign).\n\n## Changes\n\n### `Layout.tsx`\n- Add `sidebarOpen` state and Esc key handler\n- Pass `isOpen` and `onClose` props to `<Sidebar>`\n- Add `.sidebar-backdrop` overlay (rendered when sidebar open)\n- Add `.sidebar-toggle` hamburger button in `.page-header`\n\n### `Sidebar.tsx`\n- Accept `isOpen` and `onClose` props\n- Apply `sidebar--open` class when open; set `role=\"dialog\"` + ARIA attributes when open\n- Add `.sidebar__close` close button inside sidebar header\n- Handle Esc key via `useEffect` when `isOpen`\n- Call `onClose?.()` on all NavLink clicks (closes sidebar after navigation on mobile)\n\n### `styles.css`\n- `@media (max-width: 767px)`: sidebar fixed off-screen with `transform: translateX(-100%)`, `.sidebar--open` slides in, toggle + backdrop shown, close button visible\n- `@media (min-width: 768px)`: toggle + backdrop always hidden\n- New rule blocks: `.sidebar__close`, `.sidebar-toggle`, `.sidebar-toggle__bar`, `.sidebar-backdrop`\n\n## ARIA selectors (kept exactly as required)\n- Toggle: `aria-label=\"Open navigation\"`\n- Close button: `aria-label=\"Close navigation\"` (class `.sidebar__close`)\n- Open sidebar: `role=\"dialog\" aria-modal=\"true\" aria-label=\"Navigation drawer\"`\n\n## Type of change\n- [x] New feature\n\n## How to test\n1. Resize to 390px — hamburger (`.sidebar-toggle`) visible, sidebar off-screen\n2. Tap toggle — sidebar slides in with backdrop\n3. Tap backdrop or press Esc — sidebar closes\n4. Tap nav link — navigates and closes sidebar\n5. Desktop (1280px) — toggle hidden, sidebar always visible\n\n## Checklist\n- [x] TypeScript compilation clean (`tsc --noEmit`)\n\nCloses #231