### PR TITLE
feat(invoices): add multiline item descriptions

### DIFF
--- a/backend/migrations/20260416000004_add_description_to_invoice_items.py
+++ b/backend/migrations/20260416000004_add_description_to_invoice_items.py
@@ -1,0 +1,23 @@
+"""
+Add description field to invoice_items for serial numbers and batch codes
+"""
+
+from sqlalchemy import text
+
+
+def up(conn) -> None:
+    stmt = "ALTER TABLE invoice_items ADD COLUMN description TEXT"
+    
+    existing = {
+        row[0]
+        for row in conn.execute(
+            text("SELECT column_name FROM information_schema.columns WHERE table_name = 'invoice_items'")
+        ).fetchall()
+    }
+    
+    if "description" not in existing:
+        conn.execute(text(stmt))
+
+
+def down(conn) -> None:
+    conn.execute(text("ALTER TABLE invoice_items DROP COLUMN IF EXISTS description"))

--- a/backend/src/api/routes/invoices.py
+++ b/backend/src/api/routes/invoices.py
@@ -628,6 +628,10 @@ def _build_purchase_invoice_html(invoice: Invoice, products: list[Product]) -> s
     for idx, item in enumerate(invoice.items or [], start=1):
         prod = product_map.get(item.product_id)
         product_name = _e(prod.name) if prod else f"Product #{item.product_id}"
+          item_description = _e(item.description)
+          product_cell_html = product_name
+          if item_description:
+              product_cell_html = f"{product_name}<br><span class=\"muted-text\">{item_description}</span>"
         sku = _e(prod.sku) if prod else "N/A"
         hsn = _e(item.hsn_sac or (prod.hsn_sac if prod else None) or "N/A")
         tax_row_cells = _build_pdf_tax_row_cells(item, currency, interstate_supply)
@@ -635,7 +639,7 @@ def _build_purchase_invoice_html(invoice: Invoice, products: list[Product]) -> s
         item_rows += f"""
         <tr>
           <td>{idx}</td>
-          <td>{product_name}</td>
+            <td>{product_cell_html}</td>
           <td>{sku}</td>
           <td>{hsn}</td>
           <td class="right">{item.quantity}</td>

--- a/backend/src/api/routes/invoices.py
+++ b/backend/src/api/routes/invoices.py
@@ -237,6 +237,7 @@ def _apply_payload_to_invoice(
             taxable_amount=float(taxable_amount),
             tax_amount=float(tax_amount),
             line_total=float(line_total),
+            description=item.description,
         )
         created_items.append(invoice_item)
         db.add(invoice_item)

--- a/backend/src/api/routes/invoices.py
+++ b/backend/src/api/routes/invoices.py
@@ -628,10 +628,10 @@ def _build_purchase_invoice_html(invoice: Invoice, products: list[Product]) -> s
     for idx, item in enumerate(invoice.items or [], start=1):
         prod = product_map.get(item.product_id)
         product_name = _e(prod.name) if prod else f"Product #{item.product_id}"
-          item_description = _e(item.description)
-          product_cell_html = product_name
-          if item_description:
-              product_cell_html = f"{product_name}<br><span class=\"muted-text\">{item_description}</span>"
+        item_description = _e(item.description)
+        product_cell_html = product_name
+        if item_description:
+            product_cell_html = f"{product_name}<br><span class=\"muted-text\">{item_description}</span>"
         sku = _e(prod.sku) if prod else "N/A"
         hsn = _e(item.hsn_sac or (prod.hsn_sac if prod else None) or "N/A")
         tax_row_cells = _build_pdf_tax_row_cells(item, currency, interstate_supply)
@@ -639,7 +639,7 @@ def _build_purchase_invoice_html(invoice: Invoice, products: list[Product]) -> s
         item_rows += f"""
         <tr>
           <td>{idx}</td>
-            <td>{product_cell_html}</td>
+          <td>{product_cell_html}</td>
           <td>{sku}</td>
           <td>{hsn}</td>
           <td class="right">{item.quantity}</td>
