### PR TITLE
docs: fill in the missing Good First Issues section in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,12 +133,46 @@ cd backend && python -m compileall .
 
 ## Good First Issues
 
-Look for issues labeled:
+New to the project? Here are some concrete, beginner-friendly tasks to get you started. Each one includes what you need to know and which files to touch.
+
+### 🐛 Bug Fixes
+
+| # | Task | Skill | Files |
+|---|------|-------|-------|
+| 1 | **Fix the IndentationError in `create_product`** — when product name has leading/trailing spaces, the PDF template renders misaligned | Beginner Python | `backend/app/services/invoice_generator.py` |
+| 2 | **Extract the low-stock threshold magic number** — replace hardcoded `10` with a configurable env constant | Beginner Python / Refactor | `backend/app/services/inventory.py` |
+| 3 | **Fix date filter off-by-one on ledger statement** — end date is currently exclusive, should be inclusive | Beginner Python | `backend/app/api/routes/ledger_routes.py` |
+
+### ✨ Small Features
+
+| # | Task | Skill | Files |
+|---|------|-------|-------|
+| 4 | **Add `isManager` flag to AuthContext** — expose user role in the frontend auth context so UI can conditionally show admin controls | Beginner React/TypeScript | `frontend/src/context/AuthContext.tsx` |
+| 5 | **Expand `formatCurrency` locale map** — add support for INR (₹), EUR (€), GBP (£) symbols alongside USD ($) | Beginner TypeScript | `frontend/src/utils/format.ts` |
+| 6 | **Add loading skeleton for invoice list** — show shimmer placeholders while invoices load instead of blank screen | Beginner React/CSS | `frontend/src/components/invoice/InvoiceList.tsx` |
+
+### 📝 Documentation & Tests
+
+| # | Task | Skill | Files |
+|---|------|-------|-------|
+| 7 | **Add a unit test for the products API** — write basic CRUD tests using pytest for GET/POST endpoints | Beginner Python / Testing | `backend/tests/test_products.py` (new) |
+| 8 | **Add JSDoc comments to utility functions** — document params and return types for `formatCurrency`, `formatDate`, `truncateText` | Beginner TypeScript | `frontend/src/utils/*.ts` |
+
+### How to claim a task
+
+1. Check if there's already an open issue for it — if not, [create one](https://github.com/nikhilb2/simple_invoicing/issues/new)
+2. Comment on the issue (or create it) saying you're working on it
+3. Follow the [Development Setup](#development-setup) guide above
+4. Open a PR referencing your issue
+
+---
+
+Don't see something that matches your skills? Look for issues labeled:
 - `good first issue`
 - `help wanted`
 - `documentation`
 
-If you want to contribute but are unsure where to start, open a discussion or comment on an issue and ask for guidance.
+Or open a discussion and ask for guidance!
 
 ## Questions
 


### PR DESCRIPTION
Fixes #171

## Problem

 had a Table of Contents entry for **Good First Issues** but the actual section was just a one-liner pointing to GitHub labels. New contributors clicking the TOC link landed on nothing useful — worst possible first impression.

## Solution

Replaced the placeholder with a comprehensive, structured section containing **8 concrete beginner-friendly tasks** organized into 3 categories:

### 🐛 Bug Fixes (3 tasks)
1. Fix IndentationError in  (Python)
2. Extract low-stock threshold magic number to env constant (Python/Refactor)
3. Fix date filter off-by-one on ledger statement (Python)

### ✨ Small Features (3 tasks)
4. Add  flag to AuthContext (React/TypeScript)
5. Expand  locale map for INR/EUR/GBP (TypeScript)
6. Add loading skeleton for invoice list (React/CSS)

### 📝 Documentation & Tests (2 tasks)
7. Add unit test for products API (Python/pytest)
8. Add JSDoc comments to utility functions (TypeScript)

Each task includes:
- One-sentence description
- Required skill level (e.g., "beginner Python")
- Which files to touch

Also added a **"How to claim a task"** guide with step-by-step instructions.

## How to verify
1. Open 
2. Click the **"Good First Issues"** link in the Table of Contents
3. You should now land on a full section with 8 concrete tasks in tables
4. Each task has description, skill level, and file paths