### PR TITLE
fix(sidebar): remove display:none on app-shell__sidebar so fixed sidebar renders on mobile

### DIFF
--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1324,7 +1324,7 @@ textarea {
   }
 
   .app-shell__sidebar {
-    display: none;
+    /* removed from grid flow; sidebar is fixed-positioned on mobile */
   }
 
   .app-shell__main {


### PR DESCRIPTION
## Summary\n\nThe hamburger toggle on XS/SM viewports opened the sidebar but nothing was visible. The root cause: `.app-shell__sidebar` had `display: none` inside `@media (max-width: 767px)`, which removes the element from the DOM and prevents the fixed-position `.sidebar` inside it from rendering at all.\n\nSince the sidebar is `position: fixed` on mobile (out of the grid flow), the wrapper element does not need `display: none` to be visually hidden — the `transform: translateX(-100%)` on `.sidebar` already hides it off-screen. Removing `display: none` restores rendering so `.sidebar--open` can slide it into view.\n\n## Type of change\n- [x] Bug fix\n\n## How to test\n1. Resize viewport to 390px\n2. Tap the hamburger icon — sidebar slides in correctly\n3. Tap backdrop or Esc — sidebar closes