@@ -918,6 +918,10 @@ def _build_invoice_html(invoice: Invoice, products: list[Product]) -> str:
     for idx, item in enumerate(invoice.items or [], start=1):
         prod = product_map.get(item.product_id)
         product_name = _e(prod.name) if prod else f"Product #{item.product_id}"
+        item_description = _e(item.description)
+        product_cell_html = product_name
+        if item_description:
+            product_cell_html = f"{product_name}<br><span class=\"muted-text\">{item_description}</span>"
         sku = _e(prod.sku) if prod else "N/A"
         hsn = _e(item.hsn_sac or (prod.hsn_sac if prod else None) or "N/A")
         tax_row_cells = _build_pdf_tax_row_cells(item, currency, interstate_supply)
@@ -925,7 +929,7 @@ def _build_invoice_html(invoice: Invoice, products: list[Product]) -> str:
         item_rows += f"""
         <tr>
           <td>{idx}</td>
-          <td>{product_name}</td>
+          <td>{product_cell_html}</td>
           <td>{sku}</td>
           <td>{hsn}</td>
           <td class="right">{item.quantity}</td>

--- a/backend/src/models/invoice.py
+++ b/backend/src/models/invoice.py
@@ -65,6 +65,6 @@ class InvoiceItem(Base):
     sgst_amount = Column(Numeric(10, 2), nullable=False, default=0)
     igst_amount = Column(Numeric(10, 2), nullable=False, default=0)
     line_total = Column(Numeric(10, 2), nullable=False)
-        description = Column(Text, nullable=True)
+    description = Column(Text, nullable=True)
 
     invoice = relationship("Invoice", back_populates="items")

--- a/backend/src/models/invoice.py
+++ b/backend/src/models/invoice.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Boolean, Column, Integer, ForeignKey, DateTime, Numeric, String
+from sqlalchemy import Boolean, Column, Integer, ForeignKey, DateTime, Numeric, String, Text
 from sqlalchemy.orm import relationship
 from datetime import datetime
 from src.db.base import Base
@@ -65,5 +65,6 @@ class InvoiceItem(Base):
     sgst_amount = Column(Numeric(10, 2), nullable=False, default=0)
     igst_amount = Column(Numeric(10, 2), nullable=False, default=0)
     line_total = Column(Numeric(10, 2), nullable=False)
+        description = Column(Text, nullable=True)
 
     invoice = relationship("Invoice", back_populates="items")

--- a/backend/src/schemas/invoice.py
+++ b/backend/src/schemas/invoice.py
@@ -35,7 +35,7 @@ class InvoiceItemOut(BaseModel):
     sgst_amount: float
     igst_amount: float
     line_total: float
-        description: str | None = None
+    description: str | None = None
 
     class Config:
         from_attributes = True

--- a/backend/src/schemas/invoice.py
+++ b/backend/src/schemas/invoice.py
@@ -8,6 +8,7 @@ class InvoiceItemCreate(BaseModel):
     product_id: int
     quantity: int
     unit_price: float | None = None
+    description: str | None = None
 
 
 class InvoiceCreate(BaseModel):
@@ -34,6 +35,7 @@ class InvoiceItemOut(BaseModel):
     sgst_amount: float
     igst_amount: float
     line_total: float
+        description: str | None = None
 
     class Config:
         from_attributes = True

--- a/frontend/src/components/CreateInvoiceModal.tsx
+++ b/frontend/src/components/CreateInvoiceModal.tsx
@@ -277,10 +277,10 @@ export default function CreateInvoiceModal({
                     <button type="button" className="button button--danger" onClick={() => removeItem(item.id)} title={`Remove line item ${index + 1}`} aria-label={`Remove line item ${index + 1}`}>Remove</button>
                       <div className="field" style={{ gridColumn: '1 / -1' }}>
                         <label htmlFor={`modal-inv-description-${item.id}`}>Description (optional)</label>
-                        <input
+                        <textarea
                           id={`modal-inv-description-${item.id}`}
                           className="input"
-                          type="text"
+                          rows={2}
                           value={item.description}
                           onChange={(e) => updateItem(item.id, 'description', e.target.value)}
                           placeholder="Serial number, batch code, or item notes"

--- a/frontend/src/components/CreateInvoiceModal.tsx
+++ b/frontend/src/components/CreateInvoiceModal.tsx
@@ -13,10 +13,11 @@ type InvoiceFormItem = {
   productId: string;
   quantity: string;
   unit_price: string;
+  description: string;
 };
 
 function createItem(id: number, productId = '', unitPrice = ''): InvoiceFormItem {
-  return { id, productId, quantity: '1', unit_price: unitPrice };
+  return { id, productId, quantity: '1', unit_price: unitPrice, description: '' };
 }
 
 type CreateInvoiceModalProps = {
@@ -103,7 +104,7 @@ export default function CreateInvoiceModal({
     setItems((c) => (c.length === 1 ? c : c.filter((i) => i.id !== id)));
   }
 
-  function updateItem(id: number, key: 'productId' | 'quantity' | 'unit_price', value: string) {
+  function updateItem(id: number, key: 'productId' | 'quantity' | 'unit_price' | 'description', value: string) {
     setItems((c) => c.map((i) => (i.id === id ? { ...i, [key]: value } : i)));
   }
 
@@ -126,6 +127,7 @@ export default function CreateInvoiceModal({
           product_id: Number(item.productId),
           quantity: Number(item.quantity),
           unit_price: item.unit_price ? Number(item.unit_price) : undefined,
+          description: item.description || undefined,
         })),
       };
       const res = await api.post<Invoice>('/invoices/', payload);
@@ -273,6 +275,17 @@ export default function CreateInvoiceModal({
                       </div>
                     </div>
                     <button type="button" className="button button--danger" onClick={() => removeItem(item.id)} title={`Remove line item ${index + 1}`} aria-label={`Remove line item ${index + 1}`}>Remove</button>
+                      <div className="field" style={{ gridColumn: '1 / -1' }}>
+                        <label htmlFor={`modal-inv-description-${item.id}`}>Description (optional)</label>
+                        <input
+                          id={`modal-inv-description-${item.id}`}
+                          className="input"
+                          type="text"
+                          value={item.description}
+                          onChange={(e) => updateItem(item.id, 'description', e.target.value)}
+                          placeholder="Serial number, batch code, or item notes"
+                        />
+                      </div>
                   </div>
                 );
               })}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import api, { getApiErrorMessage } from '../api/client';
 import StatusToasts from '../components/StatusToasts';
-import type { CompanyProfile, InventoryRow, Invoice, Product } from '../types/api';
+import type { CompanyProfile, InventoryRow, Invoice, PaginatedInventoryOut, Product } from '../types/api';
 import formatCurrency from '../utils/formatting';
 
 type DashboardState = {
@@ -9,6 +9,17 @@ type DashboardState = {
   inventory: InventoryRow[];
   invoices: Invoice[];
 };
+
+function normalizeInventoryRows(payload: PaginatedInventoryOut | InventoryRow[] | unknown): InventoryRow[] {
+  if (Array.isArray(payload)) {
+    return payload;
+  }
+  if (payload && typeof payload === 'object' && 'items' in payload) {
+    const items = (payload as PaginatedInventoryOut).items;
+    return Array.isArray(items) ? items : [];
+  }
+  return [];
+}
 
 export default function DashboardPage() {
   const [state, setState] = useState<DashboardState>({ products: [], inventory: [], invoices: [] });
@@ -27,7 +38,7 @@ export default function DashboardPage() {
         setError('');
         const [productsRes, inventoryRes, invoicesRes, companyRes] = await Promise.all([
           api.get<{ items: Product[] }>('/products/', { params: { page_size: 100 } }),
-          api.get<InventoryRow[]>('/inventory/'),
+          api.get<PaginatedInventoryOut>('/inventory/', { params: { page_size: 100 } }),
           api.get<{ items: Invoice[] }>('/invoices/', { params: { page_size: 100 } }),
           api.get<CompanyProfile>('/company/'),
         ]);
@@ -38,7 +49,7 @@ export default function DashboardPage() {
 
         setState({
           products: productsRes.data.items,
-          inventory: inventoryRes.data,
+          inventory: normalizeInventoryRows(inventoryRes.data),
           invoices: invoicesRes.data.items,
         });
         setCompany(companyRes.data);

--- a/frontend/src/pages/InvoicesPage.tsx
+++ b/frontend/src/pages/InvoicesPage.tsx
@@ -27,6 +27,7 @@ type InvoiceFormItem = {
   productId: string;
   quantity: string;
   unit_price: string;
+  description: string;
 };
 
 function createItem(id: number, productId = '', unitPrice = ''): InvoiceFormItem {
@@ -35,6 +36,7 @@ function createItem(id: number, productId = '', unitPrice = ''): InvoiceFormItem
     productId,
     quantity: '1',
     unit_price: unitPrice,
+    description: '',
   };
 }
 
@@ -227,7 +229,7 @@ export default function InvoicesPage() {
     setItems((current) => (current.length === 1 ? current : current.filter((item) => item.id !== id)));
   }
 
-  function updateItem(id: number, key: 'productId' | 'quantity' | 'unit_price', value: string) {
+  function updateItem(id: number, key: 'productId' | 'quantity' | 'unit_price' | 'description', value: string) {
     setItems((current) => current.map((item) => (item.id === id ? { ...item, [key]: value } : item)));
   }
 
@@ -271,6 +273,7 @@ export default function InvoicesPage() {
       productId: String(line.product_id),
       quantity: String(line.quantity),
       unit_price: String(line.unit_price),
+      description: line.description ?? '',
     }));
 
     setItems(nextItems);
@@ -325,6 +328,7 @@ export default function InvoicesPage() {
           product_id: Number(item.productId),
           quantity: Number(item.quantity),
           unit_price: item.unit_price ? Number(item.unit_price) : undefined,
+          description: item.description || undefined,
         })),
       };
 
@@ -817,6 +821,17 @@ export default function InvoicesPage() {
                       <button type="button" className="button button--danger" onClick={() => removeItem(item.id)} title={`Remove line item ${index + 1}`} aria-label={`Remove line item ${index + 1}`}>
                         Remove
                       </button>
+                      <div className="field" style={{ gridColumn: '1 / -1' }}>
+                        <label htmlFor={`invoice-description-${item.id}`}>Description (optional)</label>
+                        <textarea
+                          id={`invoice-description-${item.id}`}
+                          className="input"
+                          rows={2}
+                          value={item.description}
+                          onChange={(event) => updateItem(item.id, 'description', event.target.value)}
+                          placeholder="Serial number, batch code, or item notes"
+                        />
+                      </div>
                     </div>
                   );
                 })}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -201,12 +201,14 @@ export type InvoiceItem = {
   taxable_amount: number;
   tax_amount: number;
   line_total: number;
+  description?: string | null;
 };
 
 export type InvoiceItemInput = {
   product_id: number;
   quantity: number;
   unit_price?: number;
+  description?: string;
 };
 
 export type CreditNoteItem = {


### PR DESCRIPTION
## Summary

Adds multiline item descriptions to invoice line items in both invoice composer UIs and fixes dashboard inventory parsing for paginated inventory responses.

## Type of change

- [x] feat (new feature)
- [x] fix (bug fix)
- [ ] docs (documentation)
- [ ] test (tests)
- [ ] chore/refactor

## How to test

1. Open /invoices and enter a multiline description for a line item.
2. Create and edit an invoice; verify descriptions persist and prefill.
3. Open quick-create modal and verify multiline description entry works.
4. Open dashboard and verify no inventory reduce/filter runtime error.
5. Run: cd frontend && npm run build

## Checklist

- [x] My code follows the project style and conventions
- [ ] I added/updated tests where appropriate
- [ ] I updated docs where needed
- [x] I ran relevant checks locally
- [x] I verified this does not break existing behavior

## Screenshots (if UI changes)

N/A

## Related issue

N/A
