### PR TITLE
fix(invoices): align tax split and preview totals

### DIFF
--- a/backend/src/api/routes/invoices.py
+++ b/backend/src/api/routes/invoices.py
@@ -78,43 +78,33 @@ def _assign_item_tax_split(
     items: list[InvoiceItem],
     *,
     interstate_supply: bool,
-    invoice_cgst_amount: Decimal,
-    invoice_sgst_amount: Decimal,
-    invoice_igst_amount: Decimal,
 ) -> None:
     if not items:
         return
 
     if interstate_supply:
-        remaining_igst = _money(invoice_igst_amount)
-        for index, item in enumerate(items):
+        for item in items:
             item_tax_amount = _money(Decimal(str(item.tax_amount or 0)))
-            is_last_item = index == len(items) - 1
-            item_igst_amount = remaining_igst if is_last_item else item_tax_amount
-            if not is_last_item:
-                remaining_igst = _money(remaining_igst - item_igst_amount)
+            item_igst_amount = item_tax_amount
+            taxable_amount = _money(Decimal(str(item.taxable_amount or 0)))
 
+            item.tax_amount = float(item_igst_amount)
+            item.line_total = float(_money(taxable_amount + item_igst_amount))
             item.cgst_amount = 0.0
             item.sgst_amount = 0.0
             item.igst_amount = float(item_igst_amount)
         return
 
-    remaining_cgst = _money(invoice_cgst_amount)
-    remaining_sgst = _money(invoice_sgst_amount)
-
-    for index, item in enumerate(items):
+    for item in items:
         item_tax_amount = _money(Decimal(str(item.tax_amount or 0)))
-        is_last_item = index == len(items) - 1
+        item_half_tax_amount = _money(item_tax_amount / Decimal("2"))
+        item_cgst_amount = item_half_tax_amount
+        item_sgst_amount = item_half_tax_amount
+        item_total_tax_amount = _money(item_cgst_amount + item_sgst_amount)
+        taxable_amount = _money(Decimal(str(item.taxable_amount or 0)))
 
-        if is_last_item:
-            item_cgst_amount = remaining_cgst
-            item_sgst_amount = remaining_sgst
-        else:
-            item_cgst_amount = _money(item_tax_amount / Decimal("2"))
-            item_sgst_amount = _money(item_tax_amount - item_cgst_amount)
-            remaining_cgst = _money(remaining_cgst - item_cgst_amount)
-            remaining_sgst = _money(remaining_sgst - item_sgst_amount)
-
+        item.tax_amount = float(item_total_tax_amount)
+        item.line_total = float(_money(taxable_amount + item_total_tax_amount))
         item.cgst_amount = float(item_cgst_amount)
         item.sgst_amount = float(item_sgst_amount)
         item.igst_amount = 0.0
