### PR TITLE
chore(ci): run backend pytest in workflow

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -55,3 +55,10 @@ jobs:
           DATABASE_URL: "postgresql://testuser:testpassword@localhost:5432/testdb"
           SECRET_KEY: "testing-secret-key"
         run: python -c "from app_main import app; print('FastAPI app import OK')"
+
+      - name: Run backend tests
+        working-directory: backend
+        env:
+          DATABASE_URL: "postgresql://testuser:testpassword@localhost:5432/testdb"
+          SECRET_KEY: "testing-secret-key"
+        run: python -m pytest tests/ -v

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -44,6 +44,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+          pip install pytest
 
       - name: Syntax check
         working-directory: backend


### PR DESCRIPTION
## Summary

Adds a backend CI test step to run the full backend test suite in GitHub Actions after syntax and app-import checks.
Uses the same PostgreSQL DATABASE_URL and SECRET_KEY env values used by the existing CI import validation step.

## Type of change

- [ ] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs (documentation)
- [x] test (tests)
- [x] chore/refactor

## How to test

1. Open this PR and verify the Backend CI workflow starts.
2. Confirm the new "Run backend tests" step executes `python -m pytest tests/ -v`.
3. Ensure workflow passes with the Postgres service.

## Checklist

- [x] My code follows the project style and conventions
- [x] I added/updated tests where appropriate
- [ ] I updated docs where needed
- [x] I ran relevant checks locally
- [x] I verified this does not break existing behavior

## Related issue

N/A