### PR TITLE
fix(invoices): show formatted invoice number in cancel confirmation dialog

### DIFF
--- a/frontend/src/pages/InvoicesPage.tsx
+++ b/frontend/src/pages/InvoicesPage.tsx
@@ -82,6 +82,7 @@ export default function InvoicesPage() {
   const [restoringInvoiceId, setRestoringInvoiceId] = useState<number | null>(null);
   const [showCancelDialog, setShowCancelDialog] = useState(false);
   const [pendingCancelInvoiceId, setPendingCancelInvoiceId] = useState<number | null>(null);
+  const [pendingCancelInvoiceNumber, setPendingCancelInvoiceNumber] = useState<string | null>(null);
   const [showCancelled, setShowCancelled] = useState(false);
   const [previewInvoice, setPreviewInvoice] = useState<Invoice | null>(null);
   const [loading, setLoading] = useState(true);
@@ -334,14 +335,16 @@ export default function InvoicesPage() {
     }
   }
 
-  async function handleCancelInvoice(invoiceId: number) {
+  async function handleCancelInvoice(invoiceId: number, invoiceNumber: string | null) {
     setPendingCancelInvoiceId(invoiceId);
+    setPendingCancelInvoiceNumber(invoiceNumber);
     setShowCancelDialog(true);
   }
 
   function dismissCancelDialog() {
     setShowCancelDialog(false);
     setPendingCancelInvoiceId(null);
+    setPendingCancelInvoiceNumber(null);
   }
 
   async function confirmCancelInvoice() {
@@ -950,7 +953,7 @@ export default function InvoicesPage() {
                           <button
                             type="button"
                             className="button button--danger button--icon"
-                            onClick={() => void handleCancelInvoice(invoice.id)}
+                            onClick={() => void handleCancelInvoice(invoice.id, invoice.invoice_number)}
                             disabled={cancellingInvoiceId === invoice.id}
                             title="Cancel invoice"
                             aria-label={`Cancel invoice ${invoice.invoice_number || invoice.id}`}
@@ -1340,7 +1343,7 @@ export default function InvoicesPage() {
 
       {showCancelDialog ? (
         <ConfirmDialog
-          message={`Are you sure you want to cancel invoice #${pendingCancelInvoiceId}? Inventory will be reversed. The invoice will remain visible when showing cancelled invoices.`}
+          message={`Are you sure you want to cancel invoice ${pendingCancelInvoiceNumber ?? `#${pendingCancelInvoiceId}`}? Inventory will be reversed. The invoice will remain visible when showing cancelled invoices.`}
           title="Cancel invoice"
           confirmText="Cancel invoice"
           cancelText="Keep"


### PR DESCRIPTION
## Summary

The cancel confirmation dialog was showing the raw database ID (e.g. `#42`) instead of the formatted invoice number (e.g. `INV-2024-001`). This fix passes the `invoice_number` field through to the dialog and uses it in the message, falling back to `#id` only when the number is null.

## Type of change

- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] docs (documentation)
- [ ] test (tests)
- [ ] chore/refactor

## How to test

1. Open the Invoices page.
2. Click the cancel button on any invoice that has a formatted invoice number.
3. Verify the confirmation dialog displays the formatted invoice number (e.g. `INV-2024-001`) instead of the raw ID.

## Checklist

- [x] My code follows the project style and conventions
- [x] I added/updated tests where appropriate
- [x] I ran relevant checks locally
- [x] I verified this does not break existing behavior

## Screenshots (if UI changes)

_Before:_ "Are you sure you want to cancel invoice #42?"  
_After:_ "Are you sure you want to cancel invoice INV-2024-001?"

## Related issue

Closes #252