### PR TITLE
feat(invoices): implement item-wise GST split and PDF tax columns

### DIFF
--- a/backend/migrations/20260416000001_add_item_tax_split_fields.py
+++ b/backend/migrations/20260416000001_add_item_tax_split_fields.py
@@ -1,0 +1,29 @@
+"""
+Add item-level GST split fields to invoice_items
+"""
+
+from sqlalchemy import text
+
+
+def up(conn) -> None:
+    columns = {
+        "cgst_amount": "ALTER TABLE invoice_items ADD COLUMN cgst_amount NUMERIC(10,2) NOT NULL DEFAULT 0",
+        "sgst_amount": "ALTER TABLE invoice_items ADD COLUMN sgst_amount NUMERIC(10,2) NOT NULL DEFAULT 0",
+        "igst_amount": "ALTER TABLE invoice_items ADD COLUMN igst_amount NUMERIC(10,2) NOT NULL DEFAULT 0",
+    }
+
+    existing = {
+        row[0]
+        for row in conn.execute(
+            text("SELECT column_name FROM information_schema.columns WHERE table_name = 'invoice_items'")
+        ).fetchall()
+    }
+
+    for name, stmt in columns.items():
+        if name not in existing:
+            conn.execute(text(stmt))
+
+
+def down(conn) -> None:
+    for col in ["cgst_amount", "sgst_amount", "igst_amount"]:
+        conn.execute(text(f"ALTER TABLE invoice_items DROP COLUMN IF EXISTS {col}"))

--- a/backend/migrations/20260416000002_backfill_item_tax_split_fields.py
+++ b/backend/migrations/20260416000002_backfill_item_tax_split_fields.py
@@ -1,0 +1,112 @@
+"""
+Backfill item-level GST split fields for existing invoices
+"""
+
+from decimal import Decimal, ROUND_HALF_UP
+
+from sqlalchemy import text
+
+
+def _money(value: Decimal) -> Decimal:
+    return value.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+
+def _is_interstate_supply(company_gst: str | None, ledger_gst: str | None) -> bool:
+    if not company_gst or not ledger_gst or len(company_gst) < 2 or len(ledger_gst) < 2:
+        return False
+    return company_gst[:2] != ledger_gst[:2]
+
+
+def up(conn) -> None:
+    invoice_rows = conn.execute(text("""
+        SELECT id, company_gst, ledger_gst, cgst_amount, sgst_amount, igst_amount
+        FROM invoices
+        WHERE id IN (SELECT DISTINCT invoice_id FROM invoice_items)
+        ORDER BY id
+    """)).mappings().all()
+
+    update_stmt = text("""
+        UPDATE invoice_items
+        SET cgst_amount = :cgst_amount,
+            sgst_amount = :sgst_amount,
+            igst_amount = :igst_amount
+        WHERE id = :item_id
+    """)
+
+    for invoice in invoice_rows:
+        item_rows = conn.execute(
+            text("""
+                SELECT id, tax_amount
+                FROM invoice_items
+                WHERE invoice_id = :invoice_id
+                ORDER BY id
+            """),
+            {"invoice_id": invoice["id"]},
+        ).mappings().all()
+
+        if not item_rows:
+            continue
+
+        interstate_supply = _is_interstate_supply(invoice["company_gst"], invoice["ledger_gst"])
+        item_tax_amounts = [_money(Decimal(str(item["tax_amount"] or 0))) for item in item_rows]
+        total_item_tax = _money(sum(item_tax_amounts, Decimal("0")))
+
+        if interstate_supply:
+            remaining_igst = _money(Decimal(str(invoice["igst_amount"] or 0)))
+            if remaining_igst == Decimal("0.00") and total_item_tax > 0:
+                remaining_igst = total_item_tax
+
+            for index, item in enumerate(item_rows):
+                item_igst_amount = remaining_igst if index == len(item_rows) - 1 else item_tax_amounts[index]
+                if index != len(item_rows) - 1:
+                    remaining_igst = _money(remaining_igst - item_igst_amount)
+
+                conn.execute(
+                    update_stmt,
+                    {
+                        "item_id": item["id"],
+                        "cgst_amount": 0,
+                        "sgst_amount": 0,
+                        "igst_amount": float(item_igst_amount),
+                    },
+                )
+            continue
+
+        remaining_cgst = _money(Decimal(str(invoice["cgst_amount"] or 0)))
+        remaining_sgst = _money(Decimal(str(invoice["sgst_amount"] or 0)))
+        if remaining_cgst == Decimal("0.00") and remaining_sgst == Decimal("0.00") and total_item_tax > 0:
+            adjusted_total_item_tax = total_item_tax
+            if int(adjusted_total_item_tax * Decimal("100")) % 2 != 0:
+                adjusted_total_item_tax = _money(adjusted_total_item_tax + Decimal("0.01"))
+            remaining_cgst = _money(adjusted_total_item_tax / Decimal("2"))
+            remaining_sgst = _money(adjusted_total_item_tax / Decimal("2"))
+
+        for index, item in enumerate(item_rows):
+            item_tax_amount = item_tax_amounts[index]
+            if index == len(item_rows) - 1:
+                item_cgst_amount = remaining_cgst
+                item_sgst_amount = remaining_sgst
+            else:
+                item_cgst_amount = _money(item_tax_amount / Decimal("2"))
+                item_sgst_amount = _money(item_tax_amount - item_cgst_amount)
+                remaining_cgst = _money(remaining_cgst - item_cgst_amount)
+                remaining_sgst = _money(remaining_sgst - item_sgst_amount)
+
+            conn.execute(
+                update_stmt,
+                {
+                    "item_id": item["id"],
+                    "cgst_amount": float(item_cgst_amount),
+                    "sgst_amount": float(item_sgst_amount),
+                    "igst_amount": 0,
+                },
+            )
+
+
+def down(conn) -> None:
+    conn.execute(text("""
+        UPDATE invoice_items
+        SET cgst_amount = 0,
+            sgst_amount = 0,
+            igst_amount = 0
+    """))