@@ -242,37 +232,28 @@ def _apply_payload_to_invoice(
         created_items.append(invoice_item)
         db.add(invoice_item)
 
-    invoice.taxable_amount = float(_money(taxable_total))
-    tax_total = _money(tax_total)
-
-    # Split GST components at invoice level. If intrastate total tax has odd paise,
-    # add Rs 0.01 first so CGST and SGST are always equal after splitting.
-    if interstate_supply:
-        invoice.cgst_amount = 0.0
-        invoice.sgst_amount = 0.0
-        invoice.igst_amount = float(tax_total)
-    else:
-        paise = int(tax_total * Decimal("100"))
-        if paise % 2 != 0:
-            tax_total = _money(tax_total + Decimal("0.01"))
-            if created_items:
-                last_item = created_items[-1]
-                last_item.tax_amount = float(_money(Decimal(str(last_item.tax_amount or 0)) + Decimal("0.01")))
-                last_item.line_total = float(_money(Decimal(str(last_item.line_total or 0)) + Decimal("0.01")))
-
-        half_tax_total = _money(tax_total / Decimal("2"))
-        invoice.cgst_amount = float(half_tax_total)
-        invoice.sgst_amount = float(half_tax_total)
-        invoice.igst_amount = 0.0
+    taxable_total = _money(taxable_total)
+    invoice.taxable_amount = float(taxable_total)
 
     _assign_item_tax_split(
         created_items,
         interstate_supply=interstate_supply,
-        invoice_cgst_amount=Decimal(str(invoice.cgst_amount or 0)),
-        invoice_sgst_amount=Decimal(str(invoice.sgst_amount or 0)),
-        invoice_igst_amount=Decimal(str(invoice.igst_amount or 0)),
     )
 
+    cgst_total = _money(sum((_money(Decimal(str(item.cgst_amount or 0))) for item in created_items), Decimal("0")))
+    sgst_total = _money(sum((_money(Decimal(str(item.sgst_amount or 0))) for item in created_items), Decimal("0")))
+    igst_total = _money(sum((_money(Decimal(str(item.igst_amount or 0))) for item in created_items), Decimal("0")))
+
+    if interstate_supply:
+        invoice.cgst_amount = 0.0
+        invoice.sgst_amount = 0.0
+        invoice.igst_amount = float(igst_total)
+    else:
+        invoice.cgst_amount = float(cgst_total)
+        invoice.sgst_amount = float(sgst_total)
+        invoice.igst_amount = 0.0
+
+    tax_total = _money(cgst_total + sgst_total + igst_total)
     invoice.total_tax_amount = float(tax_total)
     raw_total = _money(taxable_total + tax_total)
     if invoice.apply_round_off:

--- a/backend/src/services/credit_note.py
+++ b/backend/src/services/credit_note.py
@@ -214,8 +214,10 @@ def create_credit_note(
         else:
             half = _money(tax / Decimal("2"))
             cgst = half
-            sgst = _money(tax - half)
+            sgst = half
             igst = Decimal("0")
+            tax = _money(cgst + sgst)
+            line_total = _money(taxable + tax)
 
         taxable_total += taxable
         cgst_total += cgst

--- a/backend/tests/api/test_invoice_tax_split.py
+++ b/backend/tests/api/test_invoice_tax_split.py
@@ -140,7 +140,7 @@ def test_intrastate_odd_paise_total_tax_is_adjusted_and_split_equally(db_session
     assert "GST Split" not in html
 
 
-def test_intrastate_three_line_case_keeps_cgst_sgst_equal(db_session):
+def test_intrastate_three_line_case_keeps_itemwise_cgst_sgst_equal(db_session):
     user, ledger = _seed_common(db_session)
     p1 = _create_product_with_inventory(db_session, "MS02", 254.24, 18)
     p2 = _create_product_with_inventory(db_session, "LED01", 2457.63, 18)
@@ -176,16 +176,19 @@ def test_intrastate_three_line_case_keeps_cgst_sgst_equal(db_session):
 
     assert len(invoice.items) == 3
     assert float(invoice.items[0].tax_amount) == pytest.approx(45.76)
-    assert float(invoice.items[1].tax_amount) == pytest.approx(442.37)
-    assert float(invoice.items[2].tax_amount) == pytest.approx(91.53)
+    assert float(invoice.items[1].tax_amount) == pytest.approx(442.38)
+    assert float(invoice.items[2].tax_amount) == pytest.approx(91.52)
     assert float(invoice.items[0].cgst_amount) == pytest.approx(22.88)
     assert float(invoice.items[0].sgst_amount) == pytest.approx(22.88)
     assert float(invoice.items[1].cgst_amount) == pytest.approx(221.19)
-    assert float(invoice.items[1].sgst_amount) == pytest.approx(221.18)
+    assert float(invoice.items[1].sgst_amount) == pytest.approx(221.19)
     assert float(invoice.items[2].cgst_amount) == pytest.approx(45.76)
-    assert float(invoice.items[2].sgst_amount) == pytest.approx(45.77)
+    assert float(invoice.items[2].sgst_amount) == pytest.approx(45.76)
+    assert all(float(item.cgst_amount) == pytest.approx(float(item.sgst_amount)) for item in invoice.items)
     assert sum(float(item.cgst_amount) for item in invoice.items) == pytest.approx(289.83)
     assert sum(float(item.sgst_amount) for item in invoice.items) == pytest.approx(289.83)
+    assert sum(float(item.tax_amount) for item in invoice.items) == pytest.approx(float(invoice.total_tax_amount))
+    assert float(invoice.total_tax_amount) == pytest.approx(float(invoice.cgst_amount) + float(invoice.sgst_amount))
     assert sum(float(item.igst_amount) for item in invoice.items) == pytest.approx(0)
 
 

--- a/backend/tests/services/test_credit_notes.py
+++ b/backend/tests/services/test_credit_notes.py
@@ -324,17 +324,74 @@ class TestCreateCreditNoteValidation:
             create_credit_note(payload, db, current_user_id=1)
 
         added_credit_note_item = None
+        added_credit_note = None
         for added_call in db.add.call_args_list:
             candidate = added_call.args[0]
+            if isinstance(candidate, CreditNote) and added_credit_note is None:
+                added_credit_note = candidate
             if isinstance(candidate, CreditNoteItem):
                 added_credit_note_item = candidate
                 break
 
         assert added_credit_note_item is not None
+        assert added_credit_note is not None
         assert Decimal(str(added_credit_note_item.taxable_amount)) == Decimal("100.00")
         assert Decimal(str(added_credit_note_item.tax_amount)) == Decimal("18.00")
         assert Decimal(str(added_credit_note_item.line_total)) == Decimal("118.00")
         assert added_credit_note_item.quantity == 1
+        assert Decimal(str(added_credit_note.cgst_amount)) == Decimal("9.00")
+        assert Decimal(str(added_credit_note.sgst_amount)) == Decimal("9.00")
+        assert Decimal(str(added_credit_note.total_amount)) == Decimal("118.00")
+        assert Decimal(str(added_credit_note.cgst_amount + added_credit_note.sgst_amount)) == Decimal("18.00")
+        mock_change_inventory.assert_not_called()
+
+    def test_discount_credit_note_intrastate_keeps_item_split_equal_for_odd_paise_tax(self):
+        ledger = make_ledger(id=1)
+        inv = make_invoice(id=1, ledger_id=1)
+        ii = make_invoice_item(id=10, invoice_id=1, product_id=22, quantity=10, unit_price=100, gst_rate=18)
+
+        payload = CreditNoteCreate(
+            ledger_id=1,
+            invoice_ids=[1],
+            credit_note_type="discount",
+            items=[
+                CreditNoteItemCreate(
+                    invoice_id=1,
+                    invoice_item_id=10,
+                    discount_amount_inclusive=Decimal("118.05"),
+                )
+            ],
+        )
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = ledger
+        db.query.return_value.filter.return_value.all.side_effect = [[inv], [ii]]
+
+        with patch("src.services.credit_note.get_active_fy", return_value=SimpleNamespace(id=1)), \
+             patch("src.services.credit_note.get_fy_for_date", return_value=None), \
+             patch("src.services.credit_note.generate_next_number", return_value="CN-001"), \
+             patch("src.services.credit_note._recompute_credit_status"), \
+             patch("src.services.credit_note._change_inventory_quantity") as mock_change_inventory:
+            create_credit_note(payload, db, current_user_id=1)
+
+        added_credit_note_item = None
+        added_credit_note = None
+        for added_call in db.add.call_args_list:
+            candidate = added_call.args[0]
+            if isinstance(candidate, CreditNote) and added_credit_note is None:
+                added_credit_note = candidate
+            if isinstance(candidate, CreditNoteItem):
+                added_credit_note_item = candidate
+
+        assert added_credit_note_item is not None
+        assert added_credit_note is not None
+        assert Decimal(str(added_credit_note_item.taxable_amount)) == Decimal("100.04")
+        assert Decimal(str(added_credit_note_item.tax_amount)) == Decimal("18.02")
+        assert Decimal(str(added_credit_note_item.line_total)) == Decimal("118.06")
+        assert Decimal(str(added_credit_note.cgst_amount)) == Decimal("9.01")
+        assert Decimal(str(added_credit_note.sgst_amount)) == Decimal("9.01")
+        assert Decimal(str(added_credit_note.cgst_amount + added_credit_note.sgst_amount)) == Decimal("18.02")
+        assert Decimal(str(added_credit_note.total_amount)) == Decimal("118.06")
         mock_change_inventory.assert_not_called()
 
 

--- a/frontend/src/components/CreateInvoiceModal.tsx
+++ b/frontend/src/components/CreateInvoiceModal.tsx
@@ -43,6 +43,7 @@ export default function CreateInvoiceModal({
   const [ledgers, setLedgers] = useState<Ledger[]>([]);
   const [selectedLedgerId, setSelectedLedgerId] = useState(preselectedLedgerId ? String(preselectedLedgerId) : '');
   const [voucherType, setVoucherType] = useState<'sales' | 'purchase'>(preselectedVoucherType || 'sales');
+  const [taxInclusive, setTaxInclusive] = useState(false);
   const [invoiceDate, setInvoiceDate] = useState(new Date().toISOString().slice(0, 10));
   const [items, setItems] = useState<InvoiceFormItem[]>([createItem(1)]);
   const [nextItemId, setNextItemId] = useState(2);
@@ -90,6 +91,11 @@ export default function CreateInvoiceModal({
     const unitPrice = item.unit_price ? Number(item.unit_price) : (product?.price || 0);
     const gstRate = product?.gst_rate || 0;
     if (!product || Number.isNaN(quantity)) return sum;
+
+    if (taxInclusive) {
+      return sum + unitPrice * quantity;
+    }
+
     const taxableAmount = unitPrice * quantity;
     return sum + taxableAmount + taxableAmount * gstRate / 100;
   }, 0);
@@ -123,6 +129,7 @@ export default function CreateInvoiceModal({
         ledger_id: Number(selectedLedgerId),
         voucher_type: voucherType,
         invoice_date: invoiceDate,
+        tax_inclusive: taxInclusive,
         items: items.map((item) => ({
           product_id: Number(item.productId),
           quantity: Number(item.quantity),
@@ -210,14 +217,33 @@ export default function CreateInvoiceModal({
               </div>
             </div>
 
+            <div className="field" style={{ display: 'flex', alignItems: 'center', gap: '12px', marginBottom: 0 }}>
+              <input
+                id="modal-inv-tax-inclusive"
+                type="checkbox"
+                checked={taxInclusive}
+                onChange={(e) => setTaxInclusive(e.target.checked)}
+              />
+              <label htmlFor="modal-inv-tax-inclusive" style={{ marginBottom: 0, cursor: 'pointer' }}>
+                Prices include GST
+              </label>
+            </div>
+
             <div className="stack">
               {items.map((item, index) => {
                 const selectedProduct = products.find((p) => p.id === Number(item.productId));
                 const unitPrice = item.unit_price ? Number(item.unit_price) : (selectedProduct?.price || 0);
                 const gstRate = selectedProduct?.gst_rate || 0;
-                const taxableAmount = unitPrice * Number(item.quantity || 0);
-                const taxAmount = taxableAmount * gstRate / 100;
-                const lineTotal = taxableAmount + taxAmount;
+                let lineTotal: number;
+                let taxAmount: number;
+                if (taxInclusive) {
+                  lineTotal = unitPrice * Number(item.quantity || 0);
+                  taxAmount = lineTotal - lineTotal / (1 + gstRate / 100);
+                } else {
+                  const taxableAmount = unitPrice * Number(item.quantity || 0);
+                  taxAmount = taxableAmount * gstRate / 100;
+                  lineTotal = taxableAmount + taxAmount;
+                }
 
                 return (
                   <div key={item.id} className="line-item">
@@ -250,7 +276,7 @@ export default function CreateInvoiceModal({
                     </div>
 
                     <div className="field">
-                      <label htmlFor={`modal-inv-price-${item.id}`}>Price</label>
+                      <label htmlFor={`modal-inv-price-${item.id}`}>{taxInclusive ? 'Amount (incl. GST)' : 'Price'}</label>
                       <input
                         id={`modal-inv-price-${item.id}`}
                         className="input"

--- a/frontend/src/utils/invoiceTax.ts
+++ b/frontend/src/utils/invoiceTax.ts
@@ -61,6 +61,6 @@ export function formatInvoiceTaxBreakdown({
   }
 
   const splitCgstAmount = roundCurrency(normalizedTaxAmount / 2);
-  const splitSgstAmount = roundCurrency(normalizedTaxAmount - splitCgstAmount);
+  const splitSgstAmount = splitCgstAmount;
   return `CGST ${formatRate(normalizedGstRate / 2)}% (${formatCurrency(splitCgstAmount, currencyCode)}) + SGST ${formatRate(normalizedGstRate / 2)}% (${formatCurrency(splitSgstAmount, currencyCode)})`;
 }


### PR DESCRIPTION
## Summary

Aligns intrastate GST handling across backend persistence, PDF/header totals, and frontend previews.
Uses equal item-wise CGST/SGST splits for intrastate invoices and credit notes, derives header tax breakup from summed item values, and fixes tax-inclusive create-form preview output to match the persisted rule.

## Type of change

- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] docs (documentation)
- [x] test (tests)
- [ ] chore/refactor

## How to test

1. Create an intrastate invoice with multiple items and verify each saved item has equal CGST and SGST.
2. Verify invoice and credit-note tax breakup totals equal the sums of item-wise tax components.
3. In the create invoice UI, enable Prices include GST and confirm the preview shows equal CGST/SGST values for intrastate lines.
4. Run backend focused tests for invoice tax split and credit notes.
5. Run frontend build.

## Checklist

- [x] My code follows the project style and conventions
- [x] I added/updated tests where appropriate
- [ ] I updated docs where needed
- [x] I ran relevant checks locally
- [x] I verified this does not break existing behavior

## Screenshots (if UI changes)

N/A

## Related issue

Closes #
