### PR TITLE
test(e2e): add sidebar.spec.ts with sidebar-specific tests

### DIFF
--- a/frontend/e2e/sidebar.spec.ts
+++ b/frontend/e2e/sidebar.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from './fixtures';
+
+test.describe('Sidebar', () => {
+  // 1. Sidebar visible on desktop
+  test('sidebar is visible on desktop viewport', async ({ authedPage: page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await expect(page.locator('.sidebar')).toBeVisible();
+  });
+
+  // 2. Active link highlighted
+  test('active nav link is highlighted on current route', async ({ authedPage: page }) => {
+    await page.goto('/invoices');
+    await expect(page.locator('.sidebar__link--active[href="/invoices"]')).toBeVisible();
+  });
+
+  // 3. All nav groups present
+  test('sidebar renders Management and Settings groups', async ({ authedPage: page }) => {
+    await expect(page.locator('.sidebar__group-label', { hasText: 'Management' })).toBeVisible();
+    await expect(page.locator('.sidebar__group-label', { hasText: 'Settings' })).toBeVisible();
+  });
+
+  // 4. User email visible in footer
+  test('sidebar footer shows user email', async ({ authedPage: page }) => {
+    await expect(page.locator('.sidebar__user-email')).toBeVisible();
+    const email = await page.locator('.sidebar__user-email').textContent();
+    expect(email?.trim().length).toBeGreaterThan(0);
+  });
+
+  // 5. FY switcher in sidebar
+  test('FY switcher section visible in sidebar', async ({ authedPage: page }) => {
+    await expect(page.locator('.sidebar').getByText('Financial Year')).toBeVisible();
+    await expect(page.locator('button[aria-haspopup="listbox"]')).toBeVisible();
+  });
+
+  // 6. Sidebar persists across page navigation
+  test('sidebar stays visible when navigating between pages', async ({ authedPage: page }) => {
+    await page.click('[href="/products"]');
+    await expect(page.locator('.sidebar')).toBeVisible();
+    await page.click('[href="/invoices"]');
+    await expect(page.locator('.sidebar')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

Adds `e2e/sidebar.spec.ts` — a new Playwright spec covering sidebar-specific behaviour that wasn't tested before. This completes Phase F-5 of the Sidebar Navigation Redesign epic.

Six tests covering:
1. Sidebar visible on desktop viewport (`.sidebar` is visible at 1280×800)
2. Active nav link is highlighted on the current route (`.sidebar__link--active` selector)
3. Sidebar renders Management and Settings nav groups (`.sidebar__group-label`)
4. Sidebar footer shows the authenticated user's email (`.sidebar__user-email`)
5. FY switcher section is visible in the sidebar (`Financial Year` label + `button[aria-haspopup="listbox"]`)
6. Sidebar stays visible when navigating between pages

All 6 tests pass locally against the dev stack (`http://localhost:5173`).

## Type of change

- [x] test (tests)

## How to test

```
cd frontend
npx playwright test sidebar --reporter=list
```

Expected: 6/6 tests pass.

## Checklist

- [x] My code follows the project style and conventions
- [x] I added/updated tests where appropriate
- [x] I updated docs where needed
- [x] I ran relevant checks locally
- [x] I verified this does not break existing behavior

## Related issue

Closes #237
