### PR TITLE
feat(invoices): add round-off totals

### DIFF
--- a/backend/migrations/20260410000001_add_round_off_to_invoices.py
+++ b/backend/migrations/20260410000001_add_round_off_to_invoices.py
@@ -1,0 +1,21 @@
+"""
+Add round-off fields to invoices.
+"""
+
+from sqlalchemy import text
+
+
+def up(conn) -> None:
+    conn.execute(text("""
+        ALTER TABLE invoices
+        ADD COLUMN IF NOT EXISTS apply_round_off BOOLEAN NOT NULL DEFAULT FALSE;
+    """))
+    conn.execute(text("""
+        ALTER TABLE invoices
+        ADD COLUMN IF NOT EXISTS round_off_amount NUMERIC(5,2) NOT NULL DEFAULT 0;
+    """))
+
+
+def down(conn) -> None:
+    conn.execute(text("ALTER TABLE invoices DROP COLUMN IF EXISTS round_off_amount"))
+    conn.execute(text("ALTER TABLE invoices DROP COLUMN IF EXISTS apply_round_off"))

--- a/backend/src/api/routes/invoices.py
+++ b/backend/src/api/routes/invoices.py
@@ -121,6 +121,7 @@ def _apply_payload_to_invoice(
         invoice.due_date = datetime.combine(payload.due_date, datetime.min.time())
 
     invoice.tax_inclusive = payload.tax_inclusive
+    invoice.apply_round_off = payload.apply_round_off
     if regenerate_number:
         invoice.invoice_number = _generate_next_number(
             db, invoice.voucher_type, financial_year_id, payload.invoice_date,
@@ -207,7 +208,15 @@ def _apply_payload_to_invoice(
     invoice.cgst_amount = float(_money(cgst_total))
     invoice.sgst_amount = float(_money(sgst_total))
     invoice.igst_amount = float(_money(igst_total))
-    invoice.total_amount = float(_money(taxable_total + tax_total))
+    raw_total = _money(taxable_total + tax_total)
+    if invoice.apply_round_off:
+        rounded_total = raw_total.quantize(Decimal("1"), rounding=ROUND_HALF_UP)
+        round_off_amount = _money(rounded_total - raw_total)
+        invoice.round_off_amount = float(round_off_amount)
+        invoice.total_amount = float(_money(rounded_total))
+    else:
+        invoice.round_off_amount = 0
+        invoice.total_amount = float(raw_total)
 
 
 @router.post("", response_model=InvoiceOut, include_in_schema=False)
@@ -473,6 +482,12 @@ def _build_purchase_invoice_html(invoice: Invoice, products: list[Product]) -> s
     <span class="invoice-sheet__supplierref-value">{_e(invoice.supplier_invoice_number)}</span>
   </section>"""
 
+    round_off_amount = float(invoice.round_off_amount or 0)
+    show_round_off = bool(invoice.apply_round_off and round_off_amount != 0)
+    round_off_html = (
+        f'<p>Round off: {_fmt_currency(round_off_amount, currency)}</p>' if show_round_off else ''
+    )
+
     html = f"""<!DOCTYPE html>
 <html>
 <head>
@@ -673,6 +688,7 @@ def _build_purchase_invoice_html(invoice: Invoice, products: list[Product]) -> s
       <p>SGST: {_fmt_currency(float(invoice.sgst_amount or 0), currency)}</p>
       <p>IGST: {_fmt_currency(float(invoice.igst_amount or 0), currency)}</p>
       <p>Total tax: {_fmt_currency(float(invoice.total_tax_amount or 0), currency)}</p>
+      {round_off_html}
       <p class="eyebrow" style="margin-top: 10px;">Total due</p>
       <p class="invoice-sheet__total-value">{_fmt_currency(float(invoice.total_amount), currency)}</p>
       <p class="muted-text">Received by {_e(invoice.company_name) or 'Your company'}</p>
@@ -741,6 +757,12 @@ def _build_invoice_html(invoice: Invoice, products: list[Product]) -> str:
     if invoice.ledger_phone:
         billto_parts.append(f"Phone: {_e(invoice.ledger_phone)}")
     billto_details = " &middot; ".join(billto_parts)
+
+    round_off_amount = float(invoice.round_off_amount or 0)
+    show_round_off = bool(invoice.apply_round_off and round_off_amount != 0)
+    round_off_html = (
+        f'<p>Round off: {_fmt_currency(round_off_amount, currency)}</p>' if show_round_off else ''
+    )
 
     html = f"""<!DOCTYPE html>
 <html>
@@ -955,6 +977,7 @@ def _build_invoice_html(invoice: Invoice, products: list[Product]) -> str:
       <p>SGST: {_fmt_currency(float(invoice.sgst_amount or 0), currency)}</p>
       <p>IGST: {_fmt_currency(float(invoice.igst_amount or 0), currency)}</p>
       <p>Total tax: {_fmt_currency(float(invoice.total_tax_amount or 0), currency)}</p>
+      {round_off_html}
       <p class="eyebrow" style="margin-top: 10px;">Total due</p>
       <p class="invoice-sheet__total-value">{_fmt_currency(float(invoice.total_amount), currency)}</p>
       <p class="muted-text">Authorized by {_e(invoice.company_name) or 'Billing company'}</p>

--- a/backend/src/models/invoice.py
+++ b/backend/src/models/invoice.py
@@ -40,6 +40,8 @@ class Invoice(Base):
     invoice_date = Column(DateTime, nullable=False, default=datetime.utcnow)
     due_date = Column(DateTime, nullable=True)
     tax_inclusive = Column(Boolean, nullable=False, default=False)
+    apply_round_off = Column(Boolean, nullable=False, default=False)
+    round_off_amount = Column(Numeric(5, 2), nullable=False, default=0)
     financial_year_id = Column(Integer, ForeignKey("financial_years.id"), nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow)
 

--- a/backend/src/schemas/invoice.py
+++ b/backend/src/schemas/invoice.py
@@ -17,6 +17,7 @@ class InvoiceCreate(BaseModel):
     due_date: Optional[date] = None
     supplier_invoice_number: str | None = None
     tax_inclusive: bool = False
+    apply_round_off: bool = False
     items: List[InvoiceItemCreate]
 
 
@@ -69,6 +70,8 @@ class InvoiceOut(BaseModel):
     invoice_date: datetime
     due_date: datetime | None = None
     tax_inclusive: bool = False
+    apply_round_off: bool = False
+    round_off_amount: float = 0
     financial_year_id: Optional[int] = None
     warnings: List[str] = Field(default_factory=list)
     created_at: datetime

--- a/backend/tests/api/test_invoice_round_off.py
+++ b/backend/tests/api/test_invoice_round_off.py
@@ -1,0 +1,89 @@
+def _create_ledger(client):
+    response = client.post(
+        "/api/ledgers/",
+        json={
+            "name": "Round Off Ledger",
+            "address": "Mumbai",
+            "gst": "27ABCDE1234F1Z5",
+            "phone_number": "9999999999",
+            "email": "ledger@example.com",
+            "website": "",
+            "bank_name": "",
+            "branch_name": "",
+            "account_name": "",
+            "account_number": "",
+            "ifsc_code": "",
+        },
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["id"]
+
+
+def _create_product(client):
+    response = client.post(
+        "/api/products/",
+        json={
+            "sku": "RO-001",
+            "name": "Round Product",
+            "description": "",
+            "hsn_sac": "9988",
+            "price": 100,
+            "gst_rate": 18,
+        },
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["id"]
+
+
+def _add_inventory(client, product_id, quantity=10):
+    response = client.post(
+        "/api/inventory/adjust",
+        json={"product_id": product_id, "quantity": quantity},
+    )
+    assert response.status_code == 200, response.text
+
+
+def test_create_invoice_applies_round_off_when_enabled(client):
+    ledger_id = _create_ledger(client)
+    product_id = _create_product(client)
+    _add_inventory(client, product_id)
+
+    response = client.post(
+        "/api/invoices/",
+        json={
+            "ledger_id": ledger_id,
+            "voucher_type": "sales",
+            "tax_inclusive": False,
+            "apply_round_off": True,
+            "items": [{"product_id": product_id, "quantity": 1, "unit_price": 99.99}],
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["apply_round_off"] is True
+    assert body["total_amount"] == 118
+    assert body["round_off_amount"] == 0.01
+
+
+def test_create_invoice_keeps_exact_total_when_round_off_disabled(client):
+    ledger_id = _create_ledger(client)
+    product_id = _create_product(client)
+    _add_inventory(client, product_id)
+
+    response = client.post(
+        "/api/invoices/",
+        json={
+            "ledger_id": ledger_id,
+            "voucher_type": "sales",
+            "tax_inclusive": False,
+            "apply_round_off": False,
+            "items": [{"product_id": product_id, "quantity": 1, "unit_price": 99.99}],
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["apply_round_off"] is False
+    assert body["total_amount"] == 117.99
+    assert body["round_off_amount"] == 0

--- a/frontend/src/components/InvoicePreview.tsx
+++ b/frontend/src/components/InvoicePreview.tsx
@@ -34,6 +34,8 @@ type InvoicePreviewProps = {
 export default function InvoicePreview({ invoice, products, currencyCode, onClose, onError }: InvoicePreviewProps) {
   const [showEmailModal, setShowEmailModal] = useState(false);
   const previewCurrencyCode = invoice.company_currency_code || currencyCode;
+  const roundOffAmount = invoice.round_off_amount || 0;
+  const showRoundOff = invoice.apply_round_off && roundOffAmount !== 0;
 
   useEscapeClose(onClose);
 
@@ -209,6 +211,7 @@ export default function InvoicePreview({ invoice, products, currencyCode, onClos
               <p>SGST: {formatCurrency(invoice.sgst_amount || 0, previewCurrencyCode)}</p>
               <p>IGST: {formatCurrency(invoice.igst_amount || 0, previewCurrencyCode)}</p>
               <p>Total tax: {formatCurrency(invoice.total_tax_amount || 0, previewCurrencyCode)}</p>
+              {showRoundOff ? <p>Round off: {formatCurrency(roundOffAmount, previewCurrencyCode)}</p> : null}
               <p className="eyebrow" style={{ marginTop: '12px' }}>Total due</p>
               <p className="invoice-sheet__total-value">
                 {formatCurrency(invoice.total_amount, previewCurrencyCode)}

--- a/frontend/src/pages/InvoicesPage.tsx
+++ b/frontend/src/pages/InvoicesPage.tsx
@@ -48,6 +48,7 @@ export default function InvoicesPage() {
   const [selectedLedgerId, setSelectedLedgerId] = useState('');
   const [voucherType, setVoucherType] = useState<'sales' | 'purchase' | 'payment'>('sales');
   const [taxInclusive, setTaxInclusive] = useState(false);
+  const [applyRoundOff, setApplyRoundOff] = useState(false);
   const [supplierInvoiceNumber, setSupplierInvoiceNumber] = useState('');
   const [paymentMode, setPaymentMode] = useState('cash');
   const [paymentReference, setPaymentReference] = useState('');
@@ -199,6 +200,10 @@ export default function InvoicesPage() {
     return sum + taxableAmount + taxAmount;
   }, 0);
 
+  const roundedTotalAmount = Math.round(totalAmount);
+  const roundOffPreviewAmount = applyRoundOff ? roundedTotalAmount - totalAmount : 0;
+  const projectedTotalAmount = applyRoundOff ? roundedTotalAmount : totalAmount;
+
   const activeCurrencyCode = company?.currency_code || 'USD';
 
   function addItem() {
@@ -219,6 +224,7 @@ export default function InvoicesPage() {
     setEditingInvoiceId(null);
     setSupplierInvoiceNumber('');
     setTaxInclusive(false);
+    setApplyRoundOff(false);
     setPaymentMode('cash');
     setPaymentReference('');
     setPaymentAmount('');
@@ -245,6 +251,7 @@ export default function InvoicesPage() {
     setVoucherType(invoice.voucher_type);
     setSupplierInvoiceNumber(invoice.supplier_invoice_number ?? '');
     setTaxInclusive(invoice.tax_inclusive ?? false);
+    setApplyRoundOff(invoice.apply_round_off ?? false);
     setSelectedLedgerId(String(invoice.ledger_id));
     setInvoiceDate(invoice.invoice_date ? invoice.invoice_date.slice(0, 10) : new Date().toISOString().slice(0, 10));
 
@@ -302,6 +309,7 @@ export default function InvoicesPage() {
         invoice_date: invoiceDate,
         supplier_invoice_number: voucherType === 'purchase' ? (supplierInvoiceNumber.trim() || null) : null,
         tax_inclusive: taxInclusive,
+        apply_round_off: applyRoundOff,
         items: items.map((item) => ({
           product_id: Number(item.productId),
           quantity: Number(item.quantity),
@@ -540,7 +548,7 @@ export default function InvoicesPage() {
               <h2 className="nav-panel__title">{editingInvoiceId ? `Editing invoice #${editingInvoiceId}` : 'Order entry'}</h2>
             </div>
             <div className="button-row" style={{ justifyContent: 'flex-end' }}>
-              <div className="status-chip">Projected total {formatCurrency(totalAmount, activeCurrencyCode)}</div>
+              <div className="status-chip">Projected total {formatCurrency(projectedTotalAmount, activeCurrencyCode)}</div>
               <Link className="button button--secondary" to="/invoices-view">Open invoice view</Link>
             </div>
           </div>
@@ -650,14 +658,29 @@ export default function InvoicesPage() {
             </div>
 
             {voucherType !== 'payment' ? (
-              <div className="field" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-                <input
-                  id="invoice-tax-inclusive"
-                  type="checkbox"
-                  checked={taxInclusive}
-                  onChange={(event) => setTaxInclusive(event.target.checked)}
-                />
-                <label htmlFor="invoice-tax-inclusive" style={{ marginBottom: 0, cursor: 'pointer' }}>Prices include GST</label>
+              <div className="stack" style={{ gap: '8px' }}>
+                <div className="field" style={{ display: 'flex', alignItems: 'center', gap: '12px', marginBottom: 0 }}>
+                  <input
+                    id="invoice-tax-inclusive"
+                    type="checkbox"
+                    checked={taxInclusive}
+                    onChange={(event) => setTaxInclusive(event.target.checked)}
+                  />
+                  <label htmlFor="invoice-tax-inclusive" style={{ marginBottom: 0, cursor: 'pointer' }}>Prices include GST</label>
+
+                  <input
+                    id="invoice-apply-round-off"
+                    type="checkbox"
+                    checked={applyRoundOff}
+                    onChange={(event) => setApplyRoundOff(event.target.checked)}
+                  />
+                  <label htmlFor="invoice-apply-round-off" style={{ marginBottom: 0, cursor: 'pointer' }}>Apply round off</label>
+                </div>
+                {applyRoundOff ? (
+                  <p className="muted-text" style={{ marginTop: 0 }}>
+                    Round off: {formatCurrency(roundOffPreviewAmount, activeCurrencyCode)} · Adjusted total: {formatCurrency(projectedTotalAmount, activeCurrencyCode)}
+                  </p>
+                ) : null}
               </div>
             ) : null}
 

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -157,6 +157,8 @@ export type Invoice = {
   voucher_type: 'sales' | 'purchase';
   status: 'active' | 'cancelled';
   tax_inclusive: boolean;
+  apply_round_off: boolean;
+  round_off_amount: number;
   supplier_invoice_number?: string | null;
   ledger: Ledger | null;
   taxable_amount: number;
@@ -253,6 +255,7 @@ export type InvoiceCreate = {
   due_date?: string;
   supplier_invoice_number?: string | null;
   tax_inclusive?: boolean;
+  apply_round_off?: boolean;
   items: InvoiceItemInput[];
 };
 


### PR DESCRIPTION
## Summary

Adds per-invoice round-off support across backend, PDF/preview rendering, and invoice composer UI.
- Stores round-off settings on invoices with `apply_round_off` and `round_off_amount`.
- Rounds total due to the nearest rupee when enabled and preserves exact totals when disabled.
- Shows a Round off line between Total tax and Total due in generated invoice views.
- Adds invoice API tests for round-off enabled/disabled behavior.

## Type of change

- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs (documentation)
- [x] test (tests)
- [ ] chore/refactor

## How to test

1. Run backend migrations so new columns are available.
2. In Invoice composer, enable Apply round off and create an invoice with a non-integer grand total.
3. Verify the saved invoice total is rounded to nearest rupee and Round off value is shown in preview/PDF.
4. Disable Apply round off and create another invoice.
5. Verify total remains exact and Round off line is hidden.
6. Run `backend/.venv/bin/python -m pytest backend/tests/api/test_invoice_round_off.py -v`.
7. Run `backend/.venv/bin/python -m pytest backend/tests -v`.
8. Run `cd frontend && npm run build`.

## Checklist

- [x] My code follows the project style and conventions
- [x] I added/updated tests where appropriate
- [ ] I updated docs where needed
- [x] I ran relevant checks locally
- [x] I verified this does not break existing behavior

## Screenshots (if UI changes)

UI change; screenshots can be added during review.

## Related issue

Closes #199