### PR TITLE
fix(ui): keep modals above sticky header

### DIFF
--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -332,6 +332,9 @@ textarea {
 .page-frame,
 .section-card {
   position: relative;
+}
+
+.section-card {
   z-index: 1;
 }
 
@@ -1072,7 +1075,7 @@ textarea {
 .modal-overlay {
   position: fixed;
   inset: 0;
-  z-index: 20;
+  z-index: 400;
   display: grid;
   place-items: start center;
   padding: 20px;


### PR DESCRIPTION
## Summary

Fixes modal layering so fixed overlays render above the sticky page header.
Removes the extra stacking context from the page frame and raises the modal overlay z-index to sit above the header and sidebar.

## Type of change

- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] docs (documentation)
- [ ] test (tests)
- [ ] chore/refactor

## How to test

1. Open a page that can show a modal, such as invoice creation or send email.
2. Scroll to the top so the sticky header is visible.
3. Open the modal and confirm the close button and top actions render above the header and remain clickable.
4. Run `cd frontend && npm run build`.

## Checklist

- [x] My code follows the project style and conventions
- [ ] I added/updated tests where appropriate
- [ ] I updated docs where needed
- [x] I ran relevant checks locally
- [x] I verified this does not break existing behavior

## Screenshots (if UI changes)

Not included.

## Related issue

Closes #264