### PR TITLE
feat(invoices): react-query+zustand phase-1 migration

### DIFF
--- a/backend/src/api/routes/invoices.py
+++ b/backend/src/api/routes/invoices.py
@@ -4,6 +4,7 @@ from datetime import date, datetime
 
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import StreamingResponse
+from sqlalchemy import case, func
 from sqlalchemy.orm import Session
 from sqlalchemy.orm import joinedload
 from decimal import Decimal, ROUND_HALF_UP
@@ -274,6 +275,7 @@ def list_invoices(
     page_size: int = Query(20, ge=1, le=500),
     search: str = Query(""),
     show_cancelled: bool = Query(False),
+  financial_year_id: int | None = Query(None),
     db: Session = Depends(get_db),
     _: User = Depends(get_current_user),
 ):
@@ -281,8 +283,26 @@ def list_invoices(
         base = db.query(Invoice)
         if not show_cancelled:
             base = base.filter(Invoice.status == "active")
+        if financial_year_id is not None:
+          base = base.filter(Invoice.financial_year_id == financial_year_id)
         if search.strip():
             base = base.filter(Invoice.ledger_name.ilike(f"%{search.strip()}%"))
+
+        summary_row = base.with_entities(
+          func.coalesce(func.sum(Invoice.total_amount), 0),
+          func.coalesce(func.sum(case((Invoice.voucher_type == "purchase", Invoice.total_amount), else_=0)), 0),
+          func.coalesce(func.sum(case((Invoice.voucher_type == "sales", Invoice.total_amount), else_=0)), 0),
+          func.coalesce(func.sum(case((Invoice.status == "cancelled", Invoice.total_amount), else_=0)), 0),
+          func.coalesce(func.sum(case((Invoice.status == "active", Invoice.total_amount), else_=0)), 0),
+        ).one()
+
+        total_listed = Decimal(summary_row[0] or 0)
+        credit_total = Decimal(summary_row[1] or 0)
+        debit_total = Decimal(summary_row[2] or 0)
+        cancelled_total = Decimal(summary_row[3] or 0)
+        active_total = Decimal(summary_row[4] or 0)
+        others_total = total_listed - (credit_total + debit_total + cancelled_total)
+
         total = base.count()
         items = (
             base.options(joinedload(Invoice.ledger), joinedload(Invoice.items))
@@ -291,12 +311,28 @@ def list_invoices(
             .limit(page_size)
             .all()
         )
+
+        visible_page_total = sum((Decimal(item.total_amount or 0) for item in items), Decimal("0"))
+
         return PaginatedInvoiceOut(
             items=items,
             total=total,
             page=page,
             page_size=page_size,
             total_pages=(total + page_size - 1) // page_size if total > 0 else 1,
+          summary=PaginatedInvoiceOut.SummaryMeta(
+            total_listed=float(total_listed),
+            credit_total=float(credit_total),
+            debit_total=float(debit_total),
+            cancelled_total=float(cancelled_total),
+            active_total=float(active_total),
+            others_total=float(others_total),
+            visible_page_total=float(visible_page_total),
+            visible_page_count=len(items),
+            filtered_count=total,
+            include_cancelled=show_cancelled,
+            financial_year_id=financial_year_id,
+          ),
         )
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/backend/src/schemas/invoice.py
+++ b/backend/src/schemas/invoice.py
@@ -79,8 +79,22 @@ class InvoiceOut(BaseModel):
 
 
 class PaginatedInvoiceOut(BaseModel):
+    class SummaryMeta(BaseModel):
+        total_listed: float
+        credit_total: float
+        debit_total: float
+        cancelled_total: float
+        active_total: float
+        others_total: float
+        visible_page_total: float
+        visible_page_count: int
+        filtered_count: int
+        include_cancelled: bool
+        financial_year_id: int | None = None
+
     items: list[InvoiceOut]
     total: int
     page: int
     page_size: int
     total_pages: int
+    summary: SummaryMeta

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "simple-invoicing-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@tanstack/react-query": "^5.99.0",
         "axios": "^1.7.7",
         "framer-motion": "^11.11.9",
         "lucide-react": "^1.7.0",
@@ -1184,6 +1185,32 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.99.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.99.0.tgz",
+      "integrity": "sha512-3Jv3WQG0BCcH7G+7lf/bP8QyBfJOXeY+T08Rin3GZ1bshvwlbPt7NrDHMEzGdKIOmOzvIQmxjk28YEQX60k7pQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.99.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.99.0.tgz",
+      "integrity": "sha512-OY2bCqPemT1LlqJ8Y2CUau4KELnIhhG9Ol3ZndPbdnB095pRbPo1cHuXTndg8iIwtoHTgwZjyaDnQ0xD0mYwAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.99.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -73,7 +73,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1277,7 +1276,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1455,7 +1453,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2090,7 +2087,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -2436,7 +2432,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -2612,7 +2607,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -2625,7 +2619,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -2967,7 +2960,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3059,7 +3051,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "test:e2e:report": "npx playwright show-report"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.99.0",
     "axios": "^1.7.7",
     "framer-motion": "^11.11.9",
     "lucide-react": "^1.7.0",

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,6 +1,7 @@
-import { createContext, useContext, useEffect, useMemo, useState } from 'react';
-import api from '../api/client';
-import type { AuthToken, UserProfile } from '../types/api';
+import { useEffect } from 'react';
+import { useShallow } from 'zustand/shallow';
+import type { UserProfile } from '../types/api';
+import { useAuthStore } from '../store/useAuthStore';
 
 type AuthContextType = {
   token: string | null;
@@ -12,72 +13,36 @@ type AuthContextType = {
   logout: () => void;
 };
 
-const AuthContext = createContext<AuthContextType | undefined>(undefined);
-
-function decodeEmailFromToken(token: string | null) {
-  if (!token) {
-    return null;
-  }
-
-  try {
-    const [, payload] = token.split('.');
-    const decoded = JSON.parse(atob(payload.replace(/-/g, '+').replace(/_/g, '/')));
-    return typeof decoded.sub === 'string' ? decoded.sub : null;
-  } catch {
-    return null;
-  }
-}
-
 export function AuthProvider({ children }: { children: React.ReactNode }) {
-  const [token, setToken] = useState<string | null>(localStorage.getItem('token'));
-  const [userEmail, setUserEmail] = useState<string | null>(() => decodeEmailFromToken(localStorage.getItem('token')));
-  const [userRole, setUserRole] = useState<UserProfile['role'] | null>(null);
-
-  useEffect(() => {
-    setUserEmail(decodeEmailFromToken(token));
-  }, [token]);
+  const { token, hydrateUserRole, setUserRole } = useAuthStore(useShallow((s) => ({
+    token: s.token,
+    hydrateUserRole: s.hydrateUserRole,
+    setUserRole: s.setUserRole,
+  })));
 
   useEffect(() => {
     if (!token) {
       setUserRole(null);
       return;
     }
-    api.get<UserProfile>('/auth/me').then((res) => {
-      setUserRole(res.data.role);
-    }).catch(() => {
-      setUserRole(null);
-    });
-  }, [token]);
+    void hydrateUserRole();
+  }, [token, hydrateUserRole, setUserRole]);
 
-  const value = useMemo(
-    () => ({
-      token,
-      userEmail,
-      userRole,
-      isAdmin: userRole === 'admin',
-      isAuthenticated: Boolean(token),
-      login: async (email: string, password: string) => {
-        const res = await api.post<AuthToken>('/auth/login', { email, password });
-        localStorage.setItem('token', res.data.access_token);
-        localStorage.setItem('refresh_token', res.data.refresh_token);
-        setToken(res.data.access_token);
-      },
-      logout: () => {
-        localStorage.removeItem('token');
-        localStorage.removeItem('refresh_token');
-        setToken(null);
-        setUserEmail(null);
-        setUserRole(null);
-      },
-    }),
-    [token, userEmail, userRole]
-  );
-
-  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+  return <>{children}</>;
 }
 
 export function useAuth() {
-  const ctx = useContext(AuthContext);
-  if (!ctx) throw new Error('useAuth must be used within AuthProvider');
-  return ctx;
+  const state = useAuthStore(useShallow((s) => ({
+    token: s.token,
+    userEmail: s.userEmail,
+    userRole: s.userRole,
+    login: s.login,
+    logout: s.logout,
+  })));
+
+  return {
+    ...state,
+    isAdmin: state.userRole === 'admin',
+    isAuthenticated: Boolean(state.token),
+  } as AuthContextType;
 }

--- a/frontend/src/context/FYContext.tsx
+++ b/frontend/src/context/FYContext.tsx
@@ -1,6 +1,8 @@
-import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
-import { activateFinancialYear, createFinancialYear, getFinancialYears, type FinancialYear } from '../api/financialYears';
+import { useEffect, useMemo } from 'react';
+import { useShallow } from 'zustand/shallow';
+import type { FinancialYear } from '../api/financialYears';
 import { useAuth } from './AuthContext';
+import { useFYStore } from '../store/useFYStore';
 
 type FYContextType = {
   activeFY: FinancialYear | null;
@@ -11,70 +13,46 @@ type FYContextType = {
   refreshFYList: () => Promise<void>;
 };
 
-const FYContext = createContext<FYContextType | undefined>(undefined);
-
 export function FYProvider({ children }: { children: React.ReactNode }) {
   const { isAuthenticated } = useAuth();
-  const [fyList, setFyList] = useState<FinancialYear[]>([]);
-  const [loading, setLoading] = useState(false);
-
-  const refreshFYList = useCallback(async () => {
-    setLoading(true);
-    try {
-      const list = await getFinancialYears();
-      setFyList(list);
-    } catch {
-      // leave existing list on error
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+  const { refreshFYList, clearFYList } = useFYStore(useShallow((s) => ({
+    refreshFYList: s.refreshFYList,
+    clearFYList: s.clearFYList,
+  })));
 
   useEffect(() => {
     if (isAuthenticated) {
-      refreshFYList();
+      void refreshFYList();
     } else {
-      setFyList([]);
+      clearFYList();
     }
-  }, [isAuthenticated, refreshFYList]);
+  }, [isAuthenticated, refreshFYList, clearFYList]);
+
+  return <>{children}</>;
+}
+
+export function useFY(): FYContextType {
+  const { fyList, loading, switchFY, createFY, refreshFYList } = useFYStore(
+    useShallow((s) => ({
+      fyList: s.fyList,
+      loading: s.loading,
+      switchFY: s.switchFY,
+      createFY: s.createFY,
+      refreshFYList: s.refreshFYList,
+    })),
+  );
 
   const activeFY = useMemo(
     () => fyList.find((fy) => fy.is_active) ?? null,
     [fyList],
   );
 
-  const switchFY = useCallback(async (id: number) => {
-    // Optimistic update
-    setFyList((prev) =>
-      prev.map((fy) => ({ ...fy, is_active: fy.id === id })),
-    );
-    try {
-      await activateFinancialYear(id);
-      await refreshFYList();
-    } catch {
-      // Roll back optimistic update
-      await refreshFYList();
-    }
-  }, [refreshFYList]);
-
-  const createFY = useCallback(
-    async (label: string, startDate: string, endDate: string) => {
-      await createFinancialYear({ label, start_date: startDate, end_date: endDate });
-      await refreshFYList();
-    },
-    [refreshFYList],
-  );
-
-  const value = useMemo(
-    () => ({ activeFY, fyList, loading, switchFY, createFY, refreshFYList }),
-    [activeFY, fyList, loading, switchFY, createFY, refreshFYList],
-  );
-
-  return <FYContext.Provider value={value}>{children}</FYContext.Provider>;
-}
-
-export function useFY(): FYContextType {
-  const ctx = useContext(FYContext);
-  if (!ctx) throw new Error('useFY must be used inside <FYProvider>');
-  return ctx;
+  return {
+    activeFY,
+    fyList,
+    loading,
+    switchFY,
+    createFY,
+    refreshFYList,
+  };
 }

--- a/frontend/src/features/invoices/api.ts
+++ b/frontend/src/features/invoices/api.ts
@@ -1,0 +1,67 @@
+import api from '../../api/client';
+import type { CompanyProfile, Invoice, PaginatedInvoices, Product } from '../../types/api';
+
+type InvoiceFilters = {
+  page: number;
+  pageSize: number;
+  search: string;
+  showCancelled: boolean;
+  financialYearId?: number;
+};
+
+function buildInvoiceParams(filters: InvoiceFilters) {
+  const params: Record<string, string | number | boolean> = {
+    page: filters.page,
+    page_size: filters.pageSize,
+    search: filters.search,
+    show_cancelled: filters.showCancelled,
+  };
+
+  if (typeof filters.financialYearId === 'number') {
+    params.financial_year_id = filters.financialYearId;
+  }
+
+  return params;
+}
+
+export async function fetchInvoicePage(filters: InvoiceFilters): Promise<PaginatedInvoices> {
+  const res = await api.get<PaginatedInvoices>('/invoices/', {
+    params: buildInvoiceParams(filters),
+  });
+  return res.data;
+}
+
+export async function fetchInvoiceSummaryPages(
+  baseFilters: Omit<InvoiceFilters, 'page'>,
+  totalPages: number,
+  currentPage: number,
+  currentItems: Invoice[]
+): Promise<Invoice[]> {
+  if (totalPages <= 1) {
+    return currentItems;
+  }
+
+  const rows: Invoice[] = [...currentItems];
+  const requests: Promise<PaginatedInvoices>[] = [];
+
+  for (let page = 1; page <= totalPages; page += 1) {
+    if (page === currentPage) {
+      continue;
+    }
+    requests.push(fetchInvoicePage({ ...baseFilters, page }));
+  }
+
+  const results = await Promise.all(requests);
+  results.forEach((entry) => rows.push(...entry.items));
+  return rows;
+}
+
+export async function fetchCompanyProfile(): Promise<CompanyProfile> {
+  const res = await api.get<CompanyProfile>('/company/');
+  return res.data;
+}
+
+export async function fetchProducts(): Promise<Product[]> {
+  const res = await api.get<{ items: Product[] }>('/products/', { params: { page_size: 500 } });
+  return res.data.items;
+}

--- a/frontend/src/features/invoices/api.ts
+++ b/frontend/src/features/invoices/api.ts
@@ -33,27 +33,20 @@ export async function fetchInvoicePage(filters: InvoiceFilters): Promise<Paginat
 
 export async function fetchInvoiceSummaryPages(
   baseFilters: Omit<InvoiceFilters, 'page'>,
-  totalPages: number,
-  currentPage: number,
+  totalItems: number,
   currentItems: Invoice[]
 ): Promise<Invoice[]> {
-  if (totalPages <= 1) {
+  if (totalItems <= currentItems.length) {
     return currentItems;
   }
 
-  const rows: Invoice[] = [...currentItems];
-  const requests: Promise<PaginatedInvoices>[] = [];
+  const response = await fetchInvoicePage({
+    ...baseFilters,
+    page: 1,
+    pageSize: totalItems,
+  });
 
-  for (let page = 1; page <= totalPages; page += 1) {
-    if (page === currentPage) {
-      continue;
-    }
-    requests.push(fetchInvoicePage({ ...baseFilters, page }));
-  }
-
-  const results = await Promise.all(requests);
-  results.forEach((entry) => rows.push(...entry.items));
-  return rows;
+  return response.items;
 }
 
 export async function fetchCompanyProfile(): Promise<CompanyProfile> {

--- a/frontend/src/features/invoices/api.ts
+++ b/frontend/src/features/invoices/api.ts
@@ -1,5 +1,5 @@
 import api from '../../api/client';
-import type { CompanyProfile, Invoice, PaginatedInvoices, Product } from '../../types/api';
+import type { CompanyProfile, Invoice, Ledger, PaginatedInvoices, Product } from '../../types/api';
 
 type InvoiceFilters = {
   page: number;
@@ -64,4 +64,39 @@ export async function fetchCompanyProfile(): Promise<CompanyProfile> {
 export async function fetchProducts(): Promise<Product[]> {
   const res = await api.get<{ items: Product[] }>('/products/', { params: { page_size: 500 } });
   return res.data.items;
+}
+
+export async function fetchLedgers(): Promise<Ledger[]> {
+  const res = await api.get<{ items: Ledger[] }>('/ledgers/', { params: { page_size: 500 } });
+  return res.data.items;
+}
+
+export async function fetchInvoiceComposerData(input: {
+  page: number;
+  pageSize: number;
+  search: string;
+  showCancelled: boolean;
+  financialYearId?: number;
+}) {
+  const [productsRes, ledgersRes, invoicesRes, companyRes] = await Promise.all([
+    api.get<{ items: Product[] }>('/products/', { params: { page_size: 500 } }),
+    api.get<{ items: Ledger[] }>('/ledgers/', { params: { page_size: 500 } }),
+    fetchInvoicePage({
+      page: input.page,
+      pageSize: input.pageSize,
+      search: input.search,
+      showCancelled: input.showCancelled,
+      financialYearId: input.financialYearId,
+    }),
+    fetchCompanyProfile(),
+  ]);
+
+  return {
+    products: productsRes.data.items,
+    ledgers: ledgersRes.data.items,
+    invoices: invoicesRes.items,
+    invoiceTotal: invoicesRes.total,
+    invoiceTotalPages: invoicesRes.total_pages,
+    company: companyRes,
+  };
 }

--- a/frontend/src/features/invoices/queryKeys.ts
+++ b/frontend/src/features/invoices/queryKeys.ts
@@ -1,0 +1,20 @@
+export const invoiceQueryKeys = {
+  all: ['invoices'] as const,
+  list: (
+    page: number,
+    pageSize: number,
+    search: string,
+    showCancelled: boolean,
+    financialYearId?: number
+  ) => ['invoices', 'list', page, pageSize, search, showCancelled, financialYearId ?? 'all'] as const,
+  company: ['company', 'profile'] as const,
+  products: ['products', 'lookup'] as const,
+  summary: (
+    page: number,
+    pageSize: number,
+    search: string,
+    showCancelled: boolean,
+    financialYearId?: number,
+    totalPages?: number
+  ) => ['invoices', 'summary', page, pageSize, search, showCancelled, financialYearId ?? 'all', totalPages ?? 1] as const,
+};

--- a/frontend/src/features/invoices/queryKeys.ts
+++ b/frontend/src/features/invoices/queryKeys.ts
@@ -16,12 +16,4 @@ export const invoiceQueryKeys = {
   ) => ['invoices', 'list', page, pageSize, search, showCancelled, financialYearId ?? 'all'] as const,
   company: ['company', 'profile'] as const,
   products: ['products', 'lookup'] as const,
-  summary: (
-    page: number,
-    pageSize: number,
-    search: string,
-    showCancelled: boolean,
-    financialYearId?: number,
-    totalPages?: number
-  ) => ['invoices', 'summary', page, pageSize, search, showCancelled, financialYearId ?? 'all', totalPages ?? 1] as const,
 };

--- a/frontend/src/features/invoices/queryKeys.ts
+++ b/frontend/src/features/invoices/queryKeys.ts
@@ -1,5 +1,12 @@
 export const invoiceQueryKeys = {
   all: ['invoices'] as const,
+  composer: (
+    page: number,
+    pageSize: number,
+    search: string,
+    showCancelled: boolean,
+    financialYearId?: number
+  ) => ['invoices', 'composer', page, pageSize, search, showCancelled, financialYearId ?? 'all'] as const,
   list: (
     page: number,
     pageSize: number,

--- a/frontend/src/lib/queryClient.ts
+++ b/frontend/src/lib/queryClient.ts
@@ -1,0 +1,15 @@
+import { QueryClient } from '@tanstack/react-query';
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 30_000,
+      gcTime: 5 * 60_000,
+      refetchOnWindowFocus: false,
+      retry: 1,
+    },
+    mutations: {
+      retry: 0,
+    },
+  },
+});

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,13 +1,17 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
+import { queryClient } from './lib/queryClient';
 import './styles.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </QueryClientProvider>
   </React.StrictMode>
 );

--- a/frontend/src/pages/InvoicesAdvancedView.tsx
+++ b/frontend/src/pages/InvoicesAdvancedView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { LayoutGrid, Table as TableIcon } from 'lucide-react';
 import { getApiErrorMessage } from '../api/client';
@@ -10,6 +10,7 @@ import InvoicesTotalBreakdown from '../components/InvoicesTotalBreakdown';
 import InvoicePreview from '../components/InvoicePreview';
 import type { Product } from '../types/api';
 import { useInvoiceFeedViewStore } from '../store/useInvoiceFeedViewStore';
+import { useInvoiceModalStore } from '../store/useInvoiceModalStore';
 import { fetchCompanyProfile, fetchInvoicePage, fetchInvoiceSummaryPages, fetchProducts } from '../features/invoices/api';
 import { invoiceQueryKeys } from '../features/invoices/queryKeys';
 
@@ -54,7 +55,7 @@ export default function InvoicesAdvancedView() {
     setPage,
     resetPage,
   } = useInvoiceFeedViewStore();
-  const [previewInvoice, setPreviewInvoice] = useState<Invoice | null>(null);
+  const { previewInvoice, openPreview, closePreview } = useInvoiceModalStore();
   const pageSize = 20;
   const shouldUseAllFY = allowAllFY;
   const isFYReady = shouldUseAllFY || Boolean(activeFY);
@@ -248,14 +249,14 @@ export default function InvoicesAdvancedView() {
                 <InvoicesCompactCard
                   key={invoice.id}
                   invoice={invoice}
-                  onPreview={setPreviewInvoice}
+                  onPreview={openPreview}
                 />
               ))}
           </div>
         ) : (
           <InvoicesTable
             invoices={invoices}
-            onRowClick={setPreviewInvoice}
+            onRowClick={openPreview}
           />
         )}
       </section>
