### PR TITLE
fix(invoices): use invoice date to determine FY for series number

### DIFF
--- a/backend/src/api/routes/invoices.py
+++ b/backend/src/api/routes/invoices.py
@@ -22,7 +22,7 @@ from src.models.user import User
 from src.schemas.invoice import InvoiceCreate, InvoiceOut, PaginatedInvoiceOut
 from src.api.deps import get_current_user
 from src.services.series import generate_next_number
-from src.services.financial_year import get_active_fy
+from src.services.financial_year import get_active_fy, get_fy_for_date
 
 router = APIRouter()
 
@@ -37,8 +37,14 @@ def _is_interstate_supply(company_gst: str | None, ledger_gst: str | None) -> bo
     return company_gst[:2] != ledger_gst[:2]
 
 
-def _generate_next_number(db: Session, voucher_type: str, financial_year_id: int | None = None) -> str:
-    return generate_next_number(db, voucher_type, financial_year_id)
+def _generate_next_number(
+    db: Session,
+    voucher_type: str,
+    financial_year_id: int | None = None,
+    invoice_date: date | None = None,
+    active_financial_year_id: int | None = None,
+) -> str:
+    return generate_next_number(db, voucher_type, financial_year_id, invoice_date, active_financial_year_id)
 
 
 def _require_ledger(db: Session, ledger_id: int) -> Ledger:
@@ -77,6 +83,7 @@ def _apply_payload_to_invoice(
     payload: InvoiceCreate,
     created_by: int | None = None,
     financial_year_id: int | None = None,
+    active_financial_year_id: int | None = None,
     regenerate_number: bool = True,
 ) -> None:
     ledger = _require_ledger(db, payload.ledger_id)
