### PR TITLE
fix(invoices): use company currency in invoice feed

### DIFF
--- a/frontend/src/components/InvoicesCompactCard.tsx
+++ b/frontend/src/components/InvoicesCompactCard.tsx
@@ -4,10 +4,11 @@ import formatCurrency from '../utils/formatting';
 
 interface InvoicesCompactCardProps {
   invoice: Invoice;
+  currencyCode: string;
   onPreview: (invoice: Invoice) => void;
 }
 
-  export default function InvoicesCompactCard({ invoice, onPreview }: InvoicesCompactCardProps) {
+  export default function InvoicesCompactCard({ invoice, currencyCode, onPreview }: InvoicesCompactCardProps) {
   const isCredit = invoice.voucher_type === 'purchase';
   const isCancelled = invoice.status === 'cancelled';
 
@@ -77,11 +78,11 @@ interface InvoicesCompactCardProps {
               {isCredit ? 'Credit' : 'Debit'}
             </div>
               <div className={`invoice-compact-card__amount invoice-compact-card__amount--${invoice.voucher_type}`}>
-              {formatCurrency(invoice.total_amount)}
+              {formatCurrency(invoice.total_amount, invoice.company_currency_code || currencyCode)}
             </div>
             {invoice.total_tax_amount > 0 && (
                 <div className="invoice-compact-card__meta">
-                Tax: {formatCurrency(invoice.total_tax_amount)}
+                Tax: {formatCurrency(invoice.total_tax_amount, invoice.company_currency_code || currencyCode)}
               </div>
             )}
           </div>

--- a/frontend/src/components/InvoicesTable.tsx
+++ b/frontend/src/components/InvoicesTable.tsx
@@ -3,10 +3,11 @@ import formatCurrency from '../utils/formatting';
 
 interface InvoicesTableProps {
   invoices: Invoice[];
+  currencyCode: string;
   onRowClick: (invoice: Invoice) => void;
 }
 
-export default function InvoicesTable({ invoices, onRowClick }: InvoicesTableProps) {
+export default function InvoicesTable({ invoices, currencyCode, onRowClick }: InvoicesTableProps) {
   return (
     <div className="invoice-feed-table-wrap">
       <table className="invoice-feed-table">
@@ -45,7 +46,7 @@ export default function InvoicesTable({ invoices, onRowClick }: InvoicesTablePro
                   )}
                 </td>
                 <td className="invoice-feed-table__amount">
-                  {formatCurrency(invoice.total_amount)}
+                  {formatCurrency(invoice.total_amount, invoice.company_currency_code || currencyCode)}
                 </td>
                 <td>
                   <span className={`invoice-type-badge invoice-type-badge--${invoice.voucher_type}`}>

--- a/frontend/src/components/InvoicesTotalBreakdown.tsx
+++ b/frontend/src/components/InvoicesTotalBreakdown.tsx
@@ -9,11 +9,12 @@ interface Breakdown {
 
 interface InvoicesTotalBreakdownProps {
   breakdown: Breakdown;
+  currencyCode: string;
   title?: string;
   note?: string;
 }
 
-export default function InvoicesTotalBreakdown({ breakdown, title, note }: InvoicesTotalBreakdownProps) {
+export default function InvoicesTotalBreakdown({ breakdown, currencyCode, title, note }: InvoicesTotalBreakdownProps) {
   return (
     <section className="panel invoice-feed-breakdown">
       {(title || note) && (
@@ -25,24 +26,24 @@ export default function InvoicesTotalBreakdown({ breakdown, title, note }: Invoi
       <div className="invoice-feed-breakdown__grid">
         <div className="invoice-feed-breakdown__cell">
           <div className="invoice-feed-breakdown__label">Total Listed</div>
-          <div className="invoice-feed-breakdown__value">{formatCurrency(breakdown.total)}</div>
+          <div className="invoice-feed-breakdown__value">{formatCurrency(breakdown.total, currencyCode)}</div>
         </div>
         <div className="invoice-feed-breakdown__cell">
           <div className="invoice-feed-breakdown__label">Credit (Purchase)</div>
-          <div className="invoice-feed-breakdown__value invoice-feed-breakdown__value--purchase">{formatCurrency(breakdown.credit)}</div>
+          <div className="invoice-feed-breakdown__value invoice-feed-breakdown__value--purchase">{formatCurrency(breakdown.credit, currencyCode)}</div>
         </div>
         <div className="invoice-feed-breakdown__cell">
           <div className="invoice-feed-breakdown__label">Debit (Sales)</div>
-          <div className="invoice-feed-breakdown__value invoice-feed-breakdown__value--sales">{formatCurrency(breakdown.debit)}</div>
+          <div className="invoice-feed-breakdown__value invoice-feed-breakdown__value--sales">{formatCurrency(breakdown.debit, currencyCode)}</div>
         </div>
         <div className="invoice-feed-breakdown__cell">
           <div className="invoice-feed-breakdown__label">Cancelled</div>
-          <div className="invoice-feed-breakdown__value invoice-feed-breakdown__value--cancelled">{formatCurrency(breakdown.cancelled)}</div>
+          <div className="invoice-feed-breakdown__value invoice-feed-breakdown__value--cancelled">{formatCurrency(breakdown.cancelled, currencyCode)}</div>
         </div>
         <div className="invoice-feed-breakdown__cell">
           <div className="invoice-feed-breakdown__label">Active Total</div>
           <div className="invoice-feed-breakdown__value invoice-feed-breakdown__value--active">
-            {formatCurrency(breakdown.credit + breakdown.debit)}
+            {formatCurrency(breakdown.credit + breakdown.debit, currencyCode)}
           </div>
         </div>
       </div>

--- a/frontend/src/pages/InvoicesAdvancedView.tsx
+++ b/frontend/src/pages/InvoicesAdvancedView.tsx
@@ -90,6 +90,7 @@ export default function InvoicesAdvancedView() {
   const invoices = invoicesQuery.data?.items ?? [];
   const totalPages = invoicesQuery.data?.total_pages ?? 1;
   const company = companyQuery.data ?? null;
+  const activeCurrencyCode = company?.currency_code || 'INR';
   const products = productsQuery.data ?? [];
 
   const loading =
@@ -210,6 +211,7 @@ export default function InvoicesAdvancedView() {
 
       <InvoicesTotalBreakdown
         breakdown={allPagesBreakdown}
+        currencyCode={activeCurrencyCode}
         title="Summary of all pages"
         note="This summary includes all invoice entries matching your current filters across every page."
       />
@@ -226,6 +228,7 @@ export default function InvoicesAdvancedView() {
                 <InvoicesCompactCard
                   key={invoice.id}
                   invoice={invoice}
+                  currencyCode={activeCurrencyCode}
                   onPreview={openPreview}
                 />
               ))}
@@ -233,6 +236,7 @@ export default function InvoicesAdvancedView() {
         ) : (
           <InvoicesTable
             invoices={invoices}
+            currencyCode={activeCurrencyCode}
             onRowClick={openPreview}
           />
         )}
@@ -265,6 +269,7 @@ export default function InvoicesAdvancedView() {
 
       <InvoicesTotalBreakdown
         breakdown={currentPageBreakdown}
+        currencyCode={activeCurrencyCode}
         title="Summary of current visible page"
         note="This summary is calculated only from the invoice entries visible on this page."
       />
@@ -273,8 +278,8 @@ export default function InvoicesAdvancedView() {
       {previewInvoice && (
         <InvoicePreview
           invoice={previewInvoice}
-           products={products}
-           currencyCode={company?.currency_code ?? ''}
+          products={products}
+          currencyCode={activeCurrencyCode}
           onClose={closePreview}
         />
       )}


### PR DESCRIPTION
## Summary

Fixes currency formatting on /invoices-view so amounts use the company currency instead of defaulting to USD when rendering the feed cards, table, and summary blocks.

## Type of change

- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] docs (documentation)
- [ ] test (tests)
- [ ] chore/refactor

## How to test

1. Open /invoices-view.
2. Ensure company currency is set in Company settings (for example INR).
3. Verify card view amounts and tax values show the company currency symbol.
4. Switch to table view and verify amount formatting uses the same company currency.
5. Verify both top and bottom summary blocks use the company currency.

## Checklist

- [x] My code follows the project style and conventions
- [ ] I added/updated tests where appropriate
- [ ] I updated docs where needed
- [x] I ran relevant checks locally
- [x] I verified this does not break existing behavior

## Screenshots (if UI changes)

N/A

## Related issue

Closes #