--- a/backend/migrations/20260416000002_backfill_item_tax_split_fields.py
+++ b/backend/migrations/20260416000002_backfill_item_tax_split_fields.py
@@ -11,15 +11,15 @@ def _money(value: Decimal) -> Decimal:
     return value.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
 
 
-def _is_interstate_supply(company_gst: str | None, ledger_gst: str | None) -> bool:
-    if not company_gst or not ledger_gst or len(company_gst) < 2 or len(ledger_gst) < 2:
+def _is_interstate_supply(company_gst: str | None, buyer_gst: str | None) -> bool:
+    if not company_gst or not buyer_gst or len(company_gst) < 2 or len(buyer_gst) < 2:
         return False
-    return company_gst[:2] != ledger_gst[:2]
+    return company_gst[:2] != buyer_gst[:2]
 
 
 def up(conn) -> None:
     invoice_rows = conn.execute(text("""
-        SELECT id, company_gst, ledger_gst, cgst_amount, sgst_amount, igst_amount
+        SELECT id, company_gst, buyer_gst, cgst_amount, sgst_amount, igst_amount
         FROM invoices
         WHERE id IN (SELECT DISTINCT invoice_id FROM invoice_items)
         ORDER BY id
@@ -47,7 +47,7 @@ def up(conn) -> None:
         if not item_rows:
             continue
 
-        interstate_supply = _is_interstate_supply(invoice["company_gst"], invoice["ledger_gst"])
+        interstate_supply = _is_interstate_supply(invoice["company_gst"], invoice["buyer_gst"])
         item_tax_amounts = [_money(Decimal(str(item["tax_amount"] or 0))) for item in item_rows]
         total_item_tax = _money(sum(item_tax_amounts, Decimal("0")))
 

--- a/backend/src/api/routes/invoices.py
+++ b/backend/src/api/routes/invoices.py
@@ -498,8 +498,14 @@ def _fmt_rate(value: float) -> str:
 
 def _build_pdf_tax_header_cells(interstate_supply: bool) -> str:
     if interstate_supply:
-        return '<th class="right">IGST %</th><th class="right">Total Tax</th>'
-    return '<th class="right">SGST %</th><th class="right">CGST %</th><th class="right">Total Tax</th>'
+        return '<th class="right">IGST %</th><th class="right">IGST Amt</th><th class="right">Total Tax</th>'
+    return (
+        '<th class="right">SGST %</th>'
+        '<th class="right">SGST Amt</th>'
+        '<th class="right">CGST %</th>'
+        '<th class="right">CGST Amt</th>'
+        '<th class="right">Total Tax</th>'
+    )
 
 
 def _build_pdf_tax_row_cells(item: InvoiceItem, currency: str, interstate_supply: bool) -> str:
@@ -513,13 +519,22 @@ def _build_pdf_tax_row_cells(item: InvoiceItem, currency: str, interstate_supply
         igst_rate = gst_rate if igst_amount > 0 else 0
         return (
             f'<td class="right">{_fmt_rate(igst_rate)}%</td>'
+        f'<td class="right">{_fmt_currency(igst_amount, currency)}</td>'
             f'<td class="right">{_fmt_currency(tax_amount, currency)}</td>'
         )
 
-    split_rate = gst_rate / 2 if tax_amount > 0 else 0
+    sgst_amount = float(item.sgst_amount or 0)
+    cgst_amount = float(item.cgst_amount or 0)
+    if tax_amount > 0 and sgst_amount == 0 and cgst_amount == 0:
+      cgst_amount = float(_money(Decimal(str(tax_amount)) / Decimal("2")))
+      sgst_amount = float(_money(Decimal(str(tax_amount)) - Decimal(str(cgst_amount))))
+
+    split_rate = gst_rate / 2 if (tax_amount > 0 or sgst_amount > 0 or cgst_amount > 0) else 0
     return (
         f'<td class="right">{_fmt_rate(split_rate)}%</td>'
+      f'<td class="right">{_fmt_currency(sgst_amount, currency)}</td>'
         f'<td class="right">{_fmt_rate(split_rate)}%</td>'
+      f'<td class="right">{_fmt_currency(cgst_amount, currency)}</td>'
         f'<td class="right">{_fmt_currency(tax_amount, currency)}</td>'
     )
 

--- a/backend/src/api/routes/invoices.py
+++ b/backend/src/api/routes/invoices.py
@@ -493,37 +493,35 @@ def _e(text: str | None) -> str:
 
 
 def _fmt_rate(value: float) -> str:
-  return f"{value:.2f}".rstrip("0").rstrip(".")
+    return f"{value:.2f}".rstrip("0").rstrip(".")
 
 
-def _build_pdf_item_tax_breakup(item: InvoiceItem, currency: str, interstate_supply: bool) -> str:
-  gst_rate = float(item.gst_rate or 0)
-  tax_amount = float(item.tax_amount or 0)
-  cgst_amount = float(item.cgst_amount or 0)
-  sgst_amount = float(item.sgst_amount or 0)
-  igst_amount = float(item.igst_amount or 0)
-
-  if tax_amount > 0 and cgst_amount == 0 and sgst_amount == 0 and igst_amount == 0:
+def _build_pdf_tax_header_cells(interstate_supply: bool) -> str:
     if interstate_supply:
-      igst_amount = tax_amount
-    else:
-      cgst_amount = float(_money(Decimal(str(tax_amount)) / Decimal("2")))
-      sgst_amount = float(_money(Decimal(str(tax_amount)) - Decimal(str(cgst_amount))))
+        return '<th class="right">IGST %</th><th class="right">Total Tax</th>'
+    return '<th class="right">SGST %</th><th class="right">CGST %</th><th class="right">Total Tax</th>'
 
-  if igst_amount > 0:
+
+def _build_pdf_tax_row_cells(item: InvoiceItem, currency: str, interstate_supply: bool) -> str:
+    gst_rate = float(item.gst_rate or 0)
+    tax_amount = float(item.tax_amount or 0)
+
+    if interstate_supply:
+        igst_amount = float(item.igst_amount or 0)
+        if tax_amount > 0 and igst_amount == 0:
+            igst_amount = tax_amount
+        igst_rate = gst_rate if igst_amount > 0 else 0
+        return (
+            f'<td class="right">{_fmt_rate(igst_rate)}%</td>'
+            f'<td class="right">{_fmt_currency(tax_amount, currency)}</td>'
+        )
+
+    split_rate = gst_rate / 2 if tax_amount > 0 else 0
     return (
-      f"IGST {_fmt_rate(gst_rate)}%<br>"
-      f"{_fmt_currency(igst_amount, currency)}"
+        f'<td class="right">{_fmt_rate(split_rate)}%</td>'
+        f'<td class="right">{_fmt_rate(split_rate)}%</td>'
+        f'<td class="right">{_fmt_currency(tax_amount, currency)}</td>'
     )
-
-  if cgst_amount > 0 or sgst_amount > 0:
-    split_rate = gst_rate / 2
-    return (
-      f"CGST {_fmt_rate(split_rate)}%: {_fmt_currency(cgst_amount, currency)}<br>"
-      f"SGST {_fmt_rate(split_rate)}%: {_fmt_currency(sgst_amount, currency)}"
-    )
-
-  return f"GST {_fmt_rate(gst_rate)}%: {_fmt_currency(0, currency)}"
 
 
 def _build_pdf_tax_breakup_rows(invoice: Invoice, currency: str) -> str:
@@ -547,6 +545,7 @@ def _build_purchase_invoice_html(invoice: Invoice, products: list[Product]) -> s
     inv_number = invoice.invoice_number or f"#{invoice.id}"
     inv_date = invoice.invoice_date.strftime("%d %b %Y") if invoice.invoice_date else (invoice.created_at.strftime("%d %b %Y") if invoice.created_at else "N/A")
     interstate_supply = _is_interstate_supply(invoice.company_gst, invoice.ledger_gst)
+    tax_header_cells = _build_pdf_tax_header_cells(interstate_supply)
 
     product_map = {p.id: p for p in products}
 
@@ -556,8 +555,7 @@ def _build_purchase_invoice_html(invoice: Invoice, products: list[Product]) -> s
         product_name = _e(prod.name) if prod else f"Product #{item.product_id}"
         sku = _e(prod.sku) if prod else "N/A"
         hsn = _e(item.hsn_sac or (prod.hsn_sac if prod else None) or "N/A")
-        gst_rate = float(item.gst_rate or 0)
-        tax_breakup = _build_pdf_item_tax_breakup(item, currency, interstate_supply)
+        tax_row_cells = _build_pdf_tax_row_cells(item, currency, interstate_supply)
 
         item_rows += f"""
         <tr>
@@ -567,8 +565,7 @@ def _build_purchase_invoice_html(invoice: Invoice, products: list[Product]) -> s
           <td>{hsn}</td>
           <td class="right">{item.quantity}</td>
           <td class="right">{_fmt_currency(float(item.unit_price), currency)}</td>
-          <td class="right">{gst_rate:.2f}%</td>
-          <td class="right invoice-sheet__tax-breakup">{tax_breakup}</td>
+          {tax_row_cells}
           <td class="right">{_fmt_currency(float(item.line_total), currency)}</td>
         </tr>"""
 
@@ -726,9 +723,6 @@ def _build_purchase_invoice_html(invoice: Invoice, products: list[Product]) -> s
   .invoice-sheet__table tbody td.right {{
     text-align: right;
   }}
-  .invoice-sheet__tax-breakup {{
-    line-height: 1.35;
-  }}
   .invoice-sheet__table tbody tr:last-child td {{
     border-bottom: 2px solid #d1d5db;
   }}
@@ -792,8 +786,7 @@ def _build_purchase_invoice_html(invoice: Invoice, products: list[Product]) -> s
           <th>HSN/SAC</th>
           <th class="right">Qty</th>
           <th class="right">Unit Price</th>
-          <th class="right">GST %</th>
-          <th class="right">GST Split</th>
+          {tax_header_cells}
           <th class="right">Amount</th>
         </tr>
       </thead>
@@ -830,6 +823,7 @@ def _build_invoice_html(invoice: Invoice, products: list[Product]) -> str:
     inv_number = invoice.invoice_number or f"#{invoice.id}"
     inv_date = invoice.invoice_date.strftime("%d %b %Y") if invoice.invoice_date else (invoice.created_at.strftime("%d %b %Y") if invoice.created_at else "N/A")
     interstate_supply = _is_interstate_supply(invoice.company_gst, invoice.ledger_gst)
+    tax_header_cells = _build_pdf_tax_header_cells(interstate_supply)
 
     product_map = {p.id: p for p in products}
 
@@ -840,8 +834,7 @@ def _build_invoice_html(invoice: Invoice, products: list[Product]) -> str:
         product_name = _e(prod.name) if prod else f"Product #{item.product_id}"
         sku = _e(prod.sku) if prod else "N/A"
         hsn = _e(item.hsn_sac or (prod.hsn_sac if prod else None) or "N/A")
-        gst_rate = float(item.gst_rate or 0)
-        tax_breakup = _build_pdf_item_tax_breakup(item, currency, interstate_supply)
+        tax_row_cells = _build_pdf_tax_row_cells(item, currency, interstate_supply)
 
         item_rows += f"""
         <tr>
@@ -851,8 +844,7 @@ def _build_invoice_html(invoice: Invoice, products: list[Product]) -> str:
           <td>{hsn}</td>
           <td class="right">{item.quantity}</td>
           <td class="right">{_fmt_currency(float(item.unit_price), currency)}</td>
-          <td class="right">{gst_rate:.2f}%</td>
-          <td class="right invoice-sheet__tax-breakup">{tax_breakup}</td>
+          {tax_row_cells}
           <td class="right">{_fmt_currency(float(item.line_total), currency)}</td>
         </tr>"""
 
@@ -1004,9 +996,6 @@ def _build_invoice_html(invoice: Invoice, products: list[Product]) -> str:
   .invoice-sheet__table tbody td.right {{
     text-align: right;
   }}
-  .invoice-sheet__tax-breakup {{
-    line-height: 1.35;
-  }}
   .invoice-sheet__table tbody tr:last-child td {{
     border-bottom: 2px solid #d1d5db;
   }}
@@ -1081,8 +1070,7 @@ def _build_invoice_html(invoice: Invoice, products: list[Product]) -> str:
           <th>HSN/SAC</th>
           <th class="right">Qty</th>
           <th class="right">Unit Price</th>
-          <th class="right">GST %</th>
-          <th class="right">GST Split</th>
+          {tax_header_cells}
           <th class="right">Amount</th>
         </tr>
       </thead>

--- a/backend/src/api/routes/invoices.py
+++ b/backend/src/api/routes/invoices.py
@@ -492,6 +492,40 @@ def _e(text: str | None) -> str:
     return escape(text or "")
 
 
+def _fmt_rate(value: float) -> str:
+  return f"{value:.2f}".rstrip("0").rstrip(".")
+
+
+def _build_pdf_item_tax_breakup(item: InvoiceItem, currency: str, interstate_supply: bool) -> str:
+  gst_rate = float(item.gst_rate or 0)
+  tax_amount = float(item.tax_amount or 0)
+  cgst_amount = float(item.cgst_amount or 0)
+  sgst_amount = float(item.sgst_amount or 0)
+  igst_amount = float(item.igst_amount or 0)
+
+  if tax_amount > 0 and cgst_amount == 0 and sgst_amount == 0 and igst_amount == 0:
+    if interstate_supply:
+      igst_amount = tax_amount
+    else:
+      cgst_amount = float(_money(Decimal(str(tax_amount)) / Decimal("2")))
+      sgst_amount = float(_money(Decimal(str(tax_amount)) - Decimal(str(cgst_amount))))
+
+  if igst_amount > 0:
+    return (
+      f"IGST {_fmt_rate(gst_rate)}%<br>"
+      f"{_fmt_currency(igst_amount, currency)}"
+    )
+
+  if cgst_amount > 0 or sgst_amount > 0:
+    split_rate = gst_rate / 2
+    return (
+      f"CGST {_fmt_rate(split_rate)}%: {_fmt_currency(cgst_amount, currency)}<br>"
+      f"SGST {_fmt_rate(split_rate)}%: {_fmt_currency(sgst_amount, currency)}"
+    )
+
+  return f"GST {_fmt_rate(gst_rate)}%: {_fmt_currency(0, currency)}"
+
+
 def _build_pdf_tax_breakup_rows(invoice: Invoice, currency: str) -> str:
   cgst = float(invoice.cgst_amount or 0)
   sgst = float(invoice.sgst_amount or 0)
@@ -512,6 +546,7 @@ def _build_purchase_invoice_html(invoice: Invoice, products: list[Product]) -> s
     currency = invoice.company_currency_code or "USD"
     inv_number = invoice.invoice_number or f"#{invoice.id}"
     inv_date = invoice.invoice_date.strftime("%d %b %Y") if invoice.invoice_date else (invoice.created_at.strftime("%d %b %Y") if invoice.created_at else "N/A")
+    interstate_supply = _is_interstate_supply(invoice.company_gst, invoice.ledger_gst)
 
     product_map = {p.id: p for p in products}
 
@@ -522,8 +557,7 @@ def _build_purchase_invoice_html(invoice: Invoice, products: list[Product]) -> s
         sku = _e(prod.sku) if prod else "N/A"
         hsn = _e(item.hsn_sac or (prod.hsn_sac if prod else None) or "N/A")
         gst_rate = float(item.gst_rate or 0)
-        taxable_amt = float(item.taxable_amount or (float(item.unit_price) * item.quantity))
-        tax_amt = float(item.tax_amount or (taxable_amt * gst_rate / 100))
+        tax_breakup = _build_pdf_item_tax_breakup(item, currency, interstate_supply)
 
         item_rows += f"""
         <tr>
@@ -534,7 +568,7 @@ def _build_purchase_invoice_html(invoice: Invoice, products: list[Product]) -> s
           <td class="right">{item.quantity}</td>
           <td class="right">{_fmt_currency(float(item.unit_price), currency)}</td>
           <td class="right">{gst_rate:.2f}%</td>
-          <td class="right">{_fmt_currency(tax_amt, currency)}</td>
+          <td class="right invoice-sheet__tax-breakup">{tax_breakup}</td>
           <td class="right">{_fmt_currency(float(item.line_total), currency)}</td>
         </tr>"""
 
@@ -692,6 +726,9 @@ def _build_purchase_invoice_html(invoice: Invoice, products: list[Product]) -> s
   .invoice-sheet__table tbody td.right {{
     text-align: right;
   }}
+  .invoice-sheet__tax-breakup {{
+    line-height: 1.35;
+  }}
   .invoice-sheet__table tbody tr:last-child td {{
     border-bottom: 2px solid #d1d5db;
   }}
@@ -756,7 +793,7 @@ def _build_purchase_invoice_html(invoice: Invoice, products: list[Product]) -> s
           <th class="right">Qty</th>
           <th class="right">Unit Price</th>
           <th class="right">GST %</th>
-          <th class="right">Tax</th>
+          <th class="right">GST Split</th>
           <th class="right">Amount</th>
         </tr>
       </thead>
@@ -792,6 +829,7 @@ def _build_invoice_html(invoice: Invoice, products: list[Product]) -> str:
     voucher_label = "Sales" if invoice.voucher_type == "sales" else "Purchase"
     inv_number = invoice.invoice_number or f"#{invoice.id}"
     inv_date = invoice.invoice_date.strftime("%d %b %Y") if invoice.invoice_date else (invoice.created_at.strftime("%d %b %Y") if invoice.created_at else "N/A")
+    interstate_supply = _is_interstate_supply(invoice.company_gst, invoice.ledger_gst)
 
     product_map = {p.id: p for p in products}
 
@@ -803,8 +841,7 @@ def _build_invoice_html(invoice: Invoice, products: list[Product]) -> str:
         sku = _e(prod.sku) if prod else "N/A"
         hsn = _e(item.hsn_sac or (prod.hsn_sac if prod else None) or "N/A")
         gst_rate = float(item.gst_rate or 0)
-        taxable_amt = float(item.taxable_amount or (float(item.unit_price) * item.quantity))
-        tax_amt = float(item.tax_amount or (taxable_amt * gst_rate / 100))
+        tax_breakup = _build_pdf_item_tax_breakup(item, currency, interstate_supply)
 
         item_rows += f"""
         <tr>
@@ -815,7 +852,7 @@ def _build_invoice_html(invoice: Invoice, products: list[Product]) -> str:
           <td class="right">{item.quantity}</td>
           <td class="right">{_fmt_currency(float(item.unit_price), currency)}</td>
           <td class="right">{gst_rate:.2f}%</td>
-          <td class="right">{_fmt_currency(tax_amt, currency)}</td>
+          <td class="right invoice-sheet__tax-breakup">{tax_breakup}</td>
           <td class="right">{_fmt_currency(float(item.line_total), currency)}</td>
         </tr>"""
 
@@ -967,6 +1004,9 @@ def _build_invoice_html(invoice: Invoice, products: list[Product]) -> str:
   .invoice-sheet__table tbody td.right {{
     text-align: right;
   }}
+  .invoice-sheet__tax-breakup {{
+    line-height: 1.35;
+  }}
   .invoice-sheet__table tbody tr:last-child td {{
     border-bottom: 2px solid #d1d5db;
   }}
@@ -1042,7 +1082,7 @@ def _build_invoice_html(invoice: Invoice, products: list[Product]) -> str:
           <th class="right">Qty</th>
           <th class="right">Unit Price</th>
           <th class="right">GST %</th>
-          <th class="right">Tax</th>
+          <th class="right">GST Split</th>
           <th class="right">Amount</th>
         </tr>
       </thead>

--- a/backend/src/api/routes/invoices.py
+++ b/backend/src/api/routes/invoices.py
@@ -74,6 +74,52 @@ def _change_inventory_quantity(db: Session, product_id: int, quantity_delta: int
         raise HTTPException(status_code=400, detail=f"Insufficient inventory while {context}")
 
 
+def _assign_item_tax_split(
+    items: list[InvoiceItem],
+    *,
+    interstate_supply: bool,
+    invoice_cgst_amount: Decimal,
+    invoice_sgst_amount: Decimal,
+    invoice_igst_amount: Decimal,
+) -> None:
+    if not items:
+        return
+
+    if interstate_supply:
+        remaining_igst = _money(invoice_igst_amount)
+        for index, item in enumerate(items):
+            item_tax_amount = _money(Decimal(str(item.tax_amount or 0)))
+            is_last_item = index == len(items) - 1
+            item_igst_amount = remaining_igst if is_last_item else item_tax_amount
+            if not is_last_item:
+                remaining_igst = _money(remaining_igst - item_igst_amount)
+
+            item.cgst_amount = 0.0
+            item.sgst_amount = 0.0
+            item.igst_amount = float(item_igst_amount)
+        return
+
+    remaining_cgst = _money(invoice_cgst_amount)
+    remaining_sgst = _money(invoice_sgst_amount)
+
+    for index, item in enumerate(items):
+        item_tax_amount = _money(Decimal(str(item.tax_amount or 0)))
+        is_last_item = index == len(items) - 1
+
+        if is_last_item:
+            item_cgst_amount = remaining_cgst
+            item_sgst_amount = remaining_sgst
+        else:
+            item_cgst_amount = _money(item_tax_amount / Decimal("2"))
+            item_sgst_amount = _money(item_tax_amount - item_cgst_amount)
+            remaining_cgst = _money(remaining_cgst - item_cgst_amount)
+            remaining_sgst = _money(remaining_sgst - item_sgst_amount)
+
+        item.cgst_amount = float(item_cgst_amount)
+        item.sgst_amount = float(item_sgst_amount)
+        item.igst_amount = 0.0
+
+
 def _reverse_existing_invoice_inventory(db: Session, invoice: Invoice) -> None:
     for item in invoice.items:
         reverse_delta = item.quantity if invoice.voucher_type == "sales" else -item.quantity
@@ -217,6 +263,14 @@ def _apply_payload_to_invoice(
         invoice.cgst_amount = float(half_tax_total)
         invoice.sgst_amount = float(half_tax_total)
         invoice.igst_amount = 0.0
+
+    _assign_item_tax_split(
+        created_items,
+        interstate_supply=interstate_supply,
+        invoice_cgst_amount=Decimal(str(invoice.cgst_amount or 0)),
+        invoice_sgst_amount=Decimal(str(invoice.sgst_amount or 0)),
+        invoice_igst_amount=Decimal(str(invoice.igst_amount or 0)),
+    )
 
     invoice.total_tax_amount = float(tax_total)
     raw_total = _money(taxable_total + tax_total)

--- a/backend/src/models/invoice.py
+++ b/backend/src/models/invoice.py
@@ -61,6 +61,9 @@ class InvoiceItem(Base):
     gst_rate = Column(Numeric(5, 2), nullable=False, default=0)
     taxable_amount = Column(Numeric(10, 2), nullable=False, default=0)
     tax_amount = Column(Numeric(10, 2), nullable=False, default=0)
+    cgst_amount = Column(Numeric(10, 2), nullable=False, default=0)
+    sgst_amount = Column(Numeric(10, 2), nullable=False, default=0)
+    igst_amount = Column(Numeric(10, 2), nullable=False, default=0)
     line_total = Column(Numeric(10, 2), nullable=False)
 
     invoice = relationship("Invoice", back_populates="items")

--- a/backend/src/schemas/invoice.py
+++ b/backend/src/schemas/invoice.py
@@ -30,6 +30,9 @@ class InvoiceItemOut(BaseModel):
     gst_rate: float
     taxable_amount: float
     tax_amount: float
+    cgst_amount: float
+    sgst_amount: float
+    igst_amount: float
     line_total: float
 
     class Config:

--- a/backend/tests/api/test_invoice_tax_split.py
+++ b/backend/tests/api/test_invoice_tax_split.py
@@ -14,7 +14,7 @@ if str(BACKEND_ROOT) not in sys.path:
 
 os.environ.setdefault("DATABASE_URL", "sqlite:///./test.db")
 
-from src.api.routes.invoices import _apply_payload_to_invoice
+from src.api.routes.invoices import _apply_payload_to_invoice, _build_invoice_html
 from src.db.base import Base
 from src.models.buyer import Buyer
 from src.models.company import CompanyProfile
@@ -43,7 +43,7 @@ def db_session():
         Base.metadata.drop_all(bind=engine)
 
 
-def _seed_common(db_session):
+def _seed_common(db_session, ledger_gst: str = "07ABCDE1234F1Z5"):
     user = User(
         email="admin@example.com",
         full_name="Admin",
@@ -53,7 +53,7 @@ def _seed_common(db_session):
     ledger = Buyer(
         name="Test Ledger",
         address="Some Address",
-        gst="07ABCDE1234F1Z5",
+        gst=ledger_gst,
         phone_number="9999999999",
     )
     company = CompanyProfile(
@@ -124,7 +124,17 @@ def test_intrastate_odd_paise_total_tax_is_adjusted_and_split_equally(db_session
 
     assert len(invoice.items) == 1
     assert float(invoice.items[0].tax_amount) == pytest.approx(18.02)
+    assert float(invoice.items[0].cgst_amount) == pytest.approx(9.01)
+    assert float(invoice.items[0].sgst_amount) == pytest.approx(9.01)
+    assert float(invoice.items[0].igst_amount) == pytest.approx(0)
     assert float(invoice.items[0].line_total) == pytest.approx(118.05)
+
+    html = _build_invoice_html(invoice, [product])
+    assert "SGST %</th>" in html
+    assert "CGST %</th>" in html
+    assert "Total Tax</th>" in html
+    assert "IGST %</th>" not in html
+    assert "GST Split" not in html
 
 
 def test_intrastate_three_line_case_keeps_cgst_sgst_equal(db_session):
@@ -165,3 +175,50 @@ def test_intrastate_three_line_case_keeps_cgst_sgst_equal(db_session):
     assert float(invoice.items[0].tax_amount) == pytest.approx(45.76)
     assert float(invoice.items[1].tax_amount) == pytest.approx(442.37)
     assert float(invoice.items[2].tax_amount) == pytest.approx(91.53)
+    assert float(invoice.items[0].cgst_amount) == pytest.approx(22.88)
+    assert float(invoice.items[0].sgst_amount) == pytest.approx(22.88)
+    assert float(invoice.items[1].cgst_amount) == pytest.approx(221.19)
+    assert float(invoice.items[1].sgst_amount) == pytest.approx(221.18)
+    assert float(invoice.items[2].cgst_amount) == pytest.approx(45.76)
+    assert float(invoice.items[2].sgst_amount) == pytest.approx(45.77)
+    assert sum(float(item.cgst_amount) for item in invoice.items) == pytest.approx(289.83)
+    assert sum(float(item.sgst_amount) for item in invoice.items) == pytest.approx(289.83)
+    assert sum(float(item.igst_amount) for item in invoice.items) == pytest.approx(0)
+
+
+def test_interstate_item_tax_is_stored_as_igst_and_rendered_in_pdf(db_session):
+    user, ledger = _seed_common(db_session, ledger_gst="27ABCDE1234F1Z5")
+    product = _create_product_with_inventory(db_session, "IGST01", 100.00, 18)
+    invoice = _new_invoice(db_session)
+
+    payload = InvoiceCreate(
+        ledger_id=ledger.id,
+        voucher_type="sales",
+        tax_inclusive=False,
+        items=[InvoiceItemCreate(product_id=product.id, quantity=1, unit_price=100.00)],
+    )
+
+    _apply_payload_to_invoice(
+        db_session,
+        invoice,
+        payload,
+        created_by=user.id,
+        regenerate_number=False,
+    )
+    db_session.flush()
+    db_session.refresh(invoice)
+
+    assert float(invoice.cgst_amount) == pytest.approx(0)
+    assert float(invoice.sgst_amount) == pytest.approx(0)
+    assert float(invoice.igst_amount) == pytest.approx(18.00)
+    assert len(invoice.items) == 1
+    assert float(invoice.items[0].cgst_amount) == pytest.approx(0)
+    assert float(invoice.items[0].sgst_amount) == pytest.approx(0)
+    assert float(invoice.items[0].igst_amount) == pytest.approx(18.00)
+
+    html = _build_invoice_html(invoice, [product])
+    assert "IGST %</th>" in html
+    assert "Total Tax</th>" in html
+    assert "SGST %</th>" not in html
+    assert "CGST %</th>" not in html
+    assert "GST Split" not in html

--- a/backend/tests/api/test_invoice_tax_split.py
+++ b/backend/tests/api/test_invoice_tax_split.py
@@ -131,9 +131,12 @@ def test_intrastate_odd_paise_total_tax_is_adjusted_and_split_equally(db_session
 
     html = _build_invoice_html(invoice, [product])
     assert "SGST %</th>" in html
+    assert "SGST Amt</th>" in html
     assert "CGST %</th>" in html
+    assert "CGST Amt</th>" in html
     assert "Total Tax</th>" in html
     assert "IGST %</th>" not in html
+    assert "IGST Amt</th>" not in html
     assert "GST Split" not in html
 
 
@@ -218,7 +221,10 @@ def test_interstate_item_tax_is_stored_as_igst_and_rendered_in_pdf(db_session):
 
     html = _build_invoice_html(invoice, [product])
     assert "IGST %</th>" in html
+    assert "IGST Amt</th>" in html
     assert "Total Tax</th>" in html
     assert "SGST %</th>" not in html
+    assert "SGST Amt</th>" not in html
     assert "CGST %</th>" not in html
+    assert "CGST Amt</th>" not in html
     assert "GST Split" not in html

--- a/frontend/src/components/CreateInvoiceModal.tsx
+++ b/frontend/src/components/CreateInvoiceModal.tsx
@@ -4,6 +4,7 @@ import api, { getApiErrorMessage } from '../api/client';
 import type { InvoiceCreate, Invoice, Ledger, Product } from '../types/api';
 import { useFY } from '../context/FYContext';
 import formatCurrency from '../utils/formatting';
+import { formatInvoiceTaxBreakdown, isInterstateSupply } from '../utils/invoiceTax';
 import ProductCombobox from './ProductCombobox';
 import LedgerCombobox from './LedgerCombobox';
 
@@ -47,6 +48,7 @@ export default function CreateInvoiceModal({
   const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
   const [currencyCode, setCurrencyCode] = useState('INR');
+  const [companyGst, setCompanyGst] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -56,12 +58,13 @@ export default function CreateInvoiceModal({
         const [productsRes, ledgersRes, companyRes] = await Promise.all([
           api.get<{ items: Product[] }>('/products/', { params: { page_size: 500 } }),
           api.get<{ items: Ledger[] }>('/ledgers/', { params: { page_size: 500 } }),
-          api.get<{ currency_code: string | null }>('/company/'),
+          api.get<{ currency_code: string | null; gst: string | null }>('/company/'),
         ]);
         if (cancelled) return;
         setProducts(productsRes.data.items);
         setLedgers(ledgersRes.data.items);
         setCurrencyCode(companyRes.data.currency_code || 'INR');
+        setCompanyGst(companyRes.data.gst || null);
 
         if (!preselectedLedgerId && ledgersRes.data.items.length > 0) {
           setSelectedLedgerId(String(ledgersRes.data.items[0].id));
@@ -108,6 +111,8 @@ export default function CreateInvoiceModal({
     activeFY !== null &&
     invoiceDate !== '' &&
     (invoiceDate < activeFY.start_date || invoiceDate > activeFY.end_date);
+  const selectedLedger = ledgers.find((ledger) => ledger.id === Number(selectedLedgerId));
+  const composerInterstateSupply = isInterstateSupply(companyGst, selectedLedger?.gst);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -258,7 +263,14 @@ export default function CreateInvoiceModal({
 
                     <div className="line-item__price">
                       {formatCurrency(lineTotal, currencyCode)}
-                      <div className="table-subtext">Incl GST {gstRate}% ({formatCurrency(taxAmount, currencyCode)})</div>
+                      <div className="table-subtext">
+                        {formatInvoiceTaxBreakdown({
+                          gstRate,
+                          taxAmount,
+                          currencyCode,
+                          interstateSupply: composerInterstateSupply,
+                        })}
+                      </div>
                     </div>
                     <button type="button" className="button button--danger" onClick={() => removeItem(item.id)} title={`Remove line item ${index + 1}`} aria-label={`Remove line item ${index + 1}`}>Remove</button>
                   </div>

--- a/frontend/src/pages/InvoicesPage.tsx
+++ b/frontend/src/pages/InvoicesPage.tsx
@@ -11,6 +11,7 @@ import ProductCombobox from '../components/ProductCombobox';
 import LedgerCombobox from '../components/LedgerCombobox';
 import { useEscapeClose } from '../hooks/useEscapeClose';
 import formatCurrency from '../utils/formatting';
+import { formatInvoiceTaxBreakdown, isInterstateSupply } from '../utils/invoiceTax';
 import { useFY } from '../context/FYContext';
 import { fetchInvoiceById, fetchInvoiceComposerData } from '../features/invoices/api';
 import { invoiceQueryKeys } from '../features/invoices/queryKeys';
@@ -206,6 +207,8 @@ export default function InvoicesPage() {
   const projectedTotalAmount = applyRoundOff ? roundedTotalAmount : totalAmount;
 
   const activeCurrencyCode = company?.currency_code || 'USD';
+  const selectedLedger = ledgers.find((entry) => entry.id === Number(selectedLedgerId));
+  const composerInterstateSupply = isInterstateSupply(company?.gst, selectedLedger?.gst);
 
   function addItem() {
     const defaultProduct = products[0];
@@ -794,7 +797,14 @@ export default function InvoicesPage() {
 
                       <div className="line-item__price">
                         {formatCurrency(lineTotal, activeCurrencyCode)}
-                        <div className="table-subtext">Incl GST {gstRate}% ({formatCurrency(taxAmount, activeCurrencyCode)})</div>
+                        <div className="table-subtext">
+                          {formatInvoiceTaxBreakdown({
+                            gstRate,
+                            taxAmount,
+                            currencyCode: activeCurrencyCode,
+                            interstateSupply: composerInterstateSupply,
+                          })}
+                        </div>
                       </div>
                       <button type="button" className="button button--danger" onClick={() => removeItem(item.id)} title={`Remove line item ${index + 1}`} aria-label={`Remove line item ${index + 1}`}>
                         Remove

--- a/frontend/src/utils/invoiceTax.ts
+++ b/frontend/src/utils/invoiceTax.ts
@@ -1,0 +1,66 @@
+import formatCurrency from './formatting';
+
+type InvoiceTaxBreakdownArgs = {
+  gstRate: number;
+  taxAmount: number;
+  currencyCode: string;
+  cgstAmount?: number | null;
+  sgstAmount?: number | null;
+  igstAmount?: number | null;
+  interstateSupply?: boolean;
+};
+
+function roundCurrency(value: number): number {
+  return Math.round((value + Number.EPSILON) * 100) / 100;
+}
+
+function formatRate(rate: number): string {
+  return rate.toFixed(2).replace(/\.00$/, '').replace(/(\.\d*[1-9])0+$/, '$1');
+}
+
+export function isInterstateSupply(companyGst?: string | null, ledgerGst?: string | null): boolean {
+  const normalizedCompanyGst = companyGst?.trim() || '';
+  const normalizedLedgerGst = ledgerGst?.trim() || '';
+
+  if (normalizedCompanyGst.length < 2 || normalizedLedgerGst.length < 2) {
+    return false;
+  }
+
+  return normalizedCompanyGst.slice(0, 2) !== normalizedLedgerGst.slice(0, 2);
+}
+
+export function formatInvoiceTaxBreakdown({
+  gstRate,
+  taxAmount,
+  currencyCode,
+  cgstAmount,
+  sgstAmount,
+  igstAmount,
+  interstateSupply,
+}: InvoiceTaxBreakdownArgs): string {
+  const normalizedGstRate = Number.isFinite(gstRate) ? gstRate : 0;
+  const normalizedTaxAmount = roundCurrency(Number.isFinite(taxAmount) ? taxAmount : 0);
+  const normalizedIgstAmount = roundCurrency(Number.isFinite(igstAmount ?? NaN) ? Number(igstAmount) : 0);
+  const normalizedCgstAmount = roundCurrency(Number.isFinite(cgstAmount ?? NaN) ? Number(cgstAmount) : 0);
+  const normalizedSgstAmount = roundCurrency(Number.isFinite(sgstAmount ?? NaN) ? Number(sgstAmount) : 0);
+
+  if (normalizedIgstAmount > 0) {
+    return `IGST ${formatRate(normalizedGstRate)}% (${formatCurrency(normalizedIgstAmount, currencyCode)})`;
+  }
+
+  if (normalizedCgstAmount > 0 || normalizedSgstAmount > 0) {
+    return `CGST ${formatRate(normalizedGstRate / 2)}% (${formatCurrency(normalizedCgstAmount, currencyCode)}) + SGST ${formatRate(normalizedGstRate / 2)}% (${formatCurrency(normalizedSgstAmount, currencyCode)})`;
+  }
+
+  if (normalizedTaxAmount <= 0) {
+    return `GST ${formatRate(normalizedGstRate)}% (${formatCurrency(0, currencyCode)})`;
+  }
+
+  if (interstateSupply) {
+    return `IGST ${formatRate(normalizedGstRate)}% (${formatCurrency(normalizedTaxAmount, currencyCode)})`;
+  }
+
+  const splitCgstAmount = roundCurrency(normalizedTaxAmount / 2);
+  const splitSgstAmount = roundCurrency(normalizedTaxAmount - splitCgstAmount);
+  return `CGST ${formatRate(normalizedGstRate / 2)}% (${formatCurrency(splitCgstAmount, currencyCode)}) + SGST ${formatRate(normalizedGstRate / 2)}% (${formatCurrency(splitSgstAmount, currencyCode)})`;
+}


### PR DESCRIPTION
## Summary
Implements item-wise GST split across invoice workflows with phased commits.

- Adds item-level GST fields (cgst_amount, sgst_amount, igst_amount)
- Adds schema and backfill migrations
- Populates item-level tax split in backend invoice allocation
- Updates composer tax display to SGST+CGST or IGST
- Updates PDF tax columns:
  - Intrastate: SGST %, SGST Amt, CGST %, CGST Amt, Total Tax
  - Interstate: IGST %, IGST Amt, Total Tax
- Updates focused tests for invoice tax split/PDF behavior

## Validation
- make migrate-up / make migrate-status
- backend: pytest tests/api/test_invoice_tax_split.py -q
- frontend: npm run build

## Type of change
- [x] feat
- [x] fix
- [x] test