### PR TITLE
feat(invoices): add themed invoice feed table/card views

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import DashboardPage from './pages/DashboardPage';
 import ProductsPage from './pages/ProductsPage';
 import InventoryPage from './pages/InventoryPage';
 import InvoicesPage from './pages/InvoicesPage';
+import InvoicesAdvancedView from './pages/InvoicesAdvancedView';
 import CreditNotesPage from './pages/CreditNotesPage';
 import LedgersPage from './pages/LedgersPage';
 import LedgerCreatePage from './pages/LedgerCreatePage';
@@ -67,6 +68,7 @@ function AppRoutes() {
       <Route path="/ledgers/:id/edit" element={<Protected><Layout><LedgerCreatePage /></Layout></Protected>} />
       <Route path="/day-book" element={<Protected><Layout><DayBookPage /></Layout></Protected>} />
       <Route path="/invoices" element={<Protected><Layout><InvoicesPage /></Layout></Protected>} />
+        <Route path="/invoices-view" element={<Protected><Layout><InvoicesAdvancedView /></Layout></Protected>} />
       <Route path="/credit-notes" element={<Protected><Layout><CreditNotesPage /></Layout></Protected>} />
       <Route path="/company" element={<Protected><Layout><CompanyPage /></Layout></Protected>} />
       <Route path="/smtp-settings" element={<Protected><AdminOnly><Layout><SmtpSettingsPage /></Layout></AdminOnly></Protected>} />

--- a/frontend/src/components/InvoicesCompactCard.tsx
+++ b/frontend/src/components/InvoicesCompactCard.tsx
@@ -1,0 +1,140 @@
+import { Eye, Pencil, RotateCcw, Trash2, FileText } from 'lucide-react';
+import type { Invoice } from '../types/api';
+import formatCurrency from '../utils/formatting';
+
+interface InvoicesCompactCardProps {
+  invoice: Invoice;
+  onPreview: (invoice: Invoice) => void;
+}
+
+  export default function InvoicesCompactCard({ invoice, onPreview }: InvoicesCompactCardProps) {
+  const isCredit = invoice.voucher_type === 'purchase';
+  const isCancelled = invoice.status === 'cancelled';
+
+  return (
+      <article className={`invoice-compact-card invoice-compact-card--${invoice.voucher_type} ${isCancelled ? 'invoice-compact-card--cancelled' : ''}`}>
+        <div className="invoice-compact-card__grid">
+        {/* Main Info */}
+          <div className="invoice-compact-card__main">
+            <div className="invoice-compact-card__head">
+            <div>
+                <h3 className="invoice-compact-card__ledger">
+                {invoice.ledger?.name || 'Unknown Ledger'}
+              </h3>
+                <p className="invoice-compact-card__meta">
+                Invoice #{invoice.invoice_number}
+              </p>
+              {invoice.supplier_invoice_number && (
+                  <p className="invoice-compact-card__meta">
+                  Ref: {invoice.supplier_invoice_number}
+                </p>
+              )}
+            </div>
+              <div className="invoice-compact-card__badges">
+              {isCancelled && (
+                  <span className="invoice-compact-card__cancelled-badge">
+                  Cancelled
+                </span>
+              )}
+                <span className={`invoice-type-badge invoice-type-badge--${invoice.voucher_type}`}>
+                {isCredit ? 'Purchase' : 'Sales'}
+              </span>
+            </div>
+          </div>
+
+          {/* Address and Date */}
+            <div className="invoice-compact-card__details">
+            {invoice.ledger?.address && (
+                <p className="invoice-compact-card__address">{invoice.ledger.address}</p>
+            )}
+            {invoice.ledger?.phone_number && (
+                <p className="invoice-compact-card__meta">{invoice.ledger.phone_number}</p>
+            )}
+              <p className="invoice-compact-card__meta">
+              {new Date(invoice.invoice_date).toLocaleDateString()}
+            </p>
+          </div>
+        </div>
+
+        {/* Items Summary */}
+          <div className="invoice-compact-card__items">
+            <div>
+              <div className="invoice-compact-card__items-count">{invoice.items.length} items</div>
+              <div className="invoice-compact-card__items-list">
+              {invoice.items.map((item, idx) => (
+                  <div key={idx} className="invoice-compact-card__item">
+                  Product #{item.product_id} x{item.quantity}
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* Amount and Actions */}
+          <div className="invoice-compact-card__side">
+            <div>
+              <div className="invoice-compact-card__meta">
+              {isCredit ? 'Credit' : 'Debit'}
+            </div>
+              <div className={`invoice-compact-card__amount invoice-compact-card__amount--${invoice.voucher_type}`}>
+              {formatCurrency(invoice.total_amount)}
+            </div>
+            {invoice.total_tax_amount > 0 && (
+                <div className="invoice-compact-card__meta">
+                Tax: {formatCurrency(invoice.total_tax_amount)}
+              </div>
+            )}
+          </div>
+
+          {/* Action Buttons */}
+            <div className="invoice-compact-card__actions">
+            <button
+                type="button"
+              onClick={() => onPreview(invoice)}
+                className="button button--ghost button--icon"
+              title="Preview"
+            >
+              <Eye size={16} />
+            </button>
+            {!isCancelled && (
+              <>
+                <button
+                    type="button"
+                    className="button button--ghost button--icon"
+                  title="Create credit note"
+                >
+                  <FileText size={16} />
+                </button>
+                <button
+                    type="button"
+                    className="button button--ghost button--icon"
+                  title="Edit"
+                >
+                  <Pencil size={16} />
+                </button>
+              </>
+            )}
+            {isCancelled && (
+              <button
+                  type="button"
+                  className="button button--ghost button--icon"
+                title="Restore"
+              >
+                <RotateCcw size={16} />
+              </button>
+            )}
+            {!isCancelled && (
+              <button
+                  type="button"
+                  className="button button--ghost button--icon"
+                title="Cancel"
+              >
+                <Trash2 size={16} />
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+      </article>
+  );
+}

--- a/frontend/src/components/InvoicesTable.tsx
+++ b/frontend/src/components/InvoicesTable.tsx
@@ -1,0 +1,67 @@
+import type { Invoice } from '../types/api';
+import formatCurrency from '../utils/formatting';
+
+interface InvoicesTableProps {
+  invoices: Invoice[];
+  onRowClick: (invoice: Invoice) => void;
+}
+
+export default function InvoicesTable({ invoices, onRowClick }: InvoicesTableProps) {
+  return (
+    <div className="invoice-feed-table-wrap">
+      <table className="invoice-feed-table">
+        <thead>
+          <tr>
+            <th>Invoice #</th>
+            <th>Date</th>
+            <th>Buyer / Supplier</th>
+            <th>Amount</th>
+            <th>Type</th>
+            <th>Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {invoices.map((invoice) => {
+            const isCredit = invoice.voucher_type === 'purchase';
+            const isCancelled = invoice.status === 'cancelled';
+            const typeLabel = isCredit ? 'Purchase' : 'Sales';
+
+            return (
+              <tr
+                key={invoice.id}
+                onClick={() => onRowClick(invoice)}
+                className={isCancelled ? 'is-cancelled' : ''}
+              >
+                <td className="invoice-feed-table__invoice-number">
+                  {invoice.invoice_number}
+                </td>
+                <td>
+                  {new Date(invoice.invoice_date).toLocaleDateString()}
+                </td>
+                <td>
+                  <div className="invoice-feed-table__ledger">{invoice.ledger?.name || 'Unknown'}</div>
+                  {invoice.supplier_invoice_number && (
+                    <div className="invoice-feed-table__meta">Ref: {invoice.supplier_invoice_number}</div>
+                  )}
+                </td>
+                <td className="invoice-feed-table__amount">
+                  {formatCurrency(invoice.total_amount)}
+                </td>
+                <td>
+                  <span className={`invoice-type-badge invoice-type-badge--${invoice.voucher_type}`}>
+                    {typeLabel}
+                  </span>
+                </td>
+                <td>
+                  <span className={`invoice-feed-table__status ${isCancelled ? 'invoice-feed-table__status--cancelled' : 'invoice-feed-table__status--active'}`}>
+                    {isCancelled ? 'Cancelled' : 'Active'}
+                  </span>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/components/InvoicesTotalBreakdown.tsx
+++ b/frontend/src/components/InvoicesTotalBreakdown.tsx
@@ -1,0 +1,51 @@
+import formatCurrency from '../utils/formatting';
+
+interface Breakdown {
+  credit: number;
+  debit: number;
+  cancelled: number;
+  total: number;
+}
+
+interface InvoicesTotalBreakdownProps {
+  breakdown: Breakdown;
+  title?: string;
+  note?: string;
+}
+
+export default function InvoicesTotalBreakdown({ breakdown, title, note }: InvoicesTotalBreakdownProps) {
+  return (
+    <section className="panel invoice-feed-breakdown">
+      {(title || note) && (
+        <div className="invoice-feed-breakdown__header">
+          {title ? <h3 className="invoice-feed-breakdown__title">{title}</h3> : null}
+          {note ? <p className="invoice-feed-breakdown__note">{note}</p> : null}
+        </div>
+      )}
+      <div className="invoice-feed-breakdown__grid">
+        <div className="invoice-feed-breakdown__cell">
+          <div className="invoice-feed-breakdown__label">Total Listed</div>
+          <div className="invoice-feed-breakdown__value">{formatCurrency(breakdown.total)}</div>
+        </div>
+        <div className="invoice-feed-breakdown__cell">
+          <div className="invoice-feed-breakdown__label">Credit (Purchase)</div>
+          <div className="invoice-feed-breakdown__value invoice-feed-breakdown__value--purchase">{formatCurrency(breakdown.credit)}</div>
+        </div>
+        <div className="invoice-feed-breakdown__cell">
+          <div className="invoice-feed-breakdown__label">Debit (Sales)</div>
+          <div className="invoice-feed-breakdown__value invoice-feed-breakdown__value--sales">{formatCurrency(breakdown.debit)}</div>
+        </div>
+        <div className="invoice-feed-breakdown__cell">
+          <div className="invoice-feed-breakdown__label">Cancelled</div>
+          <div className="invoice-feed-breakdown__value invoice-feed-breakdown__value--cancelled">{formatCurrency(breakdown.cancelled)}</div>
+        </div>
+        <div className="invoice-feed-breakdown__cell">
+          <div className="invoice-feed-breakdown__label">Active Total</div>
+          <div className="invoice-feed-breakdown__value invoice-feed-breakdown__value--active">
+            {formatCurrency(breakdown.credit + breakdown.debit)}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/pages/InvoicesAdvancedView.tsx
+++ b/frontend/src/pages/InvoicesAdvancedView.tsx
@@ -36,7 +36,7 @@ function calculateBreakdown(rows: Invoice[]): Breakdown {
 }
 
 export default function InvoicesAdvancedView() {
-  const { activeFY } = useFY();
+  const { activeFY, loading: fyLoading } = useFY();
   const [viewType, setViewType] = useState<ViewType>('card');
   const [invoices, setInvoices] = useState<Invoice[]>([]);
     const [products, setProducts] = useState<Product[]>([]);
@@ -52,16 +52,25 @@ export default function InvoicesAdvancedView() {
   const [company, setCompany] = useState<CompanyProfile | null>(null);
   const [allPagesBreakdown, setAllPagesBreakdown] = useState<Breakdown>({ credit: 0, debit: 0, cancelled: 0, total: 0 });
   const pageSize = 20;
+  const shouldUseAllFY = allowAllFY;
+  const isFYReady = shouldUseAllFY || Boolean(activeFY);
 
   // Build query params based on FY filter
   const getFYParams = () => {
-    if (allowAllFY || !activeFY) {
+    if (shouldUseAllFY) {
+      return {};
+    }
+    if (!activeFY) {
       return {};
     }
     return { financial_year_id: activeFY.id };
   };
 
   async function loadData() {
+    if (!isFYReady) {
+      return;
+    }
+
     try {
       setLoading(true);
       setError('');
@@ -87,7 +96,11 @@ export default function InvoicesAdvancedView() {
 
       // Build summary for all pages (same filters, all matching entries)
       const summaryRows: Invoice[] = [...invoicesRes.data.items];
-      for (let nextPage = 2; nextPage <= invoicesRes.data.total_pages; nextPage += 1) {
+      for (let nextPage = 1; nextPage <= invoicesRes.data.total_pages; nextPage += 1) {
+        if (nextPage === page) {
+          continue;
+        }
+
         const nextRes = await api.get<PaginatedInvoices>('/invoices/', {
           params: {
             page: nextPage,
@@ -109,15 +122,19 @@ export default function InvoicesAdvancedView() {
 
   useEffect(() => {
     setPage(1); // Reset to first page when search, filters change
-  }, [invoiceSearch, showCancelled, allowAllFY]);
+  }, [invoiceSearch, showCancelled, allowAllFY, activeFY?.id]);
 
   useEffect(() => {
+    if (!isFYReady || fyLoading) {
+      return;
+    }
+
     void loadData();
-  }, [page, invoiceSearch, showCancelled, allowAllFY]);
+  }, [page, invoiceSearch, showCancelled, allowAllFY, activeFY?.id, fyLoading]);
 
   const currentPageBreakdown = calculateBreakdown(invoices);
 
-  if (!company) {
+  if (fyLoading || (!shouldUseAllFY && !activeFY) || !company) {
     return <div className="p-8 text-center">Loading...</div>;
   }
 

--- a/frontend/src/pages/InvoicesAdvancedView.tsx
+++ b/frontend/src/pages/InvoicesAdvancedView.tsx
@@ -1,0 +1,280 @@
+import { useState, useEffect } from 'react';
+import { LayoutGrid, Table as TableIcon } from 'lucide-react';
+import api, { getApiErrorMessage } from '../api/client';
+import type { Invoice, PaginatedInvoices, CompanyProfile } from '../types/api';
+import { useFY } from '../context/FYContext';
+import InvoicesTable from '../components/InvoicesTable';
+import InvoicesCompactCard from '../components/InvoicesCompactCard';
+import InvoicesTotalBreakdown from '../components/InvoicesTotalBreakdown';
+import InvoicePreview from '../components/InvoicePreview';
+import type { Product } from '../types/api';
+
+type ViewType = 'card' | 'table';
+
+type Breakdown = {
+  credit: number;
+  debit: number;
+  cancelled: number;
+  total: number;
+};
+
+function calculateBreakdown(rows: Invoice[]): Breakdown {
+  return {
+    credit: rows
+      .filter((inv) => inv.voucher_type === 'purchase' && inv.status === 'active' && inv.ledger)
+      .reduce((sum, inv) => sum + inv.total_amount, 0),
+    debit: rows
+      .filter((inv) => inv.voucher_type === 'sales' && inv.status === 'active' && inv.ledger)
+      .reduce((sum, inv) => sum + inv.total_amount, 0),
+    cancelled: rows
+      .filter((inv) => inv.status === 'cancelled' && inv.ledger)
+      .reduce((sum, inv) => sum + inv.total_amount, 0),
+    total: rows
+      .filter((inv) => inv.status === 'active' || inv.status === 'cancelled')
+      .reduce((sum, inv) => sum + inv.total_amount, 0),
+  };
+}
+
+export default function InvoicesAdvancedView() {
+  const { activeFY } = useFY();
+  const [viewType, setViewType] = useState<ViewType>('card');
+  const [invoices, setInvoices] = useState<Invoice[]>([]);
+    const [products, setProducts] = useState<Product[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [invoiceSearch, setInvoiceSearch] = useState('');
+  const [showCancelled, setShowCancelled] = useState(false);
+  const [allowAllFY, setAllowAllFY] = useState(false);
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [total, setTotal] = useState(0);
+  const [previewInvoice, setPreviewInvoice] = useState<Invoice | null>(null);
+  const [company, setCompany] = useState<CompanyProfile | null>(null);
+  const [allPagesBreakdown, setAllPagesBreakdown] = useState<Breakdown>({ credit: 0, debit: 0, cancelled: 0, total: 0 });
+  const pageSize = 20;
+
+  // Build query params based on FY filter
+  const getFYParams = () => {
+    if (allowAllFY || !activeFY) {
+      return {};
+    }
+    return { financial_year_id: activeFY.id };
+  };
+
+  async function loadData() {
+    try {
+      setLoading(true);
+      setError('');
+      const [invoicesRes, companyRes, productsRes] = await Promise.all([
+        api.get<PaginatedInvoices>('/invoices/', {
+          params: { 
+            page, 
+            page_size: pageSize, 
+            search: invoiceSearch, 
+            show_cancelled: showCancelled,
+            ...getFYParams(),
+          },
+        }),
+        api.get<CompanyProfile>('/company/'),
+        api.get<{ items: Product[] }>('/products/', { params: { page_size: 500 } }),
+      ]);
+
+      setInvoices(invoicesRes.data.items);
+      setTotal(invoicesRes.data.total);
+      setTotalPages(invoicesRes.data.total_pages);
+      setCompany(companyRes.data);
+      setProducts(productsRes.data.items);
+
+      // Build summary for all pages (same filters, all matching entries)
+      const summaryRows: Invoice[] = [...invoicesRes.data.items];
+      for (let nextPage = 2; nextPage <= invoicesRes.data.total_pages; nextPage += 1) {
+        const nextRes = await api.get<PaginatedInvoices>('/invoices/', {
+          params: {
+            page: nextPage,
+            page_size: pageSize,
+            search: invoiceSearch,
+            show_cancelled: showCancelled,
+            ...getFYParams(),
+          },
+        });
+        summaryRows.push(...nextRes.data.items);
+      }
+      setAllPagesBreakdown(calculateBreakdown(summaryRows));
+    } catch (err) {
+      setError(getApiErrorMessage(err, 'Unable to load invoices'));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    setPage(1); // Reset to first page when search, filters change
+  }, [invoiceSearch, showCancelled, allowAllFY]);
+
+  useEffect(() => {
+    void loadData();
+  }, [page, invoiceSearch, showCancelled, allowAllFY]);
+
+  const currentPageBreakdown = calculateBreakdown(invoices);
+
+  if (!company) {
+    return <div className="p-8 text-center">Loading...</div>;
+  }
+
+  return (
+    <div className="invoice-feed-view stack">
+      <section className="panel invoice-feed-view__header">
+        <div className="panel__header">
+          <div>
+            <p className="eyebrow">Invoices</p>
+            <h1 className="page-title" style={{ margin: 0 }}>Invoice Feed</h1>
+          </div>
+        </div>
+
+        <div className="invoice-feed-view__controls">
+          {/* View Toggle */}
+          <div className="button-row">
+            <button
+              type="button"
+              onClick={() => setViewType('card')}
+              className={`button button--small ${
+                viewType === 'card'
+                  ? 'button--primary'
+                  : 'button--ghost'
+              }`}
+            >
+              <LayoutGrid size={18} />
+              Card
+            </button>
+            <button
+              type="button"
+              onClick={() => setViewType('table')}
+              className={`button button--small ${
+                viewType === 'table'
+                  ? 'button--primary'
+                  : 'button--ghost'
+              }`}
+            >
+              <TableIcon size={18} />
+              Table
+            </button>
+          </div>
+
+          {/* FY Filter Toggle */}
+          <label className="invoice-feed-view__checkbox">
+            <input
+              type="checkbox"
+              checked={allowAllFY}
+              onChange={(e) => setAllowAllFY(e.target.checked)}
+            />
+            <span>Search all FY</span>
+          </label>
+
+          {/* Search */}
+          <input
+            type="text"
+            placeholder="Search invoices..."
+            value={invoiceSearch}
+            onChange={(e) => setInvoiceSearch(e.target.value)}
+            className="input invoice-feed-view__search"
+          />
+
+          {/* Cancelled toggle */}
+          <label className="invoice-feed-view__checkbox">
+            <input
+              type="checkbox"
+              checked={showCancelled}
+              onChange={(e) => setShowCancelled(e.target.checked)}
+            />
+            <span>Show cancelled</span>
+          </label>
+        </div>
+
+        {/* Current FY Info */}
+        {!allowAllFY && (
+          <div className="invoice-feed-view__fy-label">
+            Showing invoices from: <strong>{activeFY?.label}</strong>
+          </div>
+        )}
+      </section>
+
+      {/* Error Message */}
+      {error && (
+        <div className="invoice-feed-view__error">
+          {error}
+        </div>
+      )}
+
+      <InvoicesTotalBreakdown
+        breakdown={allPagesBreakdown}
+        title="Summary of all pages"
+        note="This summary includes all invoice entries matching your current filters across every page."
+      />
+
+      {/* Content Area */}
+      <section className="panel invoice-feed-view__content">
+        {loading ? (
+          <div className="empty-state">Loading invoices...</div>
+        ) : invoices.length === 0 ? (
+          <div className="empty-state">No invoices found</div>
+        ) : viewType === 'card' ? (
+          <div className="invoice-feed-view__card-list">
+              {invoices.map((invoice) => (
+                <InvoicesCompactCard
+                  key={invoice.id}
+                  invoice={invoice}
+                  onPreview={setPreviewInvoice}
+                />
+              ))}
+          </div>
+        ) : (
+          <InvoicesTable
+            invoices={invoices}
+            onRowClick={setPreviewInvoice}
+          />
+        )}
+      </section>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="invoice-feed-view__pagination button-row">
+          <button
+            type="button"
+            onClick={() => setPage(Math.max(1, page - 1))}
+            disabled={page === 1}
+            className="button button--ghost button--small"
+          >
+            Previous
+          </button>
+          <span className="invoice-feed-view__page-label">
+            Page {page} of {totalPages}
+          </span>
+          <button
+            type="button"
+            onClick={() => setPage(Math.min(totalPages, page + 1))}
+            disabled={page === totalPages}
+            className="button button--ghost button--small"
+          >
+            Next
+          </button>
+        </div>
+      )}
+
+      <InvoicesTotalBreakdown
+        breakdown={currentPageBreakdown}
+        title="Summary of current visible page"
+        note="This summary is calculated only from the invoice entries visible on this page."
+      />
+
+      {/* Invoice Preview Modal */}
+      {previewInvoice && (
+        <InvoicePreview
+          invoice={previewInvoice}
+           products={products}
+           currencyCode={company?.currency_code ?? ''}
+          onClose={() => setPreviewInvoice(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1258,6 +1258,343 @@ textarea {
   display: flex;
 }
 
+.invoice-feed-view {
+  display: grid;
+  gap: 16px;
+}
+
+.invoice-feed-view__header {
+  display: grid;
+  gap: 14px;
+}
+
+.invoice-feed-view__controls {
+  display: grid;
+  grid-template-columns: auto auto minmax(240px, 1fr) auto;
+  gap: 12px;
+  align-items: center;
+}
+
+.invoice-feed-view__search {
+  min-width: 0;
+}
+
+.invoice-feed-view__checkbox {
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.invoice-feed-view__checkbox input {
+  accent-color: var(--accent);
+}
+
+.invoice-feed-view__fy-label {
+  font-size: 0.86rem;
+  color: var(--muted);
+}
+
+.invoice-feed-view__error {
+  border: 1px solid rgba(255, 139, 139, 0.3);
+  background: rgba(255, 139, 139, 0.12);
+  color: #ffc7c7;
+  border-radius: 14px;
+  padding: 10px 14px;
+}
+
+.invoice-feed-view__content {
+  overflow: auto;
+  padding: 16px;
+}
+
+.invoice-feed-view__card-list {
+  display: grid;
+  gap: 14px;
+}
+
+.invoice-feed-view__pagination {
+  justify-content: center;
+  align-items: center;
+}
+
+.invoice-feed-view__page-label {
+  color: var(--muted);
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.invoice-feed-breakdown {
+  padding-top: 16px;
+  padding-bottom: 16px;
+}
+
+.invoice-feed-breakdown__header {
+  margin-bottom: 12px;
+}
+
+.invoice-feed-breakdown__title {
+  margin: 0 0 4px;
+  font-size: 0.96rem;
+  font-weight: 800;
+  color: var(--text);
+}
+
+.invoice-feed-breakdown__note {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--muted);
+}
+
+.invoice-feed-breakdown__grid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.invoice-feed-breakdown__cell {
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  padding: 12px;
+  background: rgba(255, 255, 255, 0.02);
+  text-align: center;
+}
+
+.invoice-feed-breakdown__label {
+  font-size: 0.78rem;
+  color: var(--muted);
+  margin-bottom: 6px;
+}
+
+.invoice-feed-breakdown__value {
+  font-size: 1.15rem;
+  font-weight: 800;
+  color: var(--text);
+}
+
+.invoice-feed-breakdown__value--purchase {
+  color: #fb923c;
+}
+
+.invoice-feed-breakdown__value--sales {
+  color: #84cc16;
+}
+
+.invoice-feed-breakdown__value--cancelled {
+  color: #fca5a5;
+}
+
+.invoice-feed-breakdown__value--active {
+  color: var(--accent);
+}
+
+.invoice-feed-table-wrap {
+  overflow-x: auto;
+}
+
+.invoice-feed-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 760px;
+}
+
+.invoice-feed-table thead th {
+  text-align: left;
+  font-size: 0.78rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--muted);
+  padding: 12px;
+  border-bottom: 1px solid var(--line);
+  position: sticky;
+  top: 0;
+  background: rgba(8, 17, 31, 0.95);
+}
+
+.invoice-feed-table tbody td {
+  padding: 12px;
+  border-bottom: 1px solid var(--line);
+  color: var(--text);
+}
+
+.invoice-feed-table tbody tr {
+  cursor: pointer;
+  transition: background 160ms ease;
+}
+
+.invoice-feed-table tbody tr:hover {
+  background: rgba(87, 209, 201, 0.08);
+}
+
+.invoice-feed-table tbody tr.is-cancelled {
+  opacity: 0.65;
+}
+
+.invoice-feed-table__invoice-number {
+  font-weight: 700;
+}
+
+.invoice-feed-table__ledger {
+  font-weight: 700;
+}
+
+.invoice-feed-table__meta {
+  font-size: 0.78rem;
+  color: var(--muted);
+}
+
+.invoice-feed-table__amount {
+  font-weight: 800;
+}
+
+.invoice-feed-table__status {
+  display: inline-flex;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 0.76rem;
+  font-weight: 700;
+}
+
+.invoice-feed-table__status--active {
+  color: #bffbf6;
+  background: rgba(87, 209, 201, 0.14);
+  border: 1px solid rgba(87, 209, 201, 0.25);
+}
+
+.invoice-feed-table__status--cancelled {
+  color: #ffc7c7;
+  background: rgba(255, 139, 139, 0.14);
+  border: 1px solid rgba(255, 139, 139, 0.25);
+}
+
+.invoice-compact-card {
+  border-radius: 20px;
+  border: 1px solid rgba(148, 184, 255, 0.12);
+  background: linear-gradient(135deg, rgba(10, 22, 40, 0.6) 0%, rgba(15, 29, 48, 0.45) 100%);
+  padding: 16px;
+  transition: border-color 180ms ease, transform 180ms ease;
+}
+
+.invoice-compact-card:hover {
+  transform: translateY(-1px);
+  border-color: rgba(148, 184, 255, 0.24);
+}
+
+.invoice-compact-card--sales {
+  border-left: 4px solid rgba(34, 197, 94, 0.45);
+}
+
+.invoice-compact-card--purchase {
+  border-left: 4px solid rgba(251, 146, 60, 0.45);
+}
+
+.invoice-compact-card--cancelled {
+  opacity: 0.72;
+}
+
+.invoice-compact-card__grid {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr) minmax(0, 1fr);
+  gap: 14px;
+  align-items: start;
+}
+
+.invoice-compact-card__head {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+
+.invoice-compact-card__ledger {
+  margin: 0;
+  font-size: 1rem;
+  color: var(--text);
+}
+
+.invoice-compact-card__meta {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.invoice-compact-card__badges {
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.invoice-compact-card__cancelled-badge {
+  display: inline-flex;
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 139, 139, 0.3);
+  color: #ffc7c7;
+  background: rgba(255, 139, 139, 0.14);
+  font-size: 0.76rem;
+  font-weight: 700;
+}
+
+.invoice-compact-card__details {
+  display: grid;
+  gap: 3px;
+}
+
+.invoice-compact-card__address {
+  margin: 0;
+  font-size: 0.84rem;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.invoice-compact-card__items-count {
+  font-size: 0.82rem;
+  font-weight: 700;
+  color: var(--muted);
+  margin-bottom: 6px;
+}
+
+.invoice-compact-card__items-list {
+  display: grid;
+  gap: 4px;
+  max-height: 72px;
+  overflow: auto;
+}
+
+.invoice-compact-card__item {
+  font-size: 0.8rem;
+  color: var(--text);
+}
+
+.invoice-compact-card__side {
+  display: grid;
+  gap: 12px;
+  justify-items: end;
+}
+
+.invoice-compact-card__amount {
+  font-size: 1.35rem;
+  font-weight: 800;
+}
+
+.invoice-compact-card__amount--sales {
+  color: #84cc16;
+}
+
+.invoice-compact-card__amount--purchase {
+  color: #fb923c;
+}
+
+.invoice-compact-card__actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
 @media print {
   body * {
     visibility: hidden !important;
@@ -1409,5 +1746,25 @@ textarea {
     width: 100%;
     flex-direction: column;
     align-items: stretch;
+  }
+
+  .invoice-feed-view__controls {
+    grid-template-columns: 1fr;
+  }
+
+  .invoice-feed-breakdown__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .invoice-compact-card__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .invoice-compact-card__side {
+    justify-items: start;
+  }
+
+  .invoice-compact-card__actions {
+    justify-content: flex-start;
   }
 }


### PR DESCRIPTION
## Summary

Adds a new invoice feed page with card/table toggle and compact themed UI, while keeping the existing visual language.
Moves summary blocks to improve clarity:
- Top summary now represents all filtered entries across all pages.
- Bottom summary now represents only the currently visible page entries.
Also hides the Not credited label in the new feed and scopes listing to current FY by default with an all-FY toggle.

## Type of change

- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs (documentation)
- [ ] test (tests)
- [ ] chore/refactor

## How to test

1. Open /invoices-view.
2. Verify card and table view toggle works.
3. Verify default list is current FY; enable Search all FY and confirm broader results.
4. Verify top summary says all pages and changes with filters.
5. Change page and verify bottom summary reflects only visible entries.
6. Confirm Not credited label is not shown in the new feed cards.

## Checklist

- [x] My code follows the project style and conventions
- [ ] I added/updated tests where appropriate
- [ ] I updated docs where needed
- [x] I ran relevant checks locally
- [x] I verified this does not break existing behavior

## Screenshots (if UI changes)

UI change; screenshots can be added during review.

## Related issue

Closes #238