@@ -114,7 +121,10 @@ def _apply_payload_to_invoice(
 
     invoice.tax_inclusive = payload.tax_inclusive
     if regenerate_number:
-        invoice.invoice_number = _generate_next_number(db, invoice.voucher_type, financial_year_id)
+        invoice.invoice_number = _generate_next_number(
+            db, invoice.voucher_type, financial_year_id, payload.invoice_date,
+            active_financial_year_id,
+        )
 
     if not invoice.company_gst or not invoice.ledger_gst:
         raise HTTPException(
@@ -214,7 +224,15 @@ def create_invoice(
 ):
     try:
         active_fy = get_active_fy(db)
-        fy_id = active_fy.id if active_fy else None
+
+        # Determine which FY this invoice belongs to based on its date.
+        # If the invoice date falls within a different FY, use that FY.
+        fy_for_invoice = active_fy
+        if payload.invoice_date:
+            date_fy = get_fy_for_date(db, payload.invoice_date)
+            if date_fy is not None:
+                fy_for_invoice = date_fy
+        fy_id = fy_for_invoice.id if fy_for_invoice else None
 
         invoice = Invoice(
             total_amount=0,
@@ -226,6 +244,7 @@ def create_invoice(
             db, invoice, payload,
             created_by=current_user.id,
             financial_year_id=fy_id,
+            active_financial_year_id=active_fy.id if active_fy else None,
         )
         db.commit()
         db.refresh(invoice)

--- a/backend/src/services/financial_year.py
+++ b/backend/src/services/financial_year.py
@@ -1,3 +1,4 @@
+from datetime import date
 from typing import Optional
 
 from sqlalchemy.orm import Session
@@ -8,6 +9,18 @@ from src.models.financial_year import FinancialYear
 def get_active_fy(db: Session) -> Optional[FinancialYear]:
     """Return the currently active financial year, or None if none is set."""
     return db.query(FinancialYear).filter(FinancialYear.is_active.is_(True)).first()
+
+
+def get_fy_for_date(db: Session, invoice_date: date) -> Optional[FinancialYear]:
+    """Return the financial year whose range contains invoice_date, or None."""
+    return (
+        db.query(FinancialYear)
+        .filter(
+            FinancialYear.start_date <= invoice_date,
+            FinancialYear.end_date >= invoice_date,
+        )
+        .first()
+    )
 
 
 def activate_fy(db: Session, fy_id: int) -> FinancialYear:

--- a/backend/src/services/series.py
+++ b/backend/src/services/series.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import date, datetime
 from typing import Optional
 
 from sqlalchemy.orm import Session
@@ -7,7 +7,12 @@ from src.models.financial_year import FinancialYear
 from src.models.invoice_series import InvoiceSeries
 
 
-def _format_number(series: InvoiceSeries, seq: int, fy: Optional[FinancialYear]) -> str:
+def _format_number(
+    series: InvoiceSeries,
+    seq: int,
+    fy: Optional[FinancialYear],
+    invoice_date: Optional[date] = None,
+) -> str:
     sep = series.separator
     seq_str = str(seq).zfill(series.pad_digits)
 
@@ -15,23 +20,33 @@ def _format_number(series: InvoiceSeries, seq: int, fy: Optional[FinancialYear])
         if series.year_format == "FY":
             year_part = fy.label if fy else "FY"
         elif series.year_format == "MM-YYYY":
-            now = datetime.utcnow()
-            year_part = now.strftime("%m") + sep + str(now.year)
+            ref = invoice_date if invoice_date is not None else datetime.utcnow().date()
+            year_part = ref.strftime("%m") + sep + str(ref.year)
         else:
-            year_part = str(datetime.utcnow().year)
+            ref = invoice_date if invoice_date is not None else datetime.utcnow().date()
+            year_part = str(ref.year)
         return f"{series.prefix}{sep}{year_part}{sep}{seq_str}"
     else:
         return f"{series.prefix}{sep}{seq_str}"
 
 
 def generate_next_number(
-    db: Session, voucher_type: str, financial_year_id: Optional[int] = None
+    db: Session,
+    voucher_type: str,
+    financial_year_id: Optional[int] = None,
+    invoice_date: Optional[date] = None,
+    active_financial_year_id: Optional[int] = None,
 ) -> str:
     """Atomically increment the series counter and return the formatted number.
 
     Lookup order:
     1. Exact match on (voucher_type, financial_year_id) if provided.
     2. Fall back to a row with NULL financial_year_id for backward compatibility.
+
+    When the invoice belongs to a non-active FY (backdated/forward-dated),
+    format settings (prefix, year_format, separator, etc.) are taken from the
+    active FY's series so the user only needs to configure one place.  The
+    sequence counter and FY label always come from the target FY.
 
     If the generated number already exists in the invoices table (e.g. due to a
     previous rolled-back transaction or cross-FY series overlap), the counter is
@@ -68,12 +83,35 @@ def generate_next_number(
     if not series:
         return "INV-000000"
 
-    # Resolve linked FY label once (only needed for "FY" year_format)
+    # When the invoice is for a different FY than the active one, borrow the
+    # active FY's series for format settings (prefix, year_format, separator,
+    # include_year, pad_digits).  This ensures the user-configured numbering
+    # style is applied consistently even for backdated/forward-dated invoices.
+    format_series = series
+    if (
+        active_financial_year_id is not None
+        and active_financial_year_id != financial_year_id
+    ):
+        active_series = (
+            db.query(InvoiceSeries)
+            .filter(
+                InvoiceSeries.voucher_type == voucher_type,
+                InvoiceSeries.financial_year_id == active_financial_year_id,
+            )
+            .first()
+        )
+        if active_series is not None:
+            format_series = active_series
+
+    # Resolve the FY label for "FY" year_format.  Always use the TARGET FY
+    # (financial_year_id) so a December 2025 invoice gets "2025-26", not "2026-27".
     linked_fy: Optional[FinancialYear] = None
-    if series.include_year and series.year_format == "FY" and series.financial_year_id is not None:
-        linked_fy = db.query(FinancialYear).filter(
-            FinancialYear.id == series.financial_year_id
-        ).first()
+    if format_series.include_year and format_series.year_format == "FY":
+        fy_id_for_label = financial_year_id if financial_year_id is not None else series.financial_year_id
+        if fy_id_for_label is not None:
+            linked_fy = db.query(FinancialYear).filter(
+                FinancialYear.id == fy_id_for_label
+            ).first()
 
     # Advance the counter, skipping any numbers already present in the DB.
     # This guards against rollback-caused repeats and cross-FY series collisions.
@@ -81,7 +119,7 @@ def generate_next_number(
     for _ in range(MAX_SKIP):
         seq = series.next_sequence
         series.next_sequence = seq + 1
-        number = _format_number(series, seq, linked_fy)
+        number = _format_number(format_series, seq, linked_fy, invoice_date)
         existing = db.query(Invoice.id).filter(Invoice.invoice_number == number).first()
         if existing is None:
             return number

--- a/backend/tests/services/test_financial_year_and_series.py
+++ b/backend/tests/services/test_financial_year_and_series.py
@@ -1,0 +1,315 @@
+"""
+Unit tests for:
+  - src.services.financial_year.get_fy_for_date
+  - src.services.series._format_number  (invoice_date parameter)
+  - src.services.series.generate_next_number  (invoice_date + active_financial_year_id)
+"""
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.services.financial_year import get_fy_for_date
+from src.services.series import _format_number, generate_next_number
+from src.models.financial_year import FinancialYear
+from src.models.invoice_series import InvoiceSeries
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+def make_fy(id: int, label: str, start: date, end: date, is_active: bool = False) -> FinancialYear:
+    fy = FinancialYear()
+    fy.id = id
+    fy.label = label
+    fy.start_date = start
+    fy.end_date = end
+    fy.is_active = is_active
+    return fy
+
+
+def make_series(
+    id: int,
+    voucher_type: str = "sales",
+    financial_year_id: int | None = None,
+    prefix: str = "INV",
+    include_year: bool = True,
+    year_format: str = "FY",
+    separator: str = "-",
+    next_sequence: int = 1,
+    pad_digits: int = 3,
+) -> InvoiceSeries:
+    s = InvoiceSeries()
+    s.id = id
+    s.voucher_type = voucher_type
+    s.financial_year_id = financial_year_id
+    s.prefix = prefix
+    s.include_year = include_year
+    s.year_format = year_format
+    s.separator = separator
+    s.next_sequence = next_sequence
+    s.pad_digits = pad_digits
+    return s
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# get_fy_for_date
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestGetFyForDate:
+    def _db(self, result):
+        """Return a mock db whose filter chain returns `result`."""
+        db = MagicMock()
+        db.query().filter().first.return_value = result
+        return db
+
+    def test_returns_matching_fy(self):
+        fy = make_fy(1, "2025-26", date(2025, 4, 1), date(2026, 3, 31))
+        db = self._db(fy)
+        assert get_fy_for_date(db, date(2025, 10, 15)) is fy
+
+    def test_returns_none_when_no_match(self):
+        db = self._db(None)
+        assert get_fy_for_date(db, date(2020, 1, 1)) is None
+
+    def test_boundary_start_date(self):
+        fy = make_fy(1, "2025-26", date(2025, 4, 1), date(2026, 3, 31))
+        db = self._db(fy)
+        assert get_fy_for_date(db, date(2025, 4, 1)) is fy
+
+    def test_boundary_end_date(self):
+        fy = make_fy(1, "2025-26", date(2025, 4, 1), date(2026, 3, 31))
+        db = self._db(fy)
+        assert get_fy_for_date(db, date(2026, 3, 31)) is fy
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _format_number — invoice_date threading
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestFormatNumber:
+    def test_fy_format_uses_fy_label(self):
+        fy = make_fy(1, "2025-26", date(2025, 4, 1), date(2026, 3, 31))
+        s = make_series(1, year_format="FY")
+        assert _format_number(s, 1, fy) == "INV-2025-26-001"
+
+    def test_fy_format_fallback_when_no_fy(self):
+        s = make_series(1, year_format="FY")
+        assert _format_number(s, 1, None) == "INV-FY-001"
+
+    def test_yyyy_uses_invoice_date_year(self):
+        s = make_series(1, year_format="YYYY")
+        result = _format_number(s, 5, None, invoice_date=date(2025, 12, 1))
+        assert result == "INV-2025-005"
+
+    def test_yyyy_falls_back_to_today_when_no_date(self):
+        s = make_series(1, year_format="YYYY")
+        today_year = str(date.today().year)
+        result = _format_number(s, 1, None, invoice_date=None)
+        assert today_year in result
+
+    def test_mm_yyyy_uses_invoice_date_month_and_year(self):
+        s = make_series(1, year_format="MM-YYYY")
+        result = _format_number(s, 3, None, invoice_date=date(2025, 12, 15))
+        assert result == "INV-12-2025-003"
+
+    def test_mm_yyyy_january(self):
+        s = make_series(1, year_format="MM-YYYY")
+        result = _format_number(s, 1, None, invoice_date=date(2026, 1, 1))
+        assert result == "INV-01-2026-001"
+
+    def test_no_year_format(self):
+        s = make_series(1, include_year=False)
+        result = _format_number(s, 7, None, invoice_date=date(2025, 6, 1))
+        assert result == "INV-007"
+
+    def test_custom_separator_and_padding(self):
+        s = make_series(1, year_format="YYYY", separator="/", pad_digits=4)
+        result = _format_number(s, 2, None, invoice_date=date(2025, 4, 1))
+        assert result == "INV/2025/0002"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# generate_next_number — FY-date and format-borrowing
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _make_db_for_generate(
+    target_series: InvoiceSeries | None,
+    active_series: InvoiceSeries | None = None,
+    linked_fy: FinancialYear | None = None,
+    existing_numbers: set[str] | None = None,
+):
+    """
+    Build a mock db suitable for generate_next_number.
+
+    Query routing (in order of appearance in generate_next_number):
+      1. InvoiceSeries (with_for_update) for target FY       → target_series
+      2. InvoiceSeries (with_for_update) for NULL fallback    → only reached if target is None
+      3. InvoiceSeries for active FY format borrowing         → active_series
+      4. FinancialYear for FY label                           → linked_fy
+      5. Invoice for duplicate check                          → None (no collision)
+    """
+    # series_call_count is in _make_db_for_generate scope so that all
+    # db.query(InvoiceSeries) calls share the same counter via closure.
+    series_call_count = {"n": 0}
+
+    def query_side_effect(model):
+        from src.models.invoice import Invoice  # noqa: PLC0415
+
+        mock_q = MagicMock()
+
+        if model is InvoiceSeries:
+            def filter_side(*args, **kwargs):
+                series_call_count["n"] += 1
+                inner = MagicMock()
+                with_update = MagicMock()
+
+                if series_call_count["n"] == 1:
+                    # First call: target FY series lookup (with_for_update path)
+                    with_update.first.return_value = target_series
+                    inner.with_for_update.return_value = with_update
+                    inner.first.return_value = target_series
+                elif series_call_count["n"] == 2 and target_series is None:
+                    # Second call: NULL fy_id fallback (only when target not found)
+                    with_update.first.return_value = None
+                    inner.with_for_update.return_value = with_update
+                    inner.first.return_value = None
+                else:
+                    # Active FY format-borrowing lookup
+                    inner.first.return_value = active_series
+
+                return inner
+
+            mock_q.filter.side_effect = filter_side
+
+        elif model is FinancialYear:
+            inner = MagicMock()
+            inner.first.return_value = linked_fy
+            mock_q.filter.return_value = inner
+
+        else:
+            # Invoice duplicate check — always returns None (no collision)
+            inner = MagicMock()
+            inner.first.return_value = None
+            mock_q.filter.return_value = inner
+
+        return mock_q
+
+    db = MagicMock()
+    db.query.side_effect = query_side_effect
+    return db
+
+
+class TestGenerateNextNumber:
+    def test_returns_fallback_when_no_series(self):
+        db = MagicMock()
+        # Both series lookups return None
+        mock_q = MagicMock()
+        mock_q.filter.return_value.with_for_update.return_value.first.return_value = None
+        mock_q.filter.return_value.first.return_value = None
+        db.query.return_value = mock_q
+        result = generate_next_number(db, "sales")
+        assert result == "INV-000000"
+
+    def test_basic_fy_format_within_active_fy(self):
+        """Generating for the active FY uses the target series + target FY label."""
+        fy = make_fy(10, "2025-26", date(2025, 4, 1), date(2026, 3, 31), is_active=True)
+        target = make_series(1, financial_year_id=10, year_format="FY")
+
+        db = _make_db_for_generate(target_series=target, linked_fy=fy)
+        result = generate_next_number(
+            db,
+            "sales",
+            financial_year_id=10,
+            active_financial_year_id=10,
+        )
+        assert result == "INV-2025-26-001"
+        assert target.next_sequence == 2
+
+    def test_backdated_borrows_active_fy_format_settings(self):
+        """
+        When financial_year_id != active_financial_year_id, format settings
+        come from the active FY's series, but the counter and FY label come
+        from the target FY.
+        """
+        past_fy = make_fy(9, "2024-25", date(2024, 4, 1), date(2025, 3, 31))
+        active_fy = make_fy(10, "2025-26", date(2025, 4, 1), date(2026, 3, 31), is_active=True)
+
+        # Past FY series has stale MM-YYYY format (seeded before user changed it)
+        target = make_series(1, financial_year_id=9, prefix="OLD", year_format="MM-YYYY")
+        # Active FY series has the user-configured FY format
+        active = make_series(2, financial_year_id=10, prefix="RES", year_format="FY")
+
+        db = _make_db_for_generate(
+            target_series=target,
+            active_series=active,
+            linked_fy=past_fy,  # label for the TARGET (past) FY
+        )
+        result = generate_next_number(
+            db,
+            "sales",
+            financial_year_id=9,
+            active_financial_year_id=10,
+        )
+        # Format from active series (RES, FY), label from past FY (2024-25),
+        # sequence from past series
+        assert result == "RES-2024-25-001"
+        assert target.next_sequence == 2  # counter incremented on target series
+
+    def test_invoice_date_used_in_yyyy_format(self):
+        """invoice_date determines the YYYY part, not today's date."""
+        target = make_series(1, financial_year_id=10, year_format="YYYY")
+        db = _make_db_for_generate(target_series=target)
+
+        result = generate_next_number(
+            db,
+            "sales",
+            financial_year_id=10,
+            invoice_date=date(2024, 12, 15),
+            active_financial_year_id=10,
+        )
+        assert result == "INV-2024-001"
+
+    def test_invoice_date_used_in_mm_yyyy_format(self):
+        """invoice_date determines MM-YYYY, not the current month."""
+        target = make_series(1, financial_year_id=10, year_format="MM-YYYY")
+        db = _make_db_for_generate(target_series=target)
+
+        result = generate_next_number(
+            db,
+            "sales",
+            financial_year_id=10,
+            invoice_date=date(2025, 7, 4),
+            active_financial_year_id=10,
+        )
+        assert result == "INV-07-2025-001"
+
+    def test_no_active_fy_id_uses_target_series_format(self):
+        """When active_financial_year_id is None, no format borrowing occurs."""
+        fy = make_fy(10, "2025-26", date(2025, 4, 1), date(2026, 3, 31))
+        target = make_series(1, financial_year_id=10, year_format="FY")
+        db = _make_db_for_generate(target_series=target, linked_fy=fy)
+
+        result = generate_next_number(
+            db,
+            "sales",
+            financial_year_id=10,
+            active_financial_year_id=None,
+        )
+        assert result == "INV-2025-26-001"
+
+    def test_counter_increments_on_target_series_not_active(self):
+        """The counter must advance on the TARGET series, never the active one."""
+        past_fy = make_fy(9, "2024-25", date(2024, 4, 1), date(2025, 3, 31))
+        target = make_series(1, financial_year_id=9, year_format="FY", next_sequence=5)
+        active = make_series(2, financial_year_id=10, prefix="RES", year_format="FY", next_sequence=1)
+
+        db = _make_db_for_generate(
+            target_series=target, active_series=active, linked_fy=past_fy
+        )
+        generate_next_number(
+            db, "sales", financial_year_id=9, active_financial_year_id=10
+        )
+        assert target.next_sequence == 6
+        assert active.next_sequence == 1  # untouched

--- a/frontend/e2e/fy-invoice-series.spec.ts
+++ b/frontend/e2e/fy-invoice-series.spec.ts
@@ -1,0 +1,192 @@
+/**
+ * Tests for invoice series FY-scoping:
+ * - A backdated invoice (date falls in a prior FY) must use that prior FY's
+ *   series counter and label in the invoice number, not the active FY's.
+ * - An invoice dated in the active FY still uses the active FY series.
+ *
+ * We use the far-future years 2031/2032 to avoid conflicts with real data.
+ */
+import { test, expect, expectSuccess, uniqueSku, uniqueGstin, selectComboboxOption } from './fixtures';
+
+// ── FY constants ─────────────────────────────────────────────────────────────
+const PAST_FY_START_YEAR = 2031;
+const PAST_FY_LABEL = '2031-32';
+const PAST_FY_DATE = '2031-10-15'; // inside 2031-04-01 … 2032-03-31
+
+const ACTIVE_FY_START_YEAR = 2032;
+const ACTIVE_FY_LABEL = '2032-33';
+const ACTIVE_FY_DATE = '2032-10-15'; // inside 2032-04-01 … 2033-03-31
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Ensure a financial year exists and activate it.
+ * Creates the FY if missing, then clicks it to activate.
+ * Clicking an FY option calls setFyDropdownOpen(false), so the dropdown is
+ * always closed when this function returns — safe to call multiple times in
+ * sequence.
+ */
+async function ensureAndActivateFY(
+  page: import('@playwright/test').Page,
+  startYear: number,
+  label: string,
+) {
+  const fyButton = page.locator('button[aria-haspopup="listbox"]');
+  await fyButton.click();
+  const listbox = page.locator('[role="listbox"]');
+  await expect(listbox).toBeVisible({ timeout: 5_000 });
+
+  const existing = listbox.locator(`button:has-text("${label}")`).first();
+  if (!(await existing.isVisible())) {
+    await listbox.locator('button:has-text("+ New FY")').click();
+    const dialog = page.locator('[role="dialog"][aria-label="Create new financial year"]');
+    await expect(dialog).toBeVisible({ timeout: 5_000 });
+    await dialog.locator('input[type="number"]').fill(String(startYear));
+    await dialog.locator('button:has-text("Create")').click();
+    await expect(dialog).not.toBeVisible({ timeout: 10_000 });
+    // Reopen the dropdown to activate
+    await fyButton.click();
+    await expect(listbox).toBeVisible({ timeout: 5_000 });
+  }
+
+  // Activate by clicking the FY option — this also calls setFyDropdownOpen(false)
+  await listbox.locator(`button:has-text("${label}")`).first().click();
+  if (await listbox.isVisible()) {
+    await page.locator('h1').first().click();
+  }
+}
+
+/** Create a product + ledger + inventory seeded for invoicing. */
+async function seedInvoiceData(page: import('@playwright/test').Page) {
+  const sku = uniqueSku();
+  const productName = `FYSeries-${sku}`;
+  const ledgerName = `FYSeriesLedger-${Date.now().toString(36)}`;
+
+  // Product
+  await page.click('[href="/products"]');
+  await page.fill('#sku', sku);
+  await page.fill('#name', productName);
+  await page.fill('#price', '100');
+  await page.fill('#gst-rate', '18');
+  await page.click('button:has-text("Create product")');
+  await expectSuccess(page, 'Product created');
+
+  // Inventory
+  await page.click('[href="/inventory"]');
+  await page.waitForTimeout(500);
+  await selectComboboxOption(page, 'inventory-product', sku);
+  await page.fill('#inventory-quantity', '100');
+  await page.click('button:has-text("Apply adjustment")');
+  await expectSuccess(page, 'Inventory updated');
+
+  // Ledger
+  await page.click('[href="/ledgers"]');
+  await page.click('button:has-text("Create ledger")');
+  await page.fill('#ledger-name', ledgerName);
+  await page.fill('#ledger-address', '1 FY Series Rd');
+  await page.fill('#ledger-gst', uniqueGstin());
+  await page.fill('#ledger-phone', '+91 9999911111');
+  await page.click('button:has-text("Create ledger")');
+  await expectSuccess(page, 'Ledger created');
+
+  return { sku, ledgerName };
+}
+
+/** Create an invoice with a given date and return the invoice number shown. */
+async function createInvoiceOnDate(
+  page: import('@playwright/test').Page,
+  ledgerName: string,
+  sku: string,
+  invoiceDate: string,
+): Promise<string> {
+  await page.click('[href="/invoices"]');
+  await page.waitForTimeout(500);
+
+  await page.selectOption('#invoice-voucher-type', 'sales');
+  await selectComboboxOption(page, 'invoice-ledger', ledgerName);
+
+  const productInputId =
+    (await page.locator('[id^="invoice-product-"]').first().getAttribute('id')) ??
+    'invoice-product-1';
+  await selectComboboxOption(page, productInputId, sku);
+  await page.locator('[id^="invoice-quantity-"]').first().fill('1');
+
+  await page.fill('#invoice-date', invoiceDate);
+
+  await page.click('button:has-text("Create invoice")');
+  await expectSuccess(page, 'invoice created');
+
+  // Grab the invoice number from the first row in the list
+  const firstRow = page.locator('.invoice-row').first();
+  await expect(firstRow).toBeVisible({ timeout: 10_000 });
+  const numberEl = firstRow.locator('.invoice-row__invoice-id').first();
+  await expect(numberEl).toBeVisible({ timeout: 5_000 });
+  const text = (await numberEl.textContent()) ?? '';
+  // Strip leading "Invoice " prefix
+  return text.replace(/^Invoice\s+/i, '').trim();
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test.describe('Invoice series — correct FY used based on invoice date', () => {
+  test(
+    'backdated invoice (prior FY date) uses prior FY label in invoice number',
+    async ({ authedPage: page }) => {
+      // Ensure both FYs exist. Activate the later one last (2032-33 = active FY).
+      await ensureAndActivateFY(page, PAST_FY_START_YEAR, PAST_FY_LABEL);
+      await ensureAndActivateFY(page, ACTIVE_FY_START_YEAR, ACTIVE_FY_LABEL);
+
+      const { sku, ledgerName } = await seedInvoiceData(page);
+
+      // Create invoice dated in prior FY (2031-32)
+      const invoiceNumber = await createInvoiceOnDate(page, ledgerName, sku, PAST_FY_DATE);
+
+      // The invoice number must contain the prior FY's start year (2031).
+      // Works for all year formats:
+      //   FY      → "RES-2031-32-0001" (contains 2031, not 2032)
+      //   MM-YYYY → "RES-10-2031-0001" (contains 2031, not 2032)
+      //   YYYY    → "RES-2031-0001"    (contains 2031, not 2032)
+      expect(invoiceNumber).toContain(String(PAST_FY_START_YEAR));
+      expect(invoiceNumber).not.toContain(String(ACTIVE_FY_START_YEAR));
+    },
+  );
+
+  test(
+    'invoice dated in active FY uses active FY label in invoice number',
+    async ({ authedPage: page }) => {
+      await ensureAndActivateFY(page, PAST_FY_START_YEAR, PAST_FY_LABEL);
+      await ensureAndActivateFY(page, ACTIVE_FY_START_YEAR, ACTIVE_FY_LABEL);
+
+      const { sku, ledgerName } = await seedInvoiceData(page);
+
+      // Create invoice dated in active FY (2032-33)
+      const invoiceNumber = await createInvoiceOnDate(page, ledgerName, sku, ACTIVE_FY_DATE);
+
+      expect(invoiceNumber).toContain(String(ACTIVE_FY_START_YEAR));
+    },
+  );
+
+  test(
+    'backdated and current-FY invoices each have independent sequence counters',
+    async ({ authedPage: page }) => {
+      await ensureAndActivateFY(page, PAST_FY_START_YEAR, PAST_FY_LABEL);
+      await ensureAndActivateFY(page, ACTIVE_FY_START_YEAR, ACTIVE_FY_LABEL);
+
+      const { sku, ledgerName } = await seedInvoiceData(page);
+
+      const num1 = await createInvoiceOnDate(page, ledgerName, sku, ACTIVE_FY_DATE);
+      const num2 = await createInvoiceOnDate(page, ledgerName, sku, PAST_FY_DATE);
+      const num3 = await createInvoiceOnDate(page, ledgerName, sku, ACTIVE_FY_DATE);
+
+      // num1 and num3 are both in active FY — num3 sequence should be higher
+      const seq = (n: string) => parseInt(n.replace(/\D+/g, '').slice(-4), 10);
+      expect(seq(num3)).toBeGreaterThan(seq(num1));
+
+      // num2 is in the prior FY — its number contains 2031, not 2032
+      expect(num2).toContain(String(PAST_FY_START_YEAR));
+      expect(num2).not.toContain(String(ACTIVE_FY_START_YEAR));
+      // num1 and num3 are in the active FY — their numbers contain 2032
+      expect(num1).toContain(String(ACTIVE_FY_START_YEAR));
+    },
+  );
+});


### PR DESCRIPTION
## Summary

Invoices dated in a different financial year than the active one were receiving a series number from the active FY instead of the correct one. This fix ensures the invoice date is used to look up the correct FY for series numbering, and that format settings (prefix, year_format, separator etc.) are borrowed from the active FY's series so the user only needs to configure one place.

## Type of change

- [x] fix (bug fix)
- [x] test (tests)

## How to test

1. Create two financial years, e.g. 2024-25 (inactive) and 2025-26 (active), each with an invoice series configured.
2. Create an invoice with a date falling in 2024-25 (e.g. 2025-01-15).
3. Verify the invoice number uses the 2024-25 series label and counter, not the active 2025-26 one.
4. Run backend unit tests: `docker compose --profile dev exec backend-dev python -m pytest tests/services/test_financial_year_and_series.py -v`
5. Run e2e tests: `make test` (or `npx playwright test e2e/fy-invoice-series.spec.ts`)

## Checklist

- [x] My code follows the project style and conventions
- [x] I added/updated tests where appropriate
- [x] I ran relevant checks locally
- [x] I verified this does not break existing behavior

## Screenshots (if UI changes)

N/A — no UI changes.

## Related issue

Closes #250