### PR TITLE
feat(onboarding): enforce company setup with guided dialogs

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,11 @@
 import { Navigate, Route, Routes } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
 import { AuthProvider, useAuth } from './context/AuthContext';
 import { FYProvider } from './context/FYContext';
 import { ShortcutsProvider } from './context/ShortcutsContext';
+import api from './api/client';
+import type { CompanyProfile } from './types/api';
+import { isCompanyConfigured } from './utils/companySetup';
 import LoginPage from './pages/LoginPage';
 import DashboardPage from './pages/DashboardPage';
 import ProductsPage from './pages/ProductsPage';
@@ -48,6 +52,31 @@ function AdminOnly({ children }: { children: React.ReactNode }) {
   return children;
 }
 
+function CompanyRequired({ children }: { children: React.ReactNode }) {
+  const companyQuery = useQuery({
+    queryKey: ['company-setup-required'],
+    queryFn: async () => {
+      const response = await api.get<CompanyProfile>('/company/');
+      return response.data;
+    },
+    retry: false,
+  });
+
+  if (companyQuery.isLoading) {
+    return <div className="empty-state">Loading company profile...</div>;
+  }
+
+  if (companyQuery.error) {
+    return children;
+  }
+
+  if (!isCompanyConfigured(companyQuery.data)) {
+    return <Navigate to="/company?setup=required" replace />;
+  }
+
+  return children;
+}
+
 function AppRoutes() {
   return (
     <Routes>
@@ -59,20 +88,20 @@ function AppRoutes() {
           </PublicOnly>
         }
       />
-      <Route path="/" element={<Protected><Layout><DashboardPage /></Layout></Protected>} />
-      <Route path="/products" element={<Protected><Layout><ProductsPage /></Layout></Protected>} />
-      <Route path="/inventory" element={<Protected><Layout><InventoryPage /></Layout></Protected>} />
-      <Route path="/ledgers" element={<Protected><Layout><LedgersPage /></Layout></Protected>} />
-      <Route path="/ledgers/new" element={<Protected><Layout><LedgerCreatePage /></Layout></Protected>} />
-      <Route path="/ledgers/:id" element={<Protected><Layout><LedgerViewPage /></Layout></Protected>} />
-      <Route path="/ledgers/:id/edit" element={<Protected><Layout><LedgerCreatePage /></Layout></Protected>} />
-      <Route path="/day-book" element={<Protected><Layout><DayBookPage /></Layout></Protected>} />
-      <Route path="/invoices" element={<Protected><Layout><InvoicesPage /></Layout></Protected>} />
-        <Route path="/invoices-view" element={<Protected><Layout><InvoicesAdvancedView /></Layout></Protected>} />
-      <Route path="/credit-notes" element={<Protected><Layout><CreditNotesPage /></Layout></Protected>} />
+      <Route path="/" element={<Protected><CompanyRequired><Layout><DashboardPage /></Layout></CompanyRequired></Protected>} />
+      <Route path="/products" element={<Protected><CompanyRequired><Layout><ProductsPage /></Layout></CompanyRequired></Protected>} />
+      <Route path="/inventory" element={<Protected><CompanyRequired><Layout><InventoryPage /></Layout></CompanyRequired></Protected>} />
+      <Route path="/ledgers" element={<Protected><CompanyRequired><Layout><LedgersPage /></Layout></CompanyRequired></Protected>} />
+      <Route path="/ledgers/new" element={<Protected><CompanyRequired><Layout><LedgerCreatePage /></Layout></CompanyRequired></Protected>} />
+      <Route path="/ledgers/:id" element={<Protected><CompanyRequired><Layout><LedgerViewPage /></Layout></CompanyRequired></Protected>} />
+      <Route path="/ledgers/:id/edit" element={<Protected><CompanyRequired><Layout><LedgerCreatePage /></Layout></CompanyRequired></Protected>} />
+      <Route path="/day-book" element={<Protected><CompanyRequired><Layout><DayBookPage /></Layout></CompanyRequired></Protected>} />
+      <Route path="/invoices" element={<Protected><CompanyRequired><Layout><InvoicesPage /></Layout></CompanyRequired></Protected>} />
+        <Route path="/invoices-view" element={<Protected><CompanyRequired><Layout><InvoicesAdvancedView /></Layout></CompanyRequired></Protected>} />
+      <Route path="/credit-notes" element={<Protected><CompanyRequired><Layout><CreditNotesPage /></Layout></CompanyRequired></Protected>} />
       <Route path="/company" element={<Protected><Layout><CompanyPage /></Layout></Protected>} />
-      <Route path="/smtp-settings" element={<Protected><AdminOnly><Layout><SmtpSettingsPage /></Layout></AdminOnly></Protected>} />
-      <Route path="/shortcuts" element={<Protected><Layout><KeyboardShortcutsPage /></Layout></Protected>} />
+      <Route path="/smtp-settings" element={<Protected><CompanyRequired><AdminOnly><Layout><SmtpSettingsPage /></Layout></AdminOnly></CompanyRequired></Protected>} />
+      <Route path="/shortcuts" element={<Protected><CompanyRequired><Layout><KeyboardShortcutsPage /></Layout></CompanyRequired></Protected>} />
       <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>
   );

--- a/frontend/src/pages/CompanyPage.tsx
+++ b/frontend/src/pages/CompanyPage.tsx
@@ -1,8 +1,11 @@
 import { useEffect, useRef, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import api, { getApiErrorMessage } from '../api/client';
 import StatusToasts from '../components/StatusToasts';
+import { useAuth } from '../context/AuthContext';
 import { useFY } from '../context/FYContext';
 import type { CompanyProfile, CompanyProfileUpdate, InvoiceSeries, InvoiceSeriesUpdate } from '../types/api';
+import { isCompanyConfigured } from '../utils/companySetup';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -38,7 +41,7 @@ function buildPreview(s: InvoiceSeriesUpdate, nextSeq: number, fyLabel?: string 
 
 type SeriesRowState = InvoiceSeriesUpdate;
 
-function InvoiceSeriesCard() {
+function InvoiceSeriesCard({ sectionRef }: { sectionRef?: React.RefObject<HTMLElement> }) {
   const { activeFY } = useFY();
   const [seriesList, setSeriesList] = useState<InvoiceSeries[]>([]);
   const [drafts, setDrafts] = useState<Record<number, SeriesRowState>>({});
@@ -105,7 +108,7 @@ function InvoiceSeriesCard() {
   if (seriesList.length === 0) return null;
 
   return (
-    <article className="panel stack">
+    <article className="panel stack" id="invoice-series-settings" ref={sectionRef} tabIndex={-1}>
       <div className="panel__header">
         <div>
           <p className="eyebrow">Numbering</p>
@@ -236,6 +239,11 @@ function InvoiceSeriesCard() {
 // ---------------------------------------------------------------------------
 
 export default function CompanyPage() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const { isAdmin } = useAuth();
+  const seriesSectionRef = useRef<HTMLElement>(null);
+  const companySetupSectionRef = useRef<HTMLElement>(null);
   const [form, setForm] = useState<CompanyProfileUpdate>({
     name: '',
     address: '',
@@ -254,12 +262,26 @@ export default function CompanyPage() {
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
+  const [initialSetupRequired, setInitialSetupRequired] = useState<boolean | null>(null);
+  const [showFirstSetupPrompt, setShowFirstSetupPrompt] = useState(false);
+  const setupRequiredByRoute = searchParams.get('setup') === 'required';
+  const [showSetupDialog, setShowSetupDialog] = useState(setupRequiredByRoute);
+  const [highlightCompanySetup, setHighlightCompanySetup] = useState(false);
+
+  useEffect(() => {
+    if (setupRequiredByRoute) {
+      setShowSetupDialog(true);
+    }
+  }, [setupRequiredByRoute]);
 
   async function loadCompanyProfile() {
     try {
       setLoading(true);
       setError('');
       const response = await api.get<CompanyProfile>('/company/');
+      if (initialSetupRequired === null) {
+        setInitialSetupRequired(!isCompanyConfigured(response.data));
+      }
       setForm({
         name: response.data.name || '',
         address: response.data.address || '',
@@ -310,11 +332,43 @@ export default function CompanyPage() {
 
       await api.put<CompanyProfile>('/company/', payload);
       setSuccess('Company profile saved. New invoices will now show this as billing company.');
+      if (initialSetupRequired && payload.name) {
+        setShowFirstSetupPrompt(true);
+      }
       await loadCompanyProfile();
     } catch (err) {
       setError(getApiErrorMessage(err, 'Unable to save company profile'));
     } finally {
       setSubmitting(false);
+    }
+  }
+
+  function handleAdjustInvoiceSeries() {
+    setShowFirstSetupPrompt(false);
+    const section = seriesSectionRef.current;
+    if (section) {
+      section.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      section.focus();
+    }
+  }
+
+  function handleSkipOnboardingStep() {
+    setShowFirstSetupPrompt(false);
+    navigate('/');
+  }
+
+  function dismissSetupDialog() {
+    setShowSetupDialog(false);
+    setHighlightCompanySetup(true);
+    setTimeout(() => setHighlightCompanySetup(false), 2500);
+
+    const section = companySetupSectionRef.current;
+    if (section) {
+      section.focus({ preventScroll: true });
+    }
+
+    if (setupRequiredByRoute) {
+      navigate('/company', { replace: true });
     }
   }
 
@@ -330,8 +384,80 @@ export default function CompanyPage() {
 
       <StatusToasts error={error} success={success} onClearError={() => setError('')} onClearSuccess={() => setSuccess('')} />
 
+      {showSetupDialog ? (
+        <div className="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="setup-required-title">
+          <div className="modal-panel">
+            <div className="panel__header">
+              <div>
+                <p className="eyebrow">Getting started</p>
+                <h2 id="setup-required-title" className="nav-panel__title">Complete company setup to continue</h2>
+              </div>
+            </div>
+            <p className="section-copy" style={{ marginTop: '8px' }}>
+              Save your company details first. After saving, you can optionally adjust invoice numbering series.
+            </p>
+            <div className="button-row" style={{ marginTop: '16px' }}>
+              <button
+                type="button"
+                className="button button--primary"
+                onClick={dismissSetupDialog}
+                title="Start company setup"
+                aria-label="Start company setup"
+              >
+                Start setup
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      {showFirstSetupPrompt ? (
+        <div className="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="company-created-title">
+          <div className="modal-panel">
+            <div className="panel__header">
+              <div>
+                <p className="eyebrow">Next step</p>
+                <h2 id="company-created-title" className="nav-panel__title">Company created successfully</h2>
+              </div>
+            </div>
+            <p className="section-copy" style={{ marginTop: '8px' }}>
+              {isAdmin
+                ? 'You can now optionally adjust invoice series before creating invoices.'
+                : 'Setup is complete. You can continue to dashboard now.'}
+            </p>
+            <div className="button-row" style={{ marginTop: '16px' }}>
+              {isAdmin ? (
+                <button
+                  type="button"
+                  className="button button--secondary"
+                  onClick={handleAdjustInvoiceSeries}
+                  title="Adjust invoice series"
+                  aria-label="Adjust invoice series"
+                >
+                  Adjust invoice series
+                </button>
+              ) : null}
+              <button
+                type="button"
+                className="button button--ghost"
+                onClick={handleSkipOnboardingStep}
+                title="Skip for now"
+                aria-label="Skip for now"
+              >
+                Skip for now
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+
       <section className="content-grid">
-        <article className="panel stack">
+        <article
+          className="panel stack"
+          ref={companySetupSectionRef}
+          tabIndex={-1}
+          style={highlightCompanySetup ? { borderColor: 'var(--color-primary)', boxShadow: '0 0 0 3px rgba(59, 130, 246, 0.25)' } : undefined}
+        >
           <div className="panel__header">
             <div>
               <p className="eyebrow">Company setup</p>
@@ -495,7 +621,7 @@ export default function CompanyPage() {
           ) : null}
         </article>
 
-        <InvoiceSeriesCard />
+        <InvoiceSeriesCard sectionRef={seriesSectionRef} />
       </section>
     </div>
   );

--- a/frontend/src/utils/companySetup.ts
+++ b/frontend/src/utils/companySetup.ts
@@ -1,0 +1,5 @@
+import type { CompanyProfile } from '../types/api';
+
+export function isCompanyConfigured(company: CompanyProfile | null | undefined): boolean {
+  return Boolean(company?.name?.trim());
+}


### PR DESCRIPTION
## Summary

Adds first-run company onboarding enforcement and guided setup dialogs.

- Enforces company setup across protected routes using a company guard.
- Redirects unconfigured users to Company setup with onboarding context.
- Converts onboarding prompts to dialogs ("Getting started" and post-save "Company created successfully").
- Adds optional next step to adjust invoice series after first successful company save.
- Adds non-jarring visual guidance (highlight/focus) without scrolling the page after starting setup.

## Type of change

- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs (documentation)
- [ ] test (tests)
- [ ] chore/refactor

## How to test

1. Log in with a user whose company profile is not configured (empty company name).
2. Navigate to any protected page (for example /invoices) and verify redirect to /company?setup=required.
3. Confirm the "Getting started" dialog appears; click "Start setup".
4. Verify the Company setup section is highlighted/focused and the page does not auto-scroll down.
5. Save valid company details.
6. Confirm "Company created successfully" dialog appears.
7. As admin: click "Adjust invoice series" and verify invoice series section is targeted.
8. Click "Skip for now" and verify navigation to dashboard (/).
9. Run frontend build and verify success.

## Checklist

- [x] My code follows the project style and conventions
- [ ] I added/updated tests where appropriate
- [ ] I updated docs where needed
- [x] I ran relevant checks locally
- [x] I verified this does not break existing behavior

## Screenshots (if UI changes)

UI changes included (dialogs and onboarding highlight). Screenshots can be added during review.

## Related issue

N/A