### PR TITLE
feat(db): add reset-db workflow for dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-.PHONY: help dev prod down logs seed migrate migrate-up migrate-down migrate-down-all migrate-status migrate-create backend-shell frontend-shell test lint build install install-backend install-frontend
+.PHONY: help dev prod down logs seed reset-db migrate migrate-up migrate-down migrate-down-all migrate-status migrate-create backend-shell frontend-shell test lint build install install-backend install-frontend
 
 help:
 	@echo "Available commands:"
@@ -13,6 +13,7 @@ help:
 	@echo "  make down             - Stop all containers"
 	@echo "  make logs             - Tail logs for all services"
 	@echo "  make seed             - Seed default admin user"
+	@echo "  make reset-db         - Reset DB schema, run migrations, and seed admin"
 	@echo "  make migrate          - Run all pending migrations (alias for migrate-up)"
 	@echo "  make migrate-up       - Run all pending migrations"
 	@echo "  make migrate-down     - Roll back last migration"
@@ -38,6 +39,9 @@ logs:
 
 seed:
 	docker compose --profile dev exec backend-dev python seed_admin.py
+
+reset-db:
+	docker compose --profile dev exec backend-dev python reset_db.py
 
 migrate: migrate-up
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ make migrate-down                     # Roll back last migration
 make migrate-down-all                 # Roll back all migrations
 make migrate-create name=<name>       # Create a new migration file
 make seed                             # Seed admin user
+make reset-db                         # Reset DB schema, migrate, and seed admin
 make logs                             # Tail all service logs
 make down                             # Stop all services
 ```

--- a/backend/reset_db.py
+++ b/backend/reset_db.py
@@ -1,0 +1,81 @@
+"""
+Reset the database for local development.
+
+This script drops and recreates the public schema, reapplies all migrations,
+and seeds the default admin user.
+
+Usage:
+    python reset_db.py
+    python reset_db.py --skip-seed
+"""
+
+import argparse
+import importlib
+import subprocess
+import sys
+from pathlib import Path
+
+from sqlalchemy import text
+
+from src.db.base import Base
+from src.db.session import engine
+
+
+def reset_schema() -> None:
+    with engine.begin() as conn:
+        conn.execute(text("DROP SCHEMA IF EXISTS public CASCADE"))
+        conn.execute(text("CREATE SCHEMA public"))
+        conn.execute(text("GRANT ALL ON SCHEMA public TO CURRENT_USER"))
+        conn.execute(text("GRANT ALL ON SCHEMA public TO public"))
+
+
+def run_script(script_name: str, *args: str) -> None:
+    backend_dir = Path(__file__).resolve().parent
+    cmd = [sys.executable, str(backend_dir / script_name), *args]
+    subprocess.run(cmd, cwd=backend_dir, check=True)
+
+
+def load_all_models() -> None:
+    models_dir = Path(__file__).resolve().parent / "src" / "models"
+    for model_file in sorted(models_dir.glob("*.py")):
+        if model_file.name == "__init__.py":
+            continue
+        importlib.import_module(f"src.models.{model_file.stem}")
+
+
+def create_core_tables() -> None:
+    load_all_models()
+    Base.metadata.create_all(bind=engine)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Reset the database")
+    parser.add_argument(
+        "--skip-seed",
+        action="store_true",
+        help="Do not run admin seed after migrations",
+    )
+    args = parser.parse_args()
+
+    print("Resetting database schema...")
+    reset_schema()
+    print("Schema reset complete.")
+
+    print("Creating core tables...")
+    create_core_tables()
+    print("Core tables created.")
+
+    print("Applying migrations...")
+    run_script("migrate.py", "up")
+    print("Migrations applied.")
+
+    if not args.skip_seed:
+        print("Seeding admin user...")
+        run_script("seed_admin.py")
+        print("Seed complete.")
+
+    print("Database reset finished.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds a development DB reset workflow.
- Adds backend reset script that recreates schema, loads models, runs migrations, and seeds admin.
- Adds make reset-db target.
- Documents command in README.

## Type of change

- [x] feat (new feature)
- [ ] fix (bug fix)
- [x] docs (documentation)
- [ ] test (tests)
- [ ] chore/refactor

## How to test

1. Run make reset-db.
2. Verify migrations apply and admin seed succeeds.

## Checklist

- [x] My code follows project conventions
- [ ] I added/updated tests where appropriate
- [x] I updated docs where needed
- [x] I ran relevant checks locally

## Related issue

N/A