### PR TITLE
fix(ledger): make GST optional with conditional validation

### DIFF
--- a/backend/migrations/20260414000001_make_buyer_gst_optional.py
+++ b/backend/migrations/20260414000001_make_buyer_gst_optional.py
@@ -1,0 +1,15 @@
+"""
+Make buyer (ledger) GST optional
+"""
+
+from sqlalchemy import text
+
+
+def up(conn) -> None:
+    conn.execute(text("UPDATE buyers SET gst = NULL WHERE btrim(gst) = ''"))
+    conn.execute(text("ALTER TABLE buyers ALTER COLUMN gst DROP NOT NULL"))
+
+
+def down(conn) -> None:
+    conn.execute(text("UPDATE buyers SET gst = '' WHERE gst IS NULL"))
+    conn.execute(text("ALTER TABLE buyers ALTER COLUMN gst SET NOT NULL"))

--- a/backend/src/api/routes/buyers.py
+++ b/backend/src/api/routes/buyers.py
@@ -17,14 +17,16 @@ def create_buyer(
     db: Session = Depends(get_db),
     _: User = Depends(require_roles(UserRole.admin, UserRole.manager)),
 ):
-    existing_buyer = db.query(Buyer).filter(Buyer.gst == payload.gst.strip()).first()
-    if existing_buyer:
-        raise HTTPException(status_code=400, detail="Buyer with this GST already exists")
+    gst = payload.gst
+    if gst:
+        existing_buyer = db.query(Buyer).filter(Buyer.gst == gst).first()
+        if existing_buyer:
+            raise HTTPException(status_code=400, detail="Buyer with this GST already exists")
 
     buyer = Buyer(
         name=payload.name.strip(),
         address=payload.address.strip(),
-        gst=payload.gst.strip().upper(),
+        gst=gst,
         phone_number=payload.phone_number.strip(),
         email=payload.email.strip() if payload.email else None,
         website=payload.website.strip() if payload.website else None,

--- a/backend/src/api/routes/invoices.py
+++ b/backend/src/api/routes/invoices.py
@@ -127,12 +127,6 @@ def _apply_payload_to_invoice(
             active_financial_year_id,
         )
 
-    if not invoice.company_gst or not invoice.ledger_gst:
-        raise HTTPException(
-            status_code=400,
-            detail="Company GSTIN and ledger GSTIN are required before creating an invoice",
-        )
-
     if not payload.items:
         raise HTTPException(status_code=400, detail="Invoice must have at least one line item")
 

--- a/backend/src/api/routes/ledgers.py
+++ b/backend/src/api/routes/ledgers.py
@@ -166,27 +166,29 @@ def create_ledger(
     db: Session = Depends(get_db),
     _: User = Depends(require_roles(UserRole.admin, UserRole.manager)),
 ):
-    existing_ledger = db.query(Ledger).filter(Ledger.gst == payload.gst.strip()).first()
+  gst = payload.gst
+  if gst:
+    existing_ledger = db.query(Ledger).filter(Ledger.gst == gst).first()
     if existing_ledger:
-        raise HTTPException(status_code=400, detail="Ledger with this GST already exists")
+      raise HTTPException(status_code=400, detail="Ledger with this GST already exists")
 
-    ledger = Ledger(
-        name=payload.name.strip(),
-        address=payload.address.strip(),
-        gst=payload.gst.strip().upper(),
-        phone_number=payload.phone_number.strip(),
-        email=payload.email.strip() if payload.email else None,
-        website=payload.website.strip() if payload.website else None,
-        bank_name=payload.bank_name.strip() if payload.bank_name else None,
-        branch_name=payload.branch_name.strip() if payload.branch_name else None,
-        account_name=payload.account_name.strip() if payload.account_name else None,
-        account_number=payload.account_number.strip() if payload.account_number else None,
-        ifsc_code=payload.ifsc_code.strip().upper() if payload.ifsc_code else None,
-    )
-    db.add(ledger)
-    db.commit()
-    db.refresh(ledger)
-    return ledger
+  ledger = Ledger(
+    name=payload.name.strip(),
+    address=payload.address.strip(),
+    gst=gst,
+    phone_number=payload.phone_number.strip(),
+    email=payload.email.strip() if payload.email else None,
+    website=payload.website.strip() if payload.website else None,
+    bank_name=payload.bank_name.strip() if payload.bank_name else None,
+    branch_name=payload.branch_name.strip() if payload.branch_name else None,
+    account_name=payload.account_name.strip() if payload.account_name else None,
+    account_number=payload.account_number.strip() if payload.account_number else None,
+    ifsc_code=payload.ifsc_code.strip().upper() if payload.ifsc_code else None,
+  )
+  db.add(ledger)
+  db.commit()
+  db.refresh(ledger)
+  return ledger
 
 
 @router.get("", response_model=PaginatedLedgerOut, include_in_schema=False)
@@ -337,10 +339,11 @@ def update_ledger(
     if not ledger:
         raise HTTPException(status_code=404, detail=f"Ledger {ledger_id} not found")
 
-    gst = payload.gst.strip().upper()
-    gst_owner = db.query(Ledger).filter(Ledger.gst == gst, Ledger.id != ledger_id).first()
-    if gst_owner:
-        raise HTTPException(status_code=400, detail="Ledger with this GST already exists")
+    gst = payload.gst
+    if gst:
+        gst_owner = db.query(Ledger).filter(Ledger.gst == gst, Ledger.id != ledger_id).first()
+        if gst_owner:
+            raise HTTPException(status_code=400, detail="Ledger with this GST already exists")
 
     ledger.name = payload.name.strip()
     ledger.address = payload.address.strip()
@@ -493,6 +496,9 @@ def _build_statement_html(
     company_gst = f"GST: {_e(company.gst)}" if company and company.gst else ""
     company_phone = f"Phone: {_e(company.phone_number)}" if company and company.phone_number else ""
     company_details = " &middot; ".join(p for p in [company_gst, company_phone] if p)
+    ledger_gst = f"GST: {_e(ledger.gst)}" if ledger.gst else ""
+    ledger_phone = f"Phone: {_e(ledger.phone_number)}" if ledger.phone_number else ""
+    ledger_details = " &middot; ".join(p for p in [ledger_gst, ledger_phone] if p)
 
     html = f"""<!DOCTYPE html>
 <html>
@@ -674,7 +680,7 @@ def _build_statement_html(
     <p class="eyebrow">Ledger</p>
     <h4>{_e(ledger.name)}</h4>
     <p>{_e(ledger.address)}</p>
-    <p>GST: {_e(ledger.gst)} &middot; Phone: {_e(ledger.phone_number)}</p>
+    <p>{ledger_details}</p>
   </section>
 
   <section class="summary">

--- a/backend/src/models/buyer.py
+++ b/backend/src/models/buyer.py
@@ -10,7 +10,7 @@ class Buyer(Base):
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String, nullable=False, index=True)
     address = Column(String, nullable=False)
-    gst = Column(String, nullable=False, unique=True, index=True)
+    gst = Column(String, nullable=True, unique=True, index=True)
     phone_number = Column(String, nullable=False)
     email = Column(String, nullable=True)
     website = Column(String, nullable=True)

--- a/backend/src/schemas/buyer.py
+++ b/backend/src/schemas/buyer.py
@@ -6,7 +6,7 @@ from src.core.validation import normalize_gstin
 class BuyerCreate(BaseModel):
     name: str
     address: str
-    gst: str
+    gst: str | None = None
     phone_number: str
     email: str | None = None
     website: str | None = None
@@ -18,18 +18,15 @@ class BuyerCreate(BaseModel):
 
     @field_validator("gst")
     @classmethod
-    def validate_gst(cls, value: str) -> str:
-        normalized = normalize_gstin(value)
-        if normalized is None:
-            raise ValueError("GSTIN is required")
-        return normalized
+    def validate_gst(cls, value: str | None) -> str | None:
+        return normalize_gstin(value)
 
 
 class BuyerOut(BaseModel):
     id: int
     name: str
     address: str
-    gst: str
+    gst: str = ""
     phone_number: str
     email: str | None = None
     website: str | None = None
@@ -38,6 +35,12 @@ class BuyerOut(BaseModel):
     account_name: str | None = None
     account_number: str | None = None
     ifsc_code: str | None = None
+
+    @field_validator("gst", mode="before")
+    @classmethod
+    def normalize_gst_output(cls, value: str | None) -> str:
+        normalized = normalize_gstin(value)
+        return normalized or ""
 
     class Config:
         from_attributes = True

--- a/backend/src/schemas/ledger.py
+++ b/backend/src/schemas/ledger.py
@@ -7,7 +7,7 @@ from src.core.validation import normalize_gstin
 class LedgerCreate(BaseModel):
     name: str
     address: str
-    gst: str
+    gst: str | None = None
     phone_number: str
     email: str | None = None
     website: str | None = None
@@ -19,18 +19,15 @@ class LedgerCreate(BaseModel):
 
     @field_validator("gst")
     @classmethod
-    def validate_gst(cls, value: str) -> str:
-        normalized = normalize_gstin(value)
-        if normalized is None:
-            raise ValueError("GSTIN is required")
-        return normalized
+    def validate_gst(cls, value: str | None) -> str | None:
+        return normalize_gstin(value)
 
 
 class LedgerOut(BaseModel):
     id: int
     name: str
     address: str
-    gst: str
+    gst: str = ""
     phone_number: str
     email: str | None = None
     website: str | None = None
@@ -39,6 +36,12 @@ class LedgerOut(BaseModel):
     account_name: str | None = None
     account_number: str | None = None
     ifsc_code: str | None = None
+
+    @field_validator("gst", mode="before")
+    @classmethod
+    def normalize_gst_output(cls, value: str | None) -> str:
+        normalized = normalize_gstin(value)
+        return normalized or ""
 
     class Config:
         from_attributes = True

--- a/frontend/src/components/LedgerCombobox.tsx
+++ b/frontend/src/components/LedgerCombobox.tsx
@@ -11,8 +11,10 @@ type LedgerComboboxProps = {
 };
 
 export default function LedgerCombobox({ id, ledgers, value, onChange, required, disabled }: LedgerComboboxProps) {
+  const formatLedgerLabel = (ledger: Ledger) => ledger.gst ? `${ledger.name} (${ledger.gst})` : ledger.name;
+  const formatSearchText = (ledger: Ledger) => `${ledger.name} ${ledger.gst || ''}`.toLowerCase();
   const selectedLedger = ledgers.find((l) => String(l.id) === value);
-  const [query, setQuery] = useState(selectedLedger ? `${selectedLedger.name} (${selectedLedger.gst})` : '');
+  const [query, setQuery] = useState(selectedLedger ? formatLedgerLabel(selectedLedger) : '');
   const [open, setOpen] = useState(false);
   const [activeIndex, setActiveIndex] = useState(-1);
   const [searching, setSearching] = useState(false);
@@ -23,13 +25,13 @@ export default function LedgerCombobox({ id, ledgers, value, onChange, required,
   // Sync label when external value changes (e.g. default ledger on load)
   useEffect(() => {
     const l = ledgers.find((ledger) => String(ledger.id) === value);
-    if (l) setQuery(`${l.name} (${l.gst})`);
+    if (l) setQuery(formatLedgerLabel(l));
   }, [value, ledgers]);
 
   const suggestions = open
     ? ledgers.filter((l) =>
         searching && query.trim() !== ''
-          ? `${l.name} ${l.gst}`.toLowerCase().includes(query.toLowerCase())
+          ? formatSearchText(l).includes(query.toLowerCase())
           : true
       )
     : [];
@@ -42,7 +44,7 @@ export default function LedgerCombobox({ id, ledgers, value, onChange, required,
   }
 
   function handleSelect(ledger: Ledger) {
-    setQuery(`${ledger.name} (${ledger.gst})`);
+    setQuery(formatLedgerLabel(ledger));
     setOpen(false);
     setActiveIndex(-1);
     setSearching(false);
@@ -74,7 +76,7 @@ export default function LedgerCombobox({ id, ledgers, value, onChange, required,
       setActiveIndex(-1);
       setSearching(false);
       const l = ledgers.find((ledger) => String(ledger.id) === value);
-      if (l) setQuery(`${l.name} (${l.gst})`);
+      if (l) setQuery(formatLedgerLabel(l));
     }
   }
 
@@ -93,7 +95,7 @@ export default function LedgerCombobox({ id, ledgers, value, onChange, required,
         setOpen(false);
         setSearching(false);
         const l = ledgers.find((ledger) => String(ledger.id) === value);
-        if (l) setQuery(`${l.name} (${l.gst})`);
+        if (l) setQuery(formatLedgerLabel(l));
       }
     }
     document.addEventListener('mousedown', handleOutside);
@@ -160,7 +162,10 @@ export default function LedgerCombobox({ id, ledgers, value, onChange, required,
                 color: i === activeIndex ? '#fff' : '#111827',
               }}
             >
-              {l.name} <span style={{ opacity: 0.75, fontSize: '0.85em', color: i === activeIndex ? '#fff' : '#374151' }}>({l.gst})</span>
+              {l.name}
+              {l.gst ? (
+                <span style={{ opacity: 0.75, fontSize: '0.85em', color: i === activeIndex ? '#fff' : '#374151' }}> ({l.gst})</span>
+              ) : null}
             </li>
           ))}
         </ul>

--- a/frontend/src/components/StatementPreview.tsx
+++ b/frontend/src/components/StatementPreview.tsx
@@ -25,6 +25,12 @@ export default function StatementPreview({ ledger, statement, company, currencyC
     company?.website ? `Web: ${company.website}` : '',
   ].filter(Boolean).join(' · ');
 
+  const ledgerContact = [
+    ledger.gst ? `GST: ${ledger.gst}` : '',
+    ledger.phone_number ? `Phone: ${ledger.phone_number}` : '',
+    ledger.email || '',
+  ].filter(Boolean).join(' · ');
+
   return (
     <div className="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="statement-preview-title">
       <div className="modal-panel modal-panel--invoice-preview">
@@ -98,10 +104,7 @@ export default function StatementPreview({ ledger, statement, company, currencyC
             <p className="eyebrow">Ledger</p>
             <h4>{ledger.name}</h4>
             <p>{ledger.address}</p>
-            <p>
-              GST: {ledger.gst} · Phone: {ledger.phone_number}
-              {ledger.email ? ` · ${ledger.email}` : ''}
-            </p>
+            <p>{ledgerContact}</p>
           </section>
 
           <section style={{ display: 'flex', gap: '12px', marginBottom: '16px' }}>

--- a/frontend/src/pages/InvoicesPage.tsx
+++ b/frontend/src/pages/InvoicesPage.tsx
@@ -835,8 +835,11 @@ export default function InvoicesPage() {
                   value={ledgerForm.gst}
                   onChange={(event) => setLedgerForm((current) => ({ ...current, gst: event.target.value }))}
                   placeholder="27ABCDE1234F1Z5"
-                  required
+                  pattern="^$|[0-9]{2}[A-Za-z]{5}[0-9]{4}[A-Za-z][A-Za-z0-9]Z[A-Za-z0-9]$"
+                  title="Enter a valid 15-character GSTIN (e.g. 27ABCDE1234F1Z5), or leave blank"
+                  maxLength={15}
                 />
+                <small className="field-hint">Optional. If entered, format must be 27ABCDE1234F1Z5.</small>
               </div>
               <div className="field">
                 <label htmlFor="modal-ledger-phone">Phone number</label>

--- a/frontend/src/pages/LedgerCreatePage.tsx
+++ b/frontend/src/pages/LedgerCreatePage.tsx
@@ -38,7 +38,7 @@ export default function LedgerCreatePage() {
         setForm({
           name: l.name,
           address: l.address,
-          gst: l.gst,
+          gst: l.gst || '',
           phone_number: l.phone_number,
           email: l.email || '',
           website: l.website || '',
@@ -139,9 +139,11 @@ export default function LedgerCreatePage() {
                   value={form.gst}
                   onChange={(e) => setForm((c) => ({ ...c, gst: e.target.value }))}
                   placeholder="27ABCDE1234F1Z5"
-                  required
+                  pattern="^$|[0-9]{2}[A-Za-z]{5}[0-9]{4}[A-Za-z][A-Za-z0-9]Z[A-Za-z0-9]$"
+                  title="Enter a valid 15-character GSTIN (e.g. 27ABCDE1234F1Z5), or leave blank"
+                  maxLength={15}
                 />
-                <small className="field-hint">Format: 27ABCDE1234F1Z5</small>
+                <small className="field-hint">Optional. If entered, format must be 27ABCDE1234F1Z5.</small>
               </div>
               <div className="field">
                 <label htmlFor="ledger-phone">Phone number</label>

--- a/frontend/src/pages/LedgerViewPage.tsx
+++ b/frontend/src/pages/LedgerViewPage.tsx
@@ -266,7 +266,7 @@ export default function LedgerViewPage() {
           <p className="eyebrow">Ledger statement</p>
           <h1 className="page-title">{ledger.name}</h1>
           <p className="section-copy">
-            {ledger.gst} · {ledger.phone_number}
+            {[ledger.gst ? `GST: ${ledger.gst}` : '', ledger.phone_number].filter(Boolean).join(' · ')}
             {ledger.email ? ` · ${ledger.email}` : ''}
           </p>
         </div>

--- a/frontend/src/pages/LedgersPage.tsx
+++ b/frontend/src/pages/LedgersPage.tsx
@@ -154,7 +154,7 @@ export default function LedgersPage() {
                     <div className="table-row__meta">
                       <strong>{ledger.name}</strong>
                       <span className="table-subtext">
-                        {ledger.gst} · {ledger.phone_number}
+                        {[ledger.gst ? `GST: ${ledger.gst}` : '', ledger.phone_number].filter(Boolean).join(' · ')}
                       </span>
                       {(ledger.email || ledger.website) ? (
                         <span className="table-subtext">


### PR DESCRIPTION
## Summary

Makes ledger GST optional in create/edit flows while still validating GSTIN format whenever a value is entered. Also removes invoice creation failure caused by missing company/ledger GST and updates ledger display surfaces to handle empty GST cleanly.

## Type of change

- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] docs (documentation)
- [ ] test (tests)
- [ ] chore/refactor

## How to test

1. Open the create ledger form and save with empty GST; verify it succeeds.
2. Enter an invalid GST value and verify validation error is shown.
3. Enter a valid GSTIN and verify ledger save succeeds.
4. Create an invoice for a ledger with empty GST; verify POST /api/invoices/ succeeds and no GST-required error appears.
5. Open ledger list/view/statement preview and verify GST text does not show awkward separators when GST is blank.
6. Run backend compile check: python -m compileall src.
7. Run frontend build: npm run build.

## Checklist

- [x] My code follows the project style and conventions
- [ ] I added/updated tests where appropriate
- [ ] I updated docs where needed
- [x] I ran relevant checks locally
- [x] I verified this does not break existing behavior

## Screenshots (if UI changes)

UI behavior changed for optional GST labels; screenshots can be added during review.

## Related issue

N/A