@@ -297,7 +298,7 @@ export default function InvoicesAdvancedView() {
           invoice={previewInvoice}
            products={products}
            currencyCode={company?.currency_code ?? ''}
-          onClose={() => setPreviewInvoice(null)}
+          onClose={closePreview}
         />
       )}
     </div>

--- a/frontend/src/pages/InvoicesAdvancedView.tsx
+++ b/frontend/src/pages/InvoicesAdvancedView.tsx
@@ -1,13 +1,17 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { LayoutGrid, Table as TableIcon } from 'lucide-react';
-import api, { getApiErrorMessage } from '../api/client';
-import type { Invoice, PaginatedInvoices, CompanyProfile } from '../types/api';
+import { getApiErrorMessage } from '../api/client';
+import type { Invoice } from '../types/api';
 import { useFY } from '../context/FYContext';
 import InvoicesTable from '../components/InvoicesTable';
 import InvoicesCompactCard from '../components/InvoicesCompactCard';
 import InvoicesTotalBreakdown from '../components/InvoicesTotalBreakdown';
 import InvoicePreview from '../components/InvoicePreview';
 import type { Product } from '../types/api';
+import { useInvoiceFeedViewStore } from '../store/useInvoiceFeedViewStore';
+import { fetchCompanyProfile, fetchInvoicePage, fetchInvoiceSummaryPages, fetchProducts } from '../features/invoices/api';
+import { invoiceQueryKeys } from '../features/invoices/queryKeys';
 
 type ViewType = 'card' | 'table';
 
