### PR TITLE
feat(invoices): show PAN when GSTIN is available

### DIFF
--- a/backend/src/api/routes/invoices.py
+++ b/backend/src/api/routes/invoices.py
@@ -38,6 +38,13 @@ def _is_interstate_supply(company_gst: str | None, ledger_gst: str | None) -> bo
     return company_gst[:2] != ledger_gst[:2]
 
 
+def _extract_pan_from_gstin(gstin: str | None) -> str | None:
+    normalized = (gstin or "").strip().upper()
+    if len(normalized) != 15:
+        return None
+    return normalized[2:12]
+
+
 def _generate_next_number(
     db: Session,
     voucher_type: str,
@@ -467,6 +474,9 @@ def _build_purchase_invoice_html(invoice: Invoice, products: list[Product]) -> s
     supplier_detail_parts = []
     if invoice.ledger_gst:
         supplier_detail_parts.append(f"GST: {_e(invoice.ledger_gst)}")
+        supplier_pan = _extract_pan_from_gstin(invoice.ledger_gst)
+        if supplier_pan:
+            supplier_detail_parts.append(f"PAN: {_e(supplier_pan)}")
     if invoice.ledger_phone:
         supplier_detail_parts.append(f"Phone: {_e(invoice.ledger_phone)}")
     supplier_details = " &middot; ".join(supplier_detail_parts)
@@ -475,6 +485,9 @@ def _build_purchase_invoice_html(invoice: Invoice, products: list[Product]) -> s
     company_detail_parts = []
     if invoice.company_gst:
         company_detail_parts.append(f"GST: {_e(invoice.company_gst)}")
+        company_pan = _extract_pan_from_gstin(invoice.company_gst)
+        if company_pan:
+            company_detail_parts.append(f"PAN: {_e(company_pan)}")
     company_details = " &middot; ".join(company_detail_parts)
 
     # Optional supplier reference row
@@ -743,6 +756,9 @@ def _build_invoice_html(invoice: Invoice, products: list[Product]) -> str:
     company_detail_parts = []
     if invoice.company_gst:
         company_detail_parts.append(f"GST: {_e(invoice.company_gst)}")
+        company_pan = _extract_pan_from_gstin(invoice.company_gst)
+        if company_pan:
+            company_detail_parts.append(f"PAN: {_e(company_pan)}")
     if invoice.company_phone:
         company_detail_parts.append(f"Phone: {_e(invoice.company_phone)}")
     company_details = " &middot; ".join(company_detail_parts)
@@ -758,6 +774,9 @@ def _build_invoice_html(invoice: Invoice, products: list[Product]) -> str:
     billto_parts = []
     if invoice.ledger_gst:
         billto_parts.append(f"GST: {_e(invoice.ledger_gst)}")
+        billto_pan = _extract_pan_from_gstin(invoice.ledger_gst)
+        if billto_pan:
+            billto_parts.append(f"PAN: {_e(billto_pan)}")
     if invoice.ledger_phone:
         billto_parts.append(f"Phone: {_e(invoice.ledger_phone)}")
     billto_details = " &middot; ".join(billto_parts)

--- a/backend/src/api/routes/invoices.py
+++ b/backend/src/api/routes/invoices.py
@@ -134,9 +134,7 @@ def _apply_payload_to_invoice(
 
     taxable_total = Decimal("0")
     tax_total = Decimal("0")
-    cgst_total = Decimal("0")
-    sgst_total = Decimal("0")
-    igst_total = Decimal("0")
+    created_items: list[InvoiceItem] = []
     for item in payload.items:
         if item.quantity <= 0:
             raise HTTPException(status_code=400, detail="Item quantity must be greater than zero")
@@ -172,41 +170,47 @@ def _apply_payload_to_invoice(
             tax_amount = _money(taxable_amount * gst_rate / Decimal("100"))
             line_total = _money(taxable_amount + tax_amount)
 
-        if interstate_supply:
-            igst_amount = tax_amount
-            cgst_amount = Decimal("0")
-            sgst_amount = Decimal("0")
-        else:
-            half_tax = _money(tax_amount / Decimal("2"))
-            cgst_amount = half_tax
-            sgst_amount = _money(tax_amount - half_tax)
-            igst_amount = Decimal("0")
-
         taxable_total += taxable_amount
         tax_total += tax_amount
-        cgst_total += cgst_amount
-        sgst_total += sgst_amount
-        igst_total += igst_amount
 
-        db.add(
-            InvoiceItem(
-                invoice_id=invoice.id,
-                product_id=product.id,
-                quantity=item.quantity,
-                hsn_sac=product.hsn_sac,
-                unit_price=float(unit_price),
-                gst_rate=float(gst_rate),
-                taxable_amount=float(taxable_amount),
-                tax_amount=float(tax_amount),
-                line_total=float(line_total),
-            )
+        invoice_item = InvoiceItem(
+            invoice_id=invoice.id,
+            product_id=product.id,
+            quantity=item.quantity,
+            hsn_sac=product.hsn_sac,
+            unit_price=float(unit_price),
+            gst_rate=float(gst_rate),
+            taxable_amount=float(taxable_amount),
+            tax_amount=float(tax_amount),
+            line_total=float(line_total),
         )
+        created_items.append(invoice_item)
+        db.add(invoice_item)
 
     invoice.taxable_amount = float(_money(taxable_total))
-    invoice.total_tax_amount = float(_money(tax_total))
-    invoice.cgst_amount = float(_money(cgst_total))
-    invoice.sgst_amount = float(_money(sgst_total))
-    invoice.igst_amount = float(_money(igst_total))
+    tax_total = _money(tax_total)
+
+    # Split GST components at invoice level. If intrastate total tax has odd paise,
+    # add Rs 0.01 first so CGST and SGST are always equal after splitting.
+    if interstate_supply:
+        invoice.cgst_amount = 0.0
+        invoice.sgst_amount = 0.0
+        invoice.igst_amount = float(tax_total)
+    else:
+        paise = int(tax_total * Decimal("100"))
+        if paise % 2 != 0:
+            tax_total = _money(tax_total + Decimal("0.01"))
+            if created_items:
+                last_item = created_items[-1]
+                last_item.tax_amount = float(_money(Decimal(str(last_item.tax_amount or 0)) + Decimal("0.01")))
+                last_item.line_total = float(_money(Decimal(str(last_item.line_total or 0)) + Decimal("0.01")))
+
+        half_tax_total = _money(tax_total / Decimal("2"))
+        invoice.cgst_amount = float(half_tax_total)
+        invoice.sgst_amount = float(half_tax_total)
+        invoice.igst_amount = 0.0
+
+    invoice.total_tax_amount = float(tax_total)
     invoice.total_amount = float(_money(taxable_total + tax_total))
 
 

--- a/backend/tests/api/test_invoice_pan_display.py
+++ b/backend/tests/api/test_invoice_pan_display.py
@@ -1,0 +1,71 @@
+from datetime import datetime
+from pathlib import Path
+import os
+import sys
+
+BACKEND_ROOT = Path(__file__).resolve().parents[2]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///./test.db")
+
+from src.api.routes.invoices import _build_invoice_html, _build_purchase_invoice_html, _extract_pan_from_gstin
+from src.models.invoice import Invoice
+
+
+def _invoice_base(voucher_type: str = "sales") -> Invoice:
+    invoice = Invoice(
+        id=1,
+        invoice_number="INV-001",
+        ledger_name="Buyer One",
+        ledger_address="Buyer Address",
+        company_name="Seller One",
+        company_address="Seller Address",
+        company_currency_code="INR",
+        voucher_type=voucher_type,
+        created_by=1,
+        taxable_amount=0,
+        total_tax_amount=0,
+        cgst_amount=0,
+        sgst_amount=0,
+        igst_amount=0,
+        total_amount=0,
+        invoice_date=datetime(2026, 4, 15),
+    )
+    invoice.items = []
+    return invoice
+
+
+def test_extract_pan_from_gstin_returns_pan_for_valid_gstin():
+    assert _extract_pan_from_gstin("07AAMPB1274B1Z8") == "AAMPB1274B"
+
+
+def test_extract_pan_from_gstin_returns_none_for_missing_or_invalid_gstin():
+    assert _extract_pan_from_gstin(None) is None
+    assert _extract_pan_from_gstin("") is None
+    assert _extract_pan_from_gstin("07AAMPB1274B1Z") is None
+
+
+def test_sales_html_shows_pan_only_when_corresponding_gst_exists():
+    invoice = _invoice_base("sales")
+    invoice.company_gst = "07AAMPB1274B1Z8"
+    invoice.ledger_gst = None
+
+    html = _build_invoice_html(invoice, [])
+
+    assert "GST: 07AAMPB1274B1Z8" in html
+    assert "PAN: AAMPB1274B" in html
+    assert "PAN:" not in html.split("Bill to", 1)[1]
+
+
+def test_purchase_html_shows_supplier_and_company_pan_when_gst_present():
+    invoice = _invoice_base("purchase")
+    invoice.ledger_gst = "29ABCDE1234F1Z5"
+    invoice.company_gst = "07AAMPB1274B1Z8"
+
+    html = _build_purchase_invoice_html(invoice, [])
+
+    assert "GST: 29ABCDE1234F1Z5" in html
+    assert "PAN: ABCDE1234F" in html
+    assert "GST: 07AAMPB1274B1Z8" in html
+    assert "PAN: AAMPB1274B" in html

--- a/backend/tests/api/test_invoice_tax_split.py
+++ b/backend/tests/api/test_invoice_tax_split.py
@@ -1,0 +1,167 @@
+from datetime import datetime
+from pathlib import Path
+import os
+import sys
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+BACKEND_ROOT = Path(__file__).resolve().parents[2]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///./test.db")
+
+from src.api.routes.invoices import _apply_payload_to_invoice
+from src.db.base import Base
+from src.models.buyer import Buyer
+from src.models.company import CompanyProfile
+from src.models.inventory import Inventory
+from src.models.invoice import Invoice
+from src.models.product import Product
+from src.models.user import User, UserRole
+from src.schemas.invoice import InvoiceCreate, InvoiceItemCreate
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    session_local = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    session = session_local()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=engine)
+
+
+def _seed_common(db_session):
+    user = User(
+        email="admin@example.com",
+        full_name="Admin",
+        hashed_password="secret",
+        role=UserRole.admin,
+    )
+    ledger = Buyer(
+        name="Test Ledger",
+        address="Some Address",
+        gst="07ABCDE1234F1Z5",
+        phone_number="9999999999",
+    )
+    company = CompanyProfile(
+        name="Respawn",
+        address="HQ",
+        gst="07AAMPB1274B1Z8",
+        phone_number="8888888888",
+        currency_code="INR",
+    )
+    db_session.add_all([user, ledger, company])
+    db_session.flush()
+    return user, ledger
+
+
+def _create_product_with_inventory(db_session, sku: str, price: float, gst_rate: float) -> Product:
+    product = Product(
+        sku=sku,
+        name=f"Product {sku}",
+        price=price,
+        gst_rate=gst_rate,
+    )
+    db_session.add(product)
+    db_session.flush()
+
+    inventory = Inventory(product_id=product.id, quantity=100)
+    db_session.add(inventory)
+    db_session.flush()
+    return product
+
+
+def _new_invoice(db_session) -> Invoice:
+    invoice = Invoice(
+        total_amount=0,
+        created_by=1,
+        invoice_date=datetime.utcnow(),
+    )
+    db_session.add(invoice)
+    db_session.flush()
+    return invoice
+
+
+def test_intrastate_odd_paise_total_tax_is_adjusted_and_split_equally(db_session):
+    user, ledger = _seed_common(db_session)
+    product = _create_product_with_inventory(db_session, "ODD01", 100.03, 18)
+    invoice = _new_invoice(db_session)
+
+    payload = InvoiceCreate(
+        ledger_id=ledger.id,
+        voucher_type="sales",
+        tax_inclusive=False,
+        items=[InvoiceItemCreate(product_id=product.id, quantity=1, unit_price=100.03)],
+    )
+
+    _apply_payload_to_invoice(
+        db_session,
+        invoice,
+        payload,
+        created_by=user.id,
+        regenerate_number=False,
+    )
+    db_session.flush()
+    db_session.refresh(invoice)
+
+    assert float(invoice.total_tax_amount) == pytest.approx(18.02)
+    assert float(invoice.cgst_amount) == pytest.approx(9.01)
+    assert float(invoice.sgst_amount) == pytest.approx(9.01)
+    assert float(invoice.cgst_amount) == pytest.approx(float(invoice.sgst_amount))
+
+    assert len(invoice.items) == 1
+    assert float(invoice.items[0].tax_amount) == pytest.approx(18.02)
+    assert float(invoice.items[0].line_total) == pytest.approx(118.05)
+
+
+def test_intrastate_three_line_case_keeps_cgst_sgst_equal(db_session):
+    user, ledger = _seed_common(db_session)
+    p1 = _create_product_with_inventory(db_session, "MS02", 254.24, 18)
+    p2 = _create_product_with_inventory(db_session, "LED01", 2457.63, 18)
+    p3 = _create_product_with_inventory(db_session, "KB04", 508.47, 18)
+    invoice = _new_invoice(db_session)
+
+    payload = InvoiceCreate(
+        ledger_id=ledger.id,
+        voucher_type="sales",
+        tax_inclusive=False,
+        items=[
+            InvoiceItemCreate(product_id=p1.id, quantity=1, unit_price=254.24),
+            InvoiceItemCreate(product_id=p2.id, quantity=1, unit_price=2457.63),
+            InvoiceItemCreate(product_id=p3.id, quantity=1, unit_price=508.47),
+        ],
+    )
+
+    _apply_payload_to_invoice(
+        db_session,
+        invoice,
+        payload,
+        created_by=user.id,
+        regenerate_number=False,
+    )
+    db_session.flush()
+    db_session.refresh(invoice)
+
+    assert float(invoice.taxable_amount) == pytest.approx(3220.34)
+    assert float(invoice.total_tax_amount) == pytest.approx(579.66)
+    assert float(invoice.cgst_amount) == pytest.approx(289.83)
+    assert float(invoice.sgst_amount) == pytest.approx(289.83)
+    assert float(invoice.cgst_amount) == pytest.approx(float(invoice.sgst_amount))
+
+    assert len(invoice.items) == 3
+    assert float(invoice.items[0].tax_amount) == pytest.approx(45.76)
+    assert float(invoice.items[1].tax_amount) == pytest.approx(442.37)
+    assert float(invoice.items[2].tax_amount) == pytest.approx(91.53)


### PR DESCRIPTION
## Summary

Adds PAN display on invoice outputs by deriving PAN from GSTIN, and only shows GST/PAN labels when GSTIN is present. Covers sales and purchase invoice HTML/PDF render paths and includes focused tests.

## Type of change

- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs (documentation)
- [x] test (tests)
- [ ] chore/refactor

## How to test

1. Run: cd backend && DATABASE_URL=postgresql://simple_user:simple_password@localhost:5432/simple_invoicing /Users/nikhil/Documents/projects/respawn-invoicing/backend/.venv/bin/python -m pytest tests/api/test_invoice_pan_display.py -q --confcutdir=tests/api
2. Verify PAN shows when GSTIN is present.
3. Verify GST/PAN are omitted for a party when GSTIN is missing.

## Checklist

- [x] My code follows the project style and conventions
- [x] I added/updated tests where appropriate
- [ ] I updated docs where needed
- [x] I ran relevant checks locally
- [x] I verified this does not break existing behavior

## Related issue

Closes #211