### PR TITLE
fix(invoices): equalize CGST/SGST with odd-paise adjustment

### DIFF
--- a/backend/src/api/routes/invoices.py
+++ b/backend/src/api/routes/invoices.py
@@ -134,9 +134,7 @@ def _apply_payload_to_invoice(
 
     taxable_total = Decimal("0")
     tax_total = Decimal("0")
-    cgst_total = Decimal("0")
-    sgst_total = Decimal("0")
-    igst_total = Decimal("0")
+    created_items: list[InvoiceItem] = []
     for item in payload.items:
         if item.quantity <= 0:
             raise HTTPException(status_code=400, detail="Item quantity must be greater than zero")
@@ -172,41 +170,47 @@ def _apply_payload_to_invoice(
             tax_amount = _money(taxable_amount * gst_rate / Decimal("100"))
             line_total = _money(taxable_amount + tax_amount)
 
-        if interstate_supply:
-            igst_amount = tax_amount
-            cgst_amount = Decimal("0")
-            sgst_amount = Decimal("0")
-        else:
-            half_tax = _money(tax_amount / Decimal("2"))
-            cgst_amount = half_tax
-            sgst_amount = _money(tax_amount - half_tax)
-            igst_amount = Decimal("0")
-
         taxable_total += taxable_amount
         tax_total += tax_amount
-        cgst_total += cgst_amount
-        sgst_total += sgst_amount
-        igst_total += igst_amount
 
-        db.add(
-            InvoiceItem(
-                invoice_id=invoice.id,
-                product_id=product.id,
-                quantity=item.quantity,
-                hsn_sac=product.hsn_sac,
-                unit_price=float(unit_price),
-                gst_rate=float(gst_rate),
-                taxable_amount=float(taxable_amount),
-                tax_amount=float(tax_amount),
-                line_total=float(line_total),
-            )
+        invoice_item = InvoiceItem(
+            invoice_id=invoice.id,
+            product_id=product.id,
+            quantity=item.quantity,
+            hsn_sac=product.hsn_sac,
+            unit_price=float(unit_price),
+            gst_rate=float(gst_rate),
+            taxable_amount=float(taxable_amount),
+            tax_amount=float(tax_amount),
+            line_total=float(line_total),
         )
+        created_items.append(invoice_item)
+        db.add(invoice_item)
 
     invoice.taxable_amount = float(_money(taxable_total))
-    invoice.total_tax_amount = float(_money(tax_total))
-    invoice.cgst_amount = float(_money(cgst_total))
-    invoice.sgst_amount = float(_money(sgst_total))
-    invoice.igst_amount = float(_money(igst_total))
+    tax_total = _money(tax_total)
+
+    # Split GST components at invoice level. If intrastate total tax has odd paise,
+    # add Rs 0.01 first so CGST and SGST are always equal after splitting.
+    if interstate_supply:
+        invoice.cgst_amount = 0.0
+        invoice.sgst_amount = 0.0
+        invoice.igst_amount = float(tax_total)
+    else:
+        paise = int(tax_total * Decimal("100"))
+        if paise % 2 != 0:
+            tax_total = _money(tax_total + Decimal("0.01"))
+            if created_items:
+                last_item = created_items[-1]
+                last_item.tax_amount = float(_money(Decimal(str(last_item.tax_amount or 0)) + Decimal("0.01")))
+                last_item.line_total = float(_money(Decimal(str(last_item.line_total or 0)) + Decimal("0.01")))
+
+        half_tax_total = _money(tax_total / Decimal("2"))
+        invoice.cgst_amount = float(half_tax_total)
+        invoice.sgst_amount = float(half_tax_total)
+        invoice.igst_amount = 0.0
+
+    invoice.total_tax_amount = float(tax_total)
     invoice.total_amount = float(_money(taxable_total + tax_total))
 
 

--- a/backend/tests/api/test_invoice_tax_split.py
+++ b/backend/tests/api/test_invoice_tax_split.py
@@ -1,0 +1,167 @@
+from datetime import datetime
+from pathlib import Path
+import os
+import sys
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+BACKEND_ROOT = Path(__file__).resolve().parents[2]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///./test.db")
+
+from src.api.routes.invoices import _apply_payload_to_invoice
+from src.db.base import Base
+from src.models.buyer import Buyer
+from src.models.company import CompanyProfile
+from src.models.inventory import Inventory
+from src.models.invoice import Invoice
+from src.models.product import Product
+from src.models.user import User, UserRole
+from src.schemas.invoice import InvoiceCreate, InvoiceItemCreate
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    session_local = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    session = session_local()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=engine)
+
+
+def _seed_common(db_session):
+    user = User(
+        email="admin@example.com",
+        full_name="Admin",
+        hashed_password="secret",
+        role=UserRole.admin,
+    )
+    ledger = Buyer(
+        name="Test Ledger",
+        address="Some Address",
+        gst="07ABCDE1234F1Z5",
+        phone_number="9999999999",
+    )
+    company = CompanyProfile(
+        name="Respawn",
+        address="HQ",
+        gst="07AAMPB1274B1Z8",
+        phone_number="8888888888",
+        currency_code="INR",
+    )
+    db_session.add_all([user, ledger, company])
+    db_session.flush()
+    return user, ledger
+
+
+def _create_product_with_inventory(db_session, sku: str, price: float, gst_rate: float) -> Product:
+    product = Product(
+        sku=sku,
+        name=f"Product {sku}",
+        price=price,
+        gst_rate=gst_rate,
+    )
+    db_session.add(product)
+    db_session.flush()
+
+    inventory = Inventory(product_id=product.id, quantity=100)
+    db_session.add(inventory)
+    db_session.flush()
+    return product
+
+
+def _new_invoice(db_session) -> Invoice:
+    invoice = Invoice(
+        total_amount=0,
+        created_by=1,
+        invoice_date=datetime.utcnow(),
+    )
+    db_session.add(invoice)
+    db_session.flush()
+    return invoice
+
+
+def test_intrastate_odd_paise_total_tax_is_adjusted_and_split_equally(db_session):
+    user, ledger = _seed_common(db_session)
+    product = _create_product_with_inventory(db_session, "ODD01", 100.03, 18)
+    invoice = _new_invoice(db_session)
+
+    payload = InvoiceCreate(
+        ledger_id=ledger.id,
+        voucher_type="sales",
+        tax_inclusive=False,
+        items=[InvoiceItemCreate(product_id=product.id, quantity=1, unit_price=100.03)],
+    )
+
+    _apply_payload_to_invoice(
+        db_session,
+        invoice,
+        payload,
+        created_by=user.id,
+        regenerate_number=False,
+    )
+    db_session.flush()
+    db_session.refresh(invoice)
+
+    assert float(invoice.total_tax_amount) == pytest.approx(18.02)
+    assert float(invoice.cgst_amount) == pytest.approx(9.01)
+    assert float(invoice.sgst_amount) == pytest.approx(9.01)
+    assert float(invoice.cgst_amount) == pytest.approx(float(invoice.sgst_amount))
+
+    assert len(invoice.items) == 1
+    assert float(invoice.items[0].tax_amount) == pytest.approx(18.02)
+    assert float(invoice.items[0].line_total) == pytest.approx(118.05)
+
+
+def test_intrastate_three_line_case_keeps_cgst_sgst_equal(db_session):
+    user, ledger = _seed_common(db_session)
+    p1 = _create_product_with_inventory(db_session, "MS02", 254.24, 18)
+    p2 = _create_product_with_inventory(db_session, "LED01", 2457.63, 18)
+    p3 = _create_product_with_inventory(db_session, "KB04", 508.47, 18)
+    invoice = _new_invoice(db_session)
+
+    payload = InvoiceCreate(
+        ledger_id=ledger.id,
+        voucher_type="sales",
+        tax_inclusive=False,
+        items=[
+            InvoiceItemCreate(product_id=p1.id, quantity=1, unit_price=254.24),
+            InvoiceItemCreate(product_id=p2.id, quantity=1, unit_price=2457.63),
+            InvoiceItemCreate(product_id=p3.id, quantity=1, unit_price=508.47),
+        ],
+    )
+
+    _apply_payload_to_invoice(
+        db_session,
+        invoice,
+        payload,
+        created_by=user.id,
+        regenerate_number=False,
+    )
+    db_session.flush()
+    db_session.refresh(invoice)
+
+    assert float(invoice.taxable_amount) == pytest.approx(3220.34)
+    assert float(invoice.total_tax_amount) == pytest.approx(579.66)
+    assert float(invoice.cgst_amount) == pytest.approx(289.83)
+    assert float(invoice.sgst_amount) == pytest.approx(289.83)
+    assert float(invoice.cgst_amount) == pytest.approx(float(invoice.sgst_amount))
+
+    assert len(invoice.items) == 3
+    assert float(invoice.items[0].tax_amount) == pytest.approx(45.76)
+    assert float(invoice.items[1].tax_amount) == pytest.approx(442.37)
+    assert float(invoice.items[2].tax_amount) == pytest.approx(91.53)


### PR DESCRIPTION
## Summary

Fixes intra-state GST breakup rounding by making CGST and SGST always equal.
When total tax has odd paise, the backend now adds Rs 0.01 before splitting and applies that adjustment to the last line item tax and line total so invoice header and line totals remain consistent.
Also adds focused unit tests, including the exact 3-line unit-price scenario where CGST and SGST previously differed.

## Type of change

- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] docs (documentation)
- [x] test (tests)
- [ ] chore/refactor

## How to test

1. Create an intrastate sales invoice where total tax ends in odd paise.
2. Verify CGST and SGST are equal in API response and rendered preview/PDF values.
3. Verify total tax and line totals remain internally consistent.
4. Run: cd backend && /Users/nikhil/Documents/projects/respawn-invoicing/backend/.venv/bin/pytest tests/api/test_invoice_tax_split.py -q -
## Summary

Fixes intra-state GST breakup rounding by makingthe project style and conventions
- [x] I added/updated tests where appropriate
- [ ] I updated docs where needed
- [x] I ran relevant checks locally
- [x] I verified this does not break existing behavior

## Related issue

N/A