@@ -37,102 +41,106 @@ function calculateBreakdown(rows: Invoice[]): Breakdown {
 
 export default function InvoicesAdvancedView() {
   const { activeFY, loading: fyLoading } = useFY();
-  const [viewType, setViewType] = useState<ViewType>('card');
-  const [invoices, setInvoices] = useState<Invoice[]>([]);
-    const [products, setProducts] = useState<Product[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState('');
-  const [invoiceSearch, setInvoiceSearch] = useState('');
-  const [showCancelled, setShowCancelled] = useState(false);
-  const [allowAllFY, setAllowAllFY] = useState(false);
-  const [page, setPage] = useState(1);
-  const [totalPages, setTotalPages] = useState(1);
-  const [total, setTotal] = useState(0);
+  const {
+    viewType,
+    invoiceSearch,
+    showCancelled,
+    allowAllFY,
+    page,
+    setViewType,
+    setInvoiceSearch,
+    setShowCancelled,
+    setAllowAllFY,
+    setPage,
+    resetPage,
+  } = useInvoiceFeedViewStore();
   const [previewInvoice, setPreviewInvoice] = useState<Invoice | null>(null);
-  const [company, setCompany] = useState<CompanyProfile | null>(null);
-  const [allPagesBreakdown, setAllPagesBreakdown] = useState<Breakdown>({ credit: 0, debit: 0, cancelled: 0, total: 0 });
   const pageSize = 20;
   const shouldUseAllFY = allowAllFY;
   const isFYReady = shouldUseAllFY || Boolean(activeFY);
+  const financialYearId = shouldUseAllFY ? undefined : activeFY?.id;
 
-  // Build query params based on FY filter
-  const getFYParams = () => {
-    if (shouldUseAllFY) {
-      return {};
-    }
-    if (!activeFY) {
-      return {};
-    }
-    return { financial_year_id: activeFY.id };
-  };
+  const invoicesQuery = useQuery({
+    queryKey: invoiceQueryKeys.list(page, pageSize, invoiceSearch, showCancelled, financialYearId),
+    queryFn: () => fetchInvoicePage({
+      page,
+      pageSize,
+      search: invoiceSearch,
+      showCancelled,
+      financialYearId,
+    }),
+    enabled: isFYReady && !fyLoading,
+  });
 
-  async function loadData() {
-    if (!isFYReady) {
-      return;
-    }
+  const companyQuery = useQuery({
+    queryKey: invoiceQueryKeys.company,
+    queryFn: fetchCompanyProfile,
+  });
 
-    try {
-      setLoading(true);
-      setError('');
-      const [invoicesRes, companyRes, productsRes] = await Promise.all([
-        api.get<PaginatedInvoices>('/invoices/', {
-          params: { 
-            page, 
-            page_size: pageSize, 
-            search: invoiceSearch, 
-            show_cancelled: showCancelled,
-            ...getFYParams(),
-          },
-        }),
-        api.get<CompanyProfile>('/company/'),
-        api.get<{ items: Product[] }>('/products/', { params: { page_size: 500 } }),
-      ]);
+  const productsQuery = useQuery<Product[]>({
+    queryKey: invoiceQueryKeys.products,
+    queryFn: fetchProducts,
+  });
 
-      setInvoices(invoicesRes.data.items);
-      setTotal(invoicesRes.data.total);
-      setTotalPages(invoicesRes.data.total_pages);
-      setCompany(companyRes.data);
-      setProducts(productsRes.data.items);
-
-      // Build summary for all pages (same filters, all matching entries)
-      const summaryRows: Invoice[] = [...invoicesRes.data.items];
-      for (let nextPage = 1; nextPage <= invoicesRes.data.total_pages; nextPage += 1) {
-        if (nextPage === page) {
-          continue;
-        }
-
-        const nextRes = await api.get<PaginatedInvoices>('/invoices/', {
-          params: {
-            page: nextPage,
-            page_size: pageSize,
-            search: invoiceSearch,
-            show_cancelled: showCancelled,
-            ...getFYParams(),
-          },
-        });
-        summaryRows.push(...nextRes.data.items);
+  const summaryRowsQuery = useQuery({
+    queryKey: invoiceQueryKeys.summary(
+      page,
+      pageSize,
+      invoiceSearch,
+      showCancelled,
+      financialYearId,
+      invoicesQuery.data?.total_pages,
+    ),
+    queryFn: async () => {
+      const pageData = invoicesQuery.data;
+      if (!pageData) {
+        return [] as Invoice[];
       }
-      setAllPagesBreakdown(calculateBreakdown(summaryRows));
-    } catch (err) {
-      setError(getApiErrorMessage(err, 'Unable to load invoices'));
-    } finally {
-      setLoading(false);
-    }
-  }
+
+      return fetchInvoiceSummaryPages(
+        {
+          pageSize,
+          search: invoiceSearch,
+          showCancelled,
+          financialYearId,
+        },
+        pageData.total_pages,
+        page,
+        pageData.items,
+      );
+    },
+    enabled: isFYReady && !fyLoading && Boolean(invoicesQuery.data),
+  });
 
   useEffect(() => {
-    setPage(1); // Reset to first page when search, filters change
+    resetPage();
   }, [invoiceSearch, showCancelled, allowAllFY, activeFY?.id]);
 
-  useEffect(() => {
-    if (!isFYReady || fyLoading) {
-      return;
-    }
+  const invoices = invoicesQuery.data?.items ?? [];
+  const totalPages = invoicesQuery.data?.total_pages ?? 1;
+  const company = companyQuery.data ?? null;
+  const products = productsQuery.data ?? [];
 
-    void loadData();
-  }, [page, invoiceSearch, showCancelled, allowAllFY, activeFY?.id, fyLoading]);
+  const loading =
+    fyLoading ||
+    invoicesQuery.isLoading ||
+    companyQuery.isLoading ||
+    productsQuery.isLoading ||
+    summaryRowsQuery.isLoading;
 
-  const currentPageBreakdown = calculateBreakdown(invoices);
+  const error = useMemo(() => {
+    if (invoicesQuery.error) return getApiErrorMessage(invoicesQuery.error, 'Unable to load invoices');
+    if (companyQuery.error) return getApiErrorMessage(companyQuery.error, 'Unable to load company profile');
+    if (productsQuery.error) return getApiErrorMessage(productsQuery.error, 'Unable to load products');
+    if (summaryRowsQuery.error) return getApiErrorMessage(summaryRowsQuery.error, 'Unable to load invoice summary');
+    return '';
+  }, [companyQuery.error, invoicesQuery.error, productsQuery.error, summaryRowsQuery.error]);
+
+  const allPagesBreakdown = useMemo(
+    () => calculateBreakdown(summaryRowsQuery.data ?? invoices),
+    [summaryRowsQuery.data, invoices],
+  );
+  const currentPageBreakdown = useMemo(() => calculateBreakdown(invoices), [invoices]);
 
   if (fyLoading || (!shouldUseAllFY && !activeFY) || !company) {
     return <div className="p-8 text-center">Loading...</div>;

--- a/frontend/src/pages/InvoicesAdvancedView.tsx
+++ b/frontend/src/pages/InvoicesAdvancedView.tsx
@@ -11,7 +11,7 @@ import InvoicePreview from '../components/InvoicePreview';
 import type { Product } from '../types/api';
 import { useInvoiceFeedViewStore } from '../store/useInvoiceFeedViewStore';
 import { useInvoiceModalStore } from '../store/useInvoiceModalStore';
-import { fetchCompanyProfile, fetchInvoicePage, fetchInvoiceSummaryPages, fetchProducts } from '../features/invoices/api';
+import { fetchCompanyProfile, fetchInvoicePage, fetchProducts } from '../features/invoices/api';
 import { invoiceQueryKeys } from '../features/invoices/queryKeys';
 
 type ViewType = 'card' | 'table';
@@ -83,36 +83,6 @@ export default function InvoicesAdvancedView() {
     queryFn: fetchProducts,
   });
 
-  const summaryRowsQuery = useQuery({
-    queryKey: invoiceQueryKeys.summary(
-      page,
-      pageSize,
-      invoiceSearch,
-      showCancelled,
-      financialYearId,
-      invoicesQuery.data?.total_pages,
-    ),
-    queryFn: async () => {
-      const pageData = invoicesQuery.data;
-      if (!pageData) {
-        return [] as Invoice[];
-      }
-
-      return fetchInvoiceSummaryPages(
-        {
-          pageSize,
-          search: invoiceSearch,
-          showCancelled,
-          financialYearId,
-        },
-        pageData.total_pages,
-        page,
-        pageData.items,
-      );
-    },
-    enabled: isFYReady && !fyLoading && Boolean(invoicesQuery.data),
-  });
-
   useEffect(() => {
     resetPage();
   }, [invoiceSearch, showCancelled, allowAllFY, activeFY?.id]);
@@ -126,21 +96,28 @@ export default function InvoicesAdvancedView() {
     fyLoading ||
     invoicesQuery.isLoading ||
     companyQuery.isLoading ||
-    productsQuery.isLoading ||
-    summaryRowsQuery.isLoading;
+    productsQuery.isLoading;
 
   const error = useMemo(() => {
     if (invoicesQuery.error) return getApiErrorMessage(invoicesQuery.error, 'Unable to load invoices');
     if (companyQuery.error) return getApiErrorMessage(companyQuery.error, 'Unable to load company profile');
     if (productsQuery.error) return getApiErrorMessage(productsQuery.error, 'Unable to load products');
-    if (summaryRowsQuery.error) return getApiErrorMessage(summaryRowsQuery.error, 'Unable to load invoice summary');
     return '';
-  }, [companyQuery.error, invoicesQuery.error, productsQuery.error, summaryRowsQuery.error]);
+  }, [companyQuery.error, invoicesQuery.error, productsQuery.error]);
 
-  const allPagesBreakdown = useMemo(
-    () => calculateBreakdown(summaryRowsQuery.data ?? invoices),
-    [summaryRowsQuery.data, invoices],
-  );
+  const allPagesBreakdown = useMemo(() => {
+    const summary = invoicesQuery.data?.summary;
+    if (!summary) {
+      return calculateBreakdown(invoices);
+    }
+
+    return {
+      total: summary.total_listed,
+      credit: summary.credit_total,
+      debit: summary.debit_total,
+      cancelled: summary.cancelled_total,
+    };
+  }, [invoicesQuery.data?.summary, invoices]);
   const currentPageBreakdown = useMemo(() => calculateBreakdown(invoices), [invoices]);
 
   if (fyLoading || (!shouldUseAllFY && !activeFY) || !company) {

--- a/frontend/src/pages/InvoicesPage.tsx
+++ b/frontend/src/pages/InvoicesPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { Eye, FileText, Pencil, Trash2, RotateCcw } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import api, { getApiErrorMessage } from '../api/client';
@@ -11,6 +12,8 @@ import LedgerCombobox from '../components/LedgerCombobox';
 import { useEscapeClose } from '../hooks/useEscapeClose';
 import formatCurrency from '../utils/formatting';
 import { useFY } from '../context/FYContext';
+import { fetchInvoiceComposerData } from '../features/invoices/api';
+import { invoiceQueryKeys } from '../features/invoices/queryKeys';
 
 type InvoiceFormItem = {
   id: number;
@@ -93,7 +96,6 @@ export default function InvoicesPage() {
   const [pendingCancelInvoiceNumber, setPendingCancelInvoiceNumber] = useState<string | null>(null);
   const [showCancelled, setShowCancelled] = useState(false);
   const [previewInvoice, setPreviewInvoice] = useState<Invoice | null>(null);
-  const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
@@ -102,41 +104,24 @@ export default function InvoicesPage() {
   const [invoiceTotal, setInvoiceTotal] = useState(0);
   const [invoiceSearch, setInvoiceSearch] = useState('');
   const invoicePageSize = 20;
+  const financialYearId = activeFY?.id;
+
+  const composerQuery = useQuery({
+    queryKey: invoiceQueryKeys.composer(invoicePage, invoicePageSize, invoiceSearch, showCancelled, financialYearId),
+    queryFn: () =>
+      fetchInvoiceComposerData({
+        page: invoicePage,
+        pageSize: invoicePageSize,
+        search: invoiceSearch,
+        showCancelled,
+        financialYearId,
+      }),
+  });
 
   async function loadInvoicePageData() {
-    try {
-      setLoading(true);
-      setError('');
-      const [productsRes, ledgersRes, invoicesRes, companyRes] = await Promise.all([
-        api.get<{ items: Product[] }>('/products/', { params: { page_size: 500 } }),
-        api.get<{ items: Ledger[] }>('/ledgers/', { params: { page_size: 500 } }),
-        api.get<PaginatedInvoices>('/invoices/', {
-          params: { page: invoicePage, page_size: invoicePageSize, search: invoiceSearch, show_cancelled: showCancelled },
-        }),
-        api.get<CompanyProfile>('/company/'),
-      ]);
-
-      setProducts(productsRes.data.items);
-      setLedgers(ledgersRes.data.items);
-      setInvoices(invoicesRes.data.items);
-      setInvoiceTotal(invoicesRes.data.total);
-      setInvoiceTotalPages(invoicesRes.data.total_pages);
-      setCompany(companyRes.data);
-      setSelectedLedgerId((current) => current || String(ledgersRes.data.items[0]?.id ?? ''));
-      setItems((current) =>
-        current.map((item, index) => {
-          const defaultProduct = productsRes.data.items[index] ?? productsRes.data.items[0];
-          return {
-            ...item,
-            productId: item.productId || String(defaultProduct?.id ?? ''),
-            unit_price: item.unit_price || String(defaultProduct?.price ?? ''),
-          };
-        })
-      );
-    } catch (err) {
-      setError(getApiErrorMessage(err, 'Unable to load invoice data'));
-    } finally {
-      setLoading(false);
+    const res = await composerQuery.refetch();
+    if (res.error) {
+      throw res.error;
     }
   }
 
@@ -153,8 +138,37 @@ export default function InvoicesPage() {
   }
 
   useEffect(() => {
-    void loadInvoicePageData();
-  }, [invoicePage, invoiceSearch, showCancelled]);
+    if (!composerQuery.data) {
+      return;
+    }
+
+    setProducts(composerQuery.data.products);
+    setLedgers(composerQuery.data.ledgers);
+    setInvoices(composerQuery.data.invoices);
+    setInvoiceTotal(composerQuery.data.invoiceTotal);
+    setInvoiceTotalPages(composerQuery.data.invoiceTotalPages);
+    setCompany(composerQuery.data.company);
+    setSelectedLedgerId((current) => current || String(composerQuery.data.ledgers[0]?.id ?? ''));
+    setItems((current) =>
+      current.map((item, index) => {
+        const defaultProduct = composerQuery.data.products[index] ?? composerQuery.data.products[0];
+        return {
+          ...item,
+          productId: item.productId || String(defaultProduct?.id ?? ''),
+          unit_price: item.unit_price || String(defaultProduct?.price ?? ''),
+        };
+      })
+    );
+  }, [composerQuery.data]);
+
+  useEffect(() => {
+    if (!composerQuery.error) {
+      return;
+    }
+    setError(getApiErrorMessage(composerQuery.error, 'Unable to load invoice data'));
+  }, [composerQuery.error]);
+
+  const loading = composerQuery.isLoading || composerQuery.isFetching;
 
   const totalAmount = items.reduce((sum, item) => {
     const product = products.find((entry) => entry.id === Number(item.productId));

--- a/frontend/src/store/useAuthStore.ts
+++ b/frontend/src/store/useAuthStore.ts
@@ -1,0 +1,74 @@
+import { create } from 'zustand';
+import api from '../api/client';
+import type { AuthToken, UserProfile } from '../types/api';
+
+function decodeEmailFromToken(token: string | null) {
+  if (!token) {
+    return null;
+  }
+
+  try {
+    const [, payload] = token.split('.');
+    const decoded = JSON.parse(atob(payload.replace(/-/g, '+').replace(/_/g, '/')));
+    return typeof decoded.sub === 'string' ? decoded.sub : null;
+  } catch {
+    return null;
+  }
+}
+
+type AuthState = {
+  token: string | null;
+  userEmail: string | null;
+  userRole: UserProfile['role'] | null;
+  setToken: (token: string | null) => void;
+  setUserRole: (role: UserProfile['role'] | null) => void;
+  hydrateUserRole: () => Promise<void>;
+  login: (email: string, password: string) => Promise<void>;
+  logout: () => void;
+};
+
+export const useAuthStore = create<AuthState>((set, get) => ({
+  token: localStorage.getItem('token'),
+  userEmail: decodeEmailFromToken(localStorage.getItem('token')),
+  userRole: null,
+
+  setToken: (token) => {
+    set({ token, userEmail: decodeEmailFromToken(token) });
+  },
+
+  setUserRole: (role) => {
+    set({ userRole: role });
+  },
+
+  hydrateUserRole: async () => {
+    const token = get().token;
+    if (!token) {
+      set({ userRole: null });
+      return;
+    }
+
+    try {
+      const res = await api.get<UserProfile>('/auth/me');
+      set({ userRole: res.data.role });
+    } catch {
+      set({ userRole: null });
+    }
+  },
+
+  login: async (email: string, password: string) => {
+    const res = await api.post<AuthToken>('/auth/login', { email, password });
+    localStorage.setItem('token', res.data.access_token);
+    localStorage.setItem('refresh_token', res.data.refresh_token);
+    set({
+      token: res.data.access_token,
+      userEmail: decodeEmailFromToken(res.data.access_token),
+    });
+    await get().hydrateUserRole();
+  },
+
+  logout: () => {
+    localStorage.removeItem('token');
+    localStorage.removeItem('refresh_token');
+    set({ token: null, userEmail: null, userRole: null });
+  },
+}));

--- a/frontend/src/store/useFYStore.ts
+++ b/frontend/src/store/useFYStore.ts
@@ -1,0 +1,49 @@
+import { create } from 'zustand';
+import { activateFinancialYear, createFinancialYear, getFinancialYears, type FinancialYear } from '../api/financialYears';
+
+type FYState = {
+  fyList: FinancialYear[];
+  loading: boolean;
+  setFYList: (list: FinancialYear[]) => void;
+  clearFYList: () => void;
+  refreshFYList: () => Promise<void>;
+  switchFY: (id: number) => Promise<void>;
+  createFY: (label: string, startDate: string, endDate: string) => Promise<void>;
+};
+
+export const useFYStore = create<FYState>((set, get) => ({
+  fyList: [],
+  loading: false,
+
+  setFYList: (list) => set({ fyList: list }),
+
+  clearFYList: () => set({ fyList: [] }),
+
+  refreshFYList: async () => {
+    set({ loading: true });
+    try {
+      const list = await getFinancialYears();
+      set({ fyList: list });
+    } catch {
+      // Keep existing list on error
+    } finally {
+      set({ loading: false });
+    }
+  },
+
+  switchFY: async (id) => {
+    const current = get().fyList;
+    set({ fyList: current.map((fy) => ({ ...fy, is_active: fy.id === id })) });
+    try {
+      await activateFinancialYear(id);
+      await get().refreshFYList();
+    } catch {
+      await get().refreshFYList();
+    }
+  },
+
+  createFY: async (label, startDate, endDate) => {
+    await createFinancialYear({ label, start_date: startDate, end_date: endDate });
+    await get().refreshFYList();
+  },
+}));

--- a/frontend/src/store/useInvoiceFeedViewStore.ts
+++ b/frontend/src/store/useInvoiceFeedViewStore.ts
@@ -1,0 +1,31 @@
+import { create } from 'zustand';
+
+type ViewType = 'card' | 'table';
+
+type InvoiceFeedViewState = {
+  viewType: ViewType;
+  invoiceSearch: string;
+  showCancelled: boolean;
+  allowAllFY: boolean;
+  page: number;
+  setViewType: (viewType: ViewType) => void;
+  setInvoiceSearch: (invoiceSearch: string) => void;
+  setShowCancelled: (showCancelled: boolean) => void;
+  setAllowAllFY: (allowAllFY: boolean) => void;
+  setPage: (page: number) => void;
+  resetPage: () => void;
+};
+
+export const useInvoiceFeedViewStore = create<InvoiceFeedViewState>((set) => ({
+  viewType: 'card',
+  invoiceSearch: '',
+  showCancelled: false,
+  allowAllFY: false,
+  page: 1,
+  setViewType: (viewType) => set({ viewType }),
+  setInvoiceSearch: (invoiceSearch) => set({ invoiceSearch }),
+  setShowCancelled: (showCancelled) => set({ showCancelled }),
+  setAllowAllFY: (allowAllFY) => set({ allowAllFY }),
+  setPage: (page) => set({ page }),
+  resetPage: () => set({ page: 1 }),
+}));

--- a/frontend/src/store/useInvoiceModalStore.ts
+++ b/frontend/src/store/useInvoiceModalStore.ts
@@ -1,0 +1,14 @@
+import { create } from 'zustand';
+import type { Invoice } from '../types/api';
+
+type InvoiceModalState = {
+  previewInvoice: Invoice | null;
+  openPreview: (invoice: Invoice) => void;
+  closePreview: () => void;
+};
+
+export const useInvoiceModalStore = create<InvoiceModalState>((set) => ({
+  previewInvoice: null,
+  openPreview: (invoice) => set({ previewInvoice: invoice }),
+  closePreview: () => set({ previewInvoice: null }),
+}));

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -85,6 +85,19 @@ export type PaginatedInvoices = {
   page: number;
   page_size: number;
   total_pages: number;
+  summary?: {
+    total_listed: number;
+    credit_total: number;
+    debit_total: number;
+    cancelled_total: number;
+    active_total: number;
+    others_total: number;
+    visible_page_total: number;
+    visible_page_count: number;
+    filtered_count: number;
+    include_cancelled: boolean;
+    financial_year_id: number | null;
+  };
 };
 
 export type CreditNoteType = 'return' | 'discount' | 'adjustment';


### PR DESCRIPTION
## Summary
Phase 1 of the migration introduces:
- **React Query** as the data-fetching foundation  
- **Zustand-backed Auth/FY internals**  
- **Backend invoice summary metadata**, eliminating multi-page summary request fan-out  

---

## Type of Change
- [x] feat (new feature)  
- [ ] fix (bug fix)  
- [ ] docs (documentation)  
- [ ] test (tests)  
- [ ] chore/refactor  

---

## How to Test
1. Start backend and frontend  
2. Open `/invoices-view`  
   - Verify invoice summary no longer triggers page 2..N fan-out requests  
3. Toggle:
   - **Search all FY**
   - **Show cancelled**  
   - Verify totals and list behavior update correctly  
4. Open `/invoices`  
   - Confirm composer, list pagination, and search still function correctly  
5. Validate:
   - Auth behavior  
   - FY switching remains intact  

---

## Checklist
- [x] My code follows project style/conventions  
- [ ] I added/updated tests where appropriate  
- [ ] I updated docs where needed  
- [x] I ran relevant checks locally  
- [x] I verified this does not break existing behavior  

---

## Screenshots
UI behavior has changed for summary loading.  
Screenshots can be added during review.

---

## Related Issue
Closes #238