### PR TITLE
feat(tax-ledger): add GST tax ledger reporting page

### DIFF
--- a/backend/src/api/routes/ledgers.py
+++ b/backend/src/api/routes/ledgers.py
@@ -14,10 +14,12 @@ from src.api.deps import get_current_user, require_roles
 from src.db.session import get_db
 from src.models.buyer import Buyer as Ledger
 from src.models.company import CompanyProfile
+from src.models.credit_note import CreditNote, CreditNoteItem
 from src.models.invoice import Invoice
+from src.models.invoice import InvoiceItem
 from src.models.payment import Payment
 from src.models.user import User, UserRole
-from src.schemas.ledger import DayBookEntry, DayBookOut, LedgerCreate, LedgerOut, LedgerStatementEntry, LedgerStatementOut, PaginatedLedgerOut
+from src.schemas.ledger import DayBookEntry, DayBookOut, LedgerCreate, LedgerOut, LedgerStatementEntry, LedgerStatementOut, PaginatedLedgerOut, TaxLedgerEntry, TaxLedgerOut, TaxLedgerTotals
 from src.services.credit_note_reporting import get_credit_note_ledger_summary
 from src.services.financial_year import get_active_fy
 
@@ -250,6 +252,33 @@ def _build_ledger_statement_data(
     )
 
 
+def _build_tax_ledger_totals(entries: list[TaxLedgerEntry]) -> TaxLedgerTotals:
+    debit_cgst = sum(entry.debit_cgst for entry in entries)
+    debit_sgst = sum(entry.debit_sgst for entry in entries)
+    debit_igst = sum(entry.debit_igst for entry in entries)
+    debit_total_tax = sum(entry.debit_total_tax for entry in entries)
+
+    credit_cgst = sum(entry.credit_cgst for entry in entries)
+    credit_sgst = sum(entry.credit_sgst for entry in entries)
+    credit_igst = sum(entry.credit_igst for entry in entries)
+    credit_total_tax = sum(entry.credit_total_tax for entry in entries)
+
+    return TaxLedgerTotals(
+        debit_cgst=debit_cgst,
+        debit_sgst=debit_sgst,
+        debit_igst=debit_igst,
+        debit_total_tax=debit_total_tax,
+        credit_cgst=credit_cgst,
+        credit_sgst=credit_sgst,
+        credit_igst=credit_igst,
+        credit_total_tax=credit_total_tax,
+        net_cgst=debit_cgst - credit_cgst,
+        net_sgst=debit_sgst - credit_sgst,
+        net_igst=debit_igst - credit_igst,
+        net_total_tax=debit_total_tax - credit_total_tax,
+    )
+
+
 @router.post("", response_model=LedgerOut, include_in_schema=False)
 @router.post("/", response_model=LedgerOut)
 def create_ledger(
@@ -407,6 +436,209 @@ def get_day_book(
         total_debit=sum(entry.debit for entry in entries),
         total_credit=sum(entry.credit for entry in entries),
         entries=entries,
+        fy_label=fy_label,
+        financial_year_id=financial_year_id,
+    )
+
+
+@router.get("/tax-ledger", response_model=TaxLedgerOut, include_in_schema=False)
+@router.get("/tax-ledger/", response_model=TaxLedgerOut)
+def get_tax_ledger(
+    from_date: date | None = Query(None),
+    to_date: date | None = Query(None),
+    voucher_type: str | None = Query(None, pattern="^(sales|purchase)$"),
+    gst_rate: float | None = Query(None, ge=0),
+    db: Session = Depends(get_db),
+    _: User = Depends(get_current_user),
+):
+    fy_label: str | None = None
+    financial_year_id: int | None = None
+    if from_date is None or to_date is None:
+        active_fy = get_active_fy(db)
+        if active_fy is None:
+            raise HTTPException(
+                status_code=400,
+                detail="No active financial year found. Please provide from_date and to_date, or activate a financial year.",
+            )
+        from_date = active_fy.start_date
+        to_date = active_fy.end_date
+        fy_label = active_fy.label
+        financial_year_id = active_fy.id
+
+    if from_date > to_date:
+        raise HTTPException(status_code=400, detail="from_date must be before or equal to to_date")
+
+    period_start = datetime.combine(from_date, time.min)
+    period_end = datetime.combine(to_date, time.max)
+
+    invoice_query = (
+        db.query(
+            Invoice.id.label("entry_id"),
+            Invoice.invoice_date.label("entry_date"),
+            Invoice.voucher_type.label("source_voucher_type"),
+            Invoice.invoice_number.label("reference_number"),
+            Invoice.ledger_name.label("ledger_name"),
+            InvoiceItem.gst_rate.label("gst_rate"),
+            func.coalesce(func.sum(InvoiceItem.taxable_amount), 0).label("taxable_amount"),
+            func.coalesce(func.sum(InvoiceItem.cgst_amount), 0).label("cgst_amount"),
+            func.coalesce(func.sum(InvoiceItem.sgst_amount), 0).label("sgst_amount"),
+            func.coalesce(func.sum(InvoiceItem.igst_amount), 0).label("igst_amount"),
+        )
+        .join(InvoiceItem, InvoiceItem.invoice_id == Invoice.id)
+        .filter(Invoice.status == "active")
+        .filter(Invoice.invoice_date >= period_start)
+        .filter(Invoice.invoice_date <= period_end)
+    )
+
+    if voucher_type is not None:
+        invoice_query = invoice_query.filter(Invoice.voucher_type == voucher_type)
+    if gst_rate is not None:
+        invoice_query = invoice_query.filter(InvoiceItem.gst_rate == gst_rate)
+
+    invoice_rows = (
+        invoice_query
+        .group_by(
+            Invoice.id,
+            Invoice.invoice_date,
+            Invoice.voucher_type,
+            Invoice.invoice_number,
+            Invoice.ledger_name,
+            InvoiceItem.gst_rate,
+        )
+        .order_by(Invoice.invoice_date.asc(), Invoice.id.asc(), InvoiceItem.gst_rate.asc())
+        .all()
+    )
+
+    credit_note_query = (
+        db.query(
+            CreditNote.id.label("entry_id"),
+            CreditNote.created_at.label("entry_date"),
+            Invoice.voucher_type.label("source_voucher_type"),
+            CreditNote.credit_note_number.label("reference_number"),
+            Invoice.ledger_name.label("ledger_name"),
+            CreditNoteItem.gst_rate.label("gst_rate"),
+            func.coalesce(func.sum(CreditNoteItem.taxable_amount), 0).label("taxable_amount"),
+        func.coalesce(
+          func.sum(
+            case(
+              (func.coalesce(InvoiceItem.igst_amount, 0) > 0, 0),
+              else_=CreditNoteItem.tax_amount / 2,
+            )
+          ),
+          0,
+        ).label("cgst_amount"),
+        func.coalesce(
+          func.sum(
+            case(
+              (func.coalesce(InvoiceItem.igst_amount, 0) > 0, 0),
+              else_=CreditNoteItem.tax_amount / 2,
+            )
+          ),
+          0,
+        ).label("sgst_amount"),
+        func.coalesce(
+          func.sum(
+            case(
+              (func.coalesce(InvoiceItem.igst_amount, 0) > 0, CreditNoteItem.tax_amount),
+              else_=0,
+            )
+          ),
+          0,
+        ).label("igst_amount"),
+        )
+        .join(CreditNoteItem, CreditNoteItem.credit_note_id == CreditNote.id)
+        .join(Invoice, Invoice.id == CreditNoteItem.invoice_id)
+      .outerjoin(InvoiceItem, InvoiceItem.id == CreditNoteItem.invoice_item_id)
+        .filter(CreditNote.status == "active")
+        .filter(CreditNote.created_at >= period_start)
+        .filter(CreditNote.created_at <= period_end)
+    )
+
+    if voucher_type is not None:
+        credit_note_query = credit_note_query.filter(Invoice.voucher_type == voucher_type)
+    if gst_rate is not None:
+        credit_note_query = credit_note_query.filter(CreditNoteItem.gst_rate == gst_rate)
+
+    credit_note_rows = (
+        credit_note_query
+        .group_by(
+            CreditNote.id,
+            CreditNote.created_at,
+            Invoice.voucher_type,
+            CreditNote.credit_note_number,
+            Invoice.ledger_name,
+            CreditNoteItem.gst_rate,
+        )
+        .order_by(CreditNote.created_at.asc(), CreditNote.id.asc(), CreditNoteItem.gst_rate.asc())
+        .all()
+    )
+
+    entries: list[TaxLedgerEntry] = []
+    for row in invoice_rows:
+        cgst_amount = float(row.cgst_amount or 0)
+        sgst_amount = float(row.sgst_amount or 0)
+        igst_amount = float(row.igst_amount or 0)
+        total_tax = cgst_amount + sgst_amount + igst_amount
+
+        is_sales = row.source_voucher_type == "sales"
+        entries.append(TaxLedgerEntry(
+            entry_id=row.entry_id,
+            entry_type="invoice",
+            date=row.entry_date,
+            voucher_type=row.source_voucher_type.title(),
+            source_voucher_type=row.source_voucher_type,
+            reference_number=row.reference_number or f"INV-{row.entry_id}",
+            ledger_name=row.ledger_name or "Unknown ledger",
+            particulars=f"{row.source_voucher_type.title()} Invoice",
+            gst_rate=float(row.gst_rate or 0),
+            taxable_amount=float(row.taxable_amount or 0),
+            debit_cgst=cgst_amount if is_sales else 0.0,
+            debit_sgst=sgst_amount if is_sales else 0.0,
+            debit_igst=igst_amount if is_sales else 0.0,
+            debit_total_tax=total_tax if is_sales else 0.0,
+            credit_cgst=0.0 if is_sales else cgst_amount,
+            credit_sgst=0.0 if is_sales else sgst_amount,
+            credit_igst=0.0 if is_sales else igst_amount,
+            credit_total_tax=0.0 if is_sales else total_tax,
+        ))
+
+    for row in credit_note_rows:
+        cgst_amount = float(row.cgst_amount or 0)
+        sgst_amount = float(row.sgst_amount or 0)
+        igst_amount = float(row.igst_amount or 0)
+        total_tax = cgst_amount + sgst_amount + igst_amount
+
+        source_is_sales = row.source_voucher_type == "sales"
+        entries.append(TaxLedgerEntry(
+            entry_id=row.entry_id,
+            entry_type="credit_note",
+            date=row.entry_date,
+            voucher_type="Credit Note",
+            source_voucher_type=row.source_voucher_type,
+            reference_number=row.reference_number or f"CN-{row.entry_id}",
+            ledger_name=row.ledger_name or "Unknown ledger",
+            particulars=f"Credit Note against {row.source_voucher_type.title()} Invoice",
+            gst_rate=float(row.gst_rate or 0),
+            taxable_amount=float(row.taxable_amount or 0),
+            debit_cgst=0.0 if source_is_sales else cgst_amount,
+            debit_sgst=0.0 if source_is_sales else sgst_amount,
+            debit_igst=0.0 if source_is_sales else igst_amount,
+            debit_total_tax=0.0 if source_is_sales else total_tax,
+            credit_cgst=cgst_amount if source_is_sales else 0.0,
+            credit_sgst=sgst_amount if source_is_sales else 0.0,
+            credit_igst=igst_amount if source_is_sales else 0.0,
+            credit_total_tax=total_tax if source_is_sales else 0.0,
+        ))
+
+    entries.sort(key=lambda entry: (_make_aware(entry.date), entry.entry_id, entry.gst_rate))
+
+    return TaxLedgerOut(
+        from_date=from_date,
+        to_date=to_date,
+        voucher_type=voucher_type,
+        gst_rate=gst_rate,
+        entries=entries,
+        totals=_build_tax_ledger_totals(entries),
         fy_label=fy_label,
         financial_year_id=financial_year_id,
     )

--- a/backend/src/schemas/ledger.py
+++ b/backend/src/schemas/ledger.py
@@ -103,3 +103,50 @@ class DayBookOut(BaseModel):
     entries: list[DayBookEntry]
     fy_label: str | None = None
     financial_year_id: int | None = None
+
+
+class TaxLedgerEntry(BaseModel):
+    entry_id: int
+    entry_type: str  # "invoice" or "credit_note"
+    date: datetime
+    voucher_type: str
+    source_voucher_type: str  # "sales" or "purchase"
+    reference_number: str
+    ledger_name: str
+    particulars: str
+    gst_rate: float
+    taxable_amount: float
+    debit_cgst: float
+    debit_sgst: float
+    debit_igst: float
+    debit_total_tax: float
+    credit_cgst: float
+    credit_sgst: float
+    credit_igst: float
+    credit_total_tax: float
+
+
+class TaxLedgerTotals(BaseModel):
+    debit_cgst: float
+    debit_sgst: float
+    debit_igst: float
+    debit_total_tax: float
+    credit_cgst: float
+    credit_sgst: float
+    credit_igst: float
+    credit_total_tax: float
+    net_cgst: float
+    net_sgst: float
+    net_igst: float
+    net_total_tax: float
+
+
+class TaxLedgerOut(BaseModel):
+    from_date: date
+    to_date: date
+    voucher_type: str | None = None
+    gst_rate: float | None = None
+    entries: list[TaxLedgerEntry]
+    totals: TaxLedgerTotals
+    fy_label: str | None = None
+    financial_year_id: int | None = None

--- a/backend/tests/api/test_tax_ledger.py
+++ b/backend/tests/api/test_tax_ledger.py
@@ -1,0 +1,335 @@
+from datetime import date, datetime
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from src.api.routes.ledgers import get_tax_ledger
+from src.db.base import Base
+from src.models.buyer import Buyer
+from src.models.credit_note import CreditNote, CreditNoteItem
+from src.models.invoice import Invoice, InvoiceItem
+from src.models.user import User, UserRole
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=engine)
+
+
+def _seed_basics(db_session):
+    user = User(
+        email="admin@example.com",
+        full_name="Admin",
+        hashed_password="secret",
+        role=UserRole.admin,
+    )
+    ledger = Buyer(
+        name="Acme Stores",
+        address="42 Market Road",
+        gst="29ABCDE1234F1Z5",
+        phone_number="9999999999",
+        email="ledger@example.com",
+    )
+    db_session.add_all([user, ledger])
+    db_session.commit()
+    return user, ledger
+
+
+def _add_invoice_with_item(
+    db_session,
+    ledger,
+    user,
+    *,
+    voucher_type: str,
+    invoice_number: str,
+    when: datetime,
+    gst_rate: float,
+    taxable_amount: float,
+    cgst_amount: float,
+    sgst_amount: float,
+    igst_amount: float,
+):
+    total_tax = cgst_amount + sgst_amount + igst_amount
+    invoice = Invoice(
+        invoice_number=invoice_number,
+        ledger_id=ledger.id,
+        ledger_name=ledger.name,
+        ledger_address=ledger.address,
+        ledger_gst=ledger.gst,
+        ledger_phone=ledger.phone_number,
+        company_name="Respawn Pvt Ltd",
+        company_address="1 Billing Street",
+        company_gst="29RESP1234N1Z1",
+        company_phone="8888888888",
+        company_email="accounts@example.com",
+        company_currency_code="INR",
+        voucher_type=voucher_type,
+        status="active",
+        created_by=user.id,
+        taxable_amount=taxable_amount,
+        total_tax_amount=total_tax,
+        cgst_amount=cgst_amount,
+        sgst_amount=sgst_amount,
+        igst_amount=igst_amount,
+        total_amount=taxable_amount + total_tax,
+        invoice_date=when,
+    )
+    db_session.add(invoice)
+    db_session.flush()
+
+    item = InvoiceItem(
+        invoice_id=invoice.id,
+        product_id=1,
+        quantity=1,
+        unit_price=taxable_amount,
+        gst_rate=gst_rate,
+        taxable_amount=taxable_amount,
+        tax_amount=total_tax,
+        cgst_amount=cgst_amount,
+        sgst_amount=sgst_amount,
+        igst_amount=igst_amount,
+        line_total=taxable_amount + total_tax,
+    )
+    db_session.add(item)
+    db_session.flush()
+    return invoice
+
+
+def _add_credit_note_item(
+    db_session,
+    user,
+    ledger,
+    invoice,
+    *,
+    number: str,
+    when: datetime,
+    gst_rate: float,
+    taxable_amount: float,
+    cgst_amount: float,
+    sgst_amount: float,
+    igst_amount: float,
+):
+    total_tax = cgst_amount + sgst_amount + igst_amount
+    credit_note = CreditNote(
+        credit_note_number=number,
+        ledger_id=ledger.id,
+        created_by=user.id,
+        credit_note_type="return",
+        status="active",
+        taxable_amount=taxable_amount,
+        cgst_amount=cgst_amount,
+        sgst_amount=sgst_amount,
+        igst_amount=igst_amount,
+        total_amount=taxable_amount + total_tax,
+        created_at=when,
+    )
+    db_session.add(credit_note)
+    db_session.flush()
+
+    item = CreditNoteItem(
+        credit_note_id=credit_note.id,
+        invoice_id=invoice.id,
+        invoice_item_id=invoice.items[0].id if invoice.items else None,
+        quantity=1,
+        unit_price=taxable_amount,
+        gst_rate=gst_rate,
+        taxable_amount=taxable_amount,
+        tax_amount=total_tax,
+        line_total=taxable_amount + total_tax,
+        created_at=when,
+    )
+    db_session.add(item)
+    db_session.flush()
+    return credit_note
+
+
+def test_tax_ledger_includes_invoice_tax_and_credit_note_reversals(db_session):
+    user, ledger = _seed_basics(db_session)
+
+    sales_invoice = _add_invoice_with_item(
+        db_session,
+        ledger,
+        user,
+        voucher_type="sales",
+        invoice_number="S-001",
+        when=datetime(2026, 1, 10, 9, 0, 0),
+        gst_rate=18,
+        taxable_amount=100,
+        cgst_amount=9,
+        sgst_amount=9,
+        igst_amount=0,
+    )
+    purchase_invoice = _add_invoice_with_item(
+        db_session,
+        ledger,
+        user,
+        voucher_type="purchase",
+        invoice_number="P-001",
+        when=datetime(2026, 1, 11, 9, 0, 0),
+        gst_rate=18,
+        taxable_amount=200,
+        cgst_amount=0,
+        sgst_amount=0,
+        igst_amount=36,
+    )
+
+    sales_credit_note = _add_credit_note_item(
+        db_session,
+        user,
+        ledger,
+        sales_invoice,
+        number="CN-S-001",
+        when=datetime(2026, 1, 12, 9, 0, 0),
+        gst_rate=18,
+        taxable_amount=50,
+        cgst_amount=4.5,
+        sgst_amount=4.5,
+        igst_amount=0,
+    )
+    purchase_credit_note = _add_credit_note_item(
+        db_session,
+        user,
+        ledger,
+        purchase_invoice,
+        number="CN-P-001",
+        when=datetime(2026, 1, 13, 9, 0, 0),
+        gst_rate=18,
+        taxable_amount=100,
+        cgst_amount=0,
+        sgst_amount=0,
+        igst_amount=18,
+    )
+    db_session.commit()
+
+    response = get_tax_ledger(
+        from_date=date(2026, 1, 1),
+        to_date=date(2026, 1, 31),
+        voucher_type=None,
+        gst_rate=None,
+        db=db_session,
+        _=user,
+    )
+
+    assert len(response.entries) == 4
+
+    entry_by_key = {(entry.entry_type, entry.entry_id): entry for entry in response.entries}
+    assert entry_by_key[("invoice", sales_invoice.id)].debit_total_tax == pytest.approx(18.0)
+    assert entry_by_key[("invoice", purchase_invoice.id)].credit_total_tax == pytest.approx(36.0)
+    assert entry_by_key[("credit_note", sales_credit_note.id)].credit_total_tax == pytest.approx(9.0)
+    assert entry_by_key[("credit_note", purchase_credit_note.id)].debit_total_tax == pytest.approx(18.0)
+
+    assert response.totals.debit_cgst == pytest.approx(9.0)
+    assert response.totals.debit_sgst == pytest.approx(9.0)
+    assert response.totals.debit_igst == pytest.approx(18.0)
+    assert response.totals.debit_total_tax == pytest.approx(36.0)
+
+    assert response.totals.credit_cgst == pytest.approx(4.5)
+    assert response.totals.credit_sgst == pytest.approx(4.5)
+    assert response.totals.credit_igst == pytest.approx(36.0)
+    assert response.totals.credit_total_tax == pytest.approx(45.0)
+    assert response.totals.net_total_tax == pytest.approx(-9.0)
+
+
+def test_tax_ledger_supports_voucher_type_and_gst_rate_filters(db_session):
+    user, ledger = _seed_basics(db_session)
+
+    sales_invoice = _add_invoice_with_item(
+        db_session,
+        ledger,
+        user,
+        voucher_type="sales",
+        invoice_number="S-010",
+        when=datetime(2026, 2, 10, 9, 0, 0),
+        gst_rate=18,
+        taxable_amount=100,
+        cgst_amount=9,
+        sgst_amount=9,
+        igst_amount=0,
+    )
+    _add_invoice_with_item(
+        db_session,
+        ledger,
+        user,
+        voucher_type="sales",
+        invoice_number="S-005",
+        when=datetime(2026, 2, 11, 9, 0, 0),
+        gst_rate=5,
+        taxable_amount=100,
+        cgst_amount=2.5,
+        sgst_amount=2.5,
+        igst_amount=0,
+    )
+    purchase_invoice = _add_invoice_with_item(
+        db_session,
+        ledger,
+        user,
+        voucher_type="purchase",
+        invoice_number="P-010",
+        when=datetime(2026, 2, 12, 9, 0, 0),
+        gst_rate=18,
+        taxable_amount=200,
+        cgst_amount=0,
+        sgst_amount=0,
+        igst_amount=36,
+    )
+
+    sales_credit_note = _add_credit_note_item(
+        db_session,
+        user,
+        ledger,
+        sales_invoice,
+        number="CN-S-010",
+        when=datetime(2026, 2, 13, 9, 0, 0),
+        gst_rate=18,
+        taxable_amount=20,
+        cgst_amount=1.8,
+        sgst_amount=1.8,
+        igst_amount=0,
+    )
+    _add_credit_note_item(
+        db_session,
+        user,
+        ledger,
+        purchase_invoice,
+        number="CN-P-010",
+        when=datetime(2026, 2, 14, 9, 0, 0),
+        gst_rate=18,
+        taxable_amount=100,
+        cgst_amount=0,
+        sgst_amount=0,
+        igst_amount=18,
+    )
+    db_session.commit()
+
+    response = get_tax_ledger(
+        from_date=date(2026, 2, 1),
+        to_date=date(2026, 2, 28),
+        voucher_type="sales",
+        gst_rate=18,
+        db=db_session,
+        _=user,
+    )
+
+    assert len(response.entries) == 2
+    assert {entry.entry_type for entry in response.entries} == {"invoice", "credit_note"}
+    assert all(entry.source_voucher_type == "sales" for entry in response.entries)
+    assert all(entry.gst_rate == pytest.approx(18.0) for entry in response.entries)
+
+    entry_by_key = {(entry.entry_type, entry.entry_id): entry for entry in response.entries}
+    assert entry_by_key[("invoice", sales_invoice.id)].debit_total_tax == pytest.approx(18.0)
+    assert entry_by_key[("credit_note", sales_credit_note.id)].credit_total_tax == pytest.approx(3.6)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import LedgersPage from './pages/LedgersPage';
 import LedgerCreatePage from './pages/LedgerCreatePage';
 import LedgerViewPage from './pages/LedgerViewPage';
 import DayBookPage from './pages/DayBookPage';
+import TaxLedgerPage from './pages/TaxLedgerPage';
 import CashBankPage from './pages/CashBankPage';
 import CashBankAccountsPage from './pages/CashBankAccountsPage';
 import CompanyPage from './pages/CompanyPage';
@@ -99,6 +100,7 @@ function AppRoutes() {
       <Route path="/ledgers/:id" element={<Protected><CompanyRequired><Layout><LedgerViewPage /></Layout></CompanyRequired></Protected>} />
       <Route path="/ledgers/:id/edit" element={<Protected><CompanyRequired><Layout><LedgerCreatePage /></Layout></CompanyRequired></Protected>} />
       <Route path="/day-book" element={<Protected><CompanyRequired><Layout><DayBookPage /></Layout></CompanyRequired></Protected>} />
+      <Route path="/tax-ledger" element={<Protected><CompanyRequired><Layout><TaxLedgerPage /></Layout></CompanyRequired></Protected>} />
       <Route path="/cash-bank" element={<Protected><CompanyRequired><Layout><CashBankPage /></Layout></CompanyRequired></Protected>} />
       <Route path="/cash-bank/accounts" element={<Protected><CompanyRequired><Layout><CashBankAccountsPage /></Layout></CompanyRequired></Protected>} />
       <Route path="/invoices" element={<Protected><CompanyRequired><Layout><InvoicesPage /></Layout></CompanyRequired></Protected>} />

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -26,6 +26,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
       registerAction('go_products',  () => navigate('/products')),
       registerAction('go_inventory', () => navigate('/inventory')),
       registerAction('go_day_book',  () => navigate('/day-book')),
+      registerAction('go_tax_ledger',() => navigate('/tax-ledger')),
       registerAction('open_reports', () => navigate('/day-book')),
       registerAction('new_customer', () => navigate('/ledgers/new')),
     ];

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -17,6 +17,7 @@ const mainGroup: NavItem[] = [
   { to: '/invoices', label: 'Invoices' },
   { to: '/credit-notes', label: 'Credit Notes' },
   { to: '/day-book', label: 'Day Book' },
+  { to: '/tax-ledger', label: 'Tax Ledger' },
   { to: '/cash-bank', label: 'Cash & Bank' },
 ];
 

--- a/frontend/src/pages/TaxLedgerPage.tsx
+++ b/frontend/src/pages/TaxLedgerPage.tsx
@@ -1,0 +1,244 @@
+import { useEffect, useMemo, useState } from 'react';
+import api, { getApiErrorMessage } from '../api/client';
+import StatusToasts from '../components/StatusToasts';
+import { useFY } from '../context/FYContext';
+import type { CompanyProfile, TaxLedger } from '../types/api';
+import formatCurrency from '../utils/formatting';
+
+function defaultDateRange() {
+  const today = new Date();
+  const firstDay = new Date(today.getFullYear(), today.getMonth(), 1);
+  const toIso = (date: Date) => date.toISOString().slice(0, 10);
+
+  return {
+    fromDate: toIso(firstDay),
+    toDate: toIso(today),
+  };
+}
+
+export default function TaxLedgerPage() {
+  const { activeFY } = useFY();
+  const [period, setPeriod] = useState(() => ({
+    fromDate: activeFY?.start_date ?? defaultDateRange().fromDate,
+    toDate: activeFY?.end_date ?? defaultDateRange().toDate,
+  }));
+  const [voucherType, setVoucherType] = useState<'all' | 'sales' | 'purchase'>('all');
+  const [gstRate, setGstRate] = useState('');
+  const [taxLedger, setTaxLedger] = useState<TaxLedger | null>(null);
+  const [company, setCompany] = useState<CompanyProfile | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  const activeCurrencyCode = company?.currency_code || 'INR';
+  const numericGstRate = useMemo(() => {
+    if (!gstRate.trim()) return undefined;
+    const parsed = Number(gstRate);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }, [gstRate]);
+
+  async function loadTaxLedger() {
+    try {
+      setLoading(true);
+      setError('');
+
+      const [taxLedgerResponse, companyResponse] = await Promise.all([
+        api.get<TaxLedger>('/ledgers/tax-ledger/', {
+          params: {
+            from_date: period.fromDate,
+            to_date: period.toDate,
+            voucher_type: voucherType === 'all' ? undefined : voucherType,
+            gst_rate: numericGstRate,
+          },
+        }),
+        api.get<CompanyProfile>('/company/'),
+      ]);
+
+      setTaxLedger(taxLedgerResponse.data);
+      setCompany(companyResponse.data);
+    } catch (err) {
+      setTaxLedger(null);
+      setError(getApiErrorMessage(err, 'Unable to load tax ledger'));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void loadTaxLedger();
+  }, [period.fromDate, period.toDate, voucherType, numericGstRate]);
+
+  useEffect(() => {
+    setPeriod({
+      fromDate: activeFY?.start_date ?? defaultDateRange().fromDate,
+      toDate: activeFY?.end_date ?? defaultDateRange().toDate,
+    });
+  }, [activeFY]);
+
+  return (
+    <div className="page-grid">
+      <section className="page-hero">
+        <div>
+          <p className="eyebrow">GST reports</p>
+          <h1 className="page-title">Tax ledger</h1>
+          <p className="section-copy">Track SGST, CGST and IGST debit/credit to monitor net tax due.</p>
+        </div>
+        <div className="status-chip">{taxLedger?.entries.length ?? 0} rows</div>
+      </section>
+
+      <StatusToasts error={error} onClearError={() => setError('')} onClearSuccess={() => {}} />
+
+      <section className="content-grid">
+        <article className="panel stack">
+          <div className="panel__header">
+            <div>
+              <p className="eyebrow">Filters</p>
+              <h2 className="nav-panel__title">Reporting scope</h2>
+            </div>
+          </div>
+
+          <div className="field-grid">
+            <div className="field">
+              <label htmlFor="tax-ledger-from">From</label>
+              <input
+                id="tax-ledger-from"
+                className="input"
+                type="date"
+                value={period.fromDate}
+                onChange={(event) => setPeriod((current) => ({ ...current, fromDate: event.target.value }))}
+              />
+            </div>
+            <div className="field">
+              <label htmlFor="tax-ledger-to">To</label>
+              <input
+                id="tax-ledger-to"
+                className="input"
+                type="date"
+                value={period.toDate}
+                onChange={(event) => setPeriod((current) => ({ ...current, toDate: event.target.value }))}
+              />
+            </div>
+            <div className="field">
+              <label htmlFor="tax-ledger-voucher-type">Voucher type</label>
+              <select
+                id="tax-ledger-voucher-type"
+                className="input"
+                value={voucherType}
+                onChange={(event) => setVoucherType(event.target.value as 'all' | 'sales' | 'purchase')}
+              >
+                <option value="all">All</option>
+                <option value="sales">Sales</option>
+                <option value="purchase">Purchase</option>
+              </select>
+            </div>
+            <div className="field">
+              <label htmlFor="tax-ledger-gst-rate">GST rate</label>
+              <input
+                id="tax-ledger-gst-rate"
+                className="input"
+                type="number"
+                min="0"
+                step="0.01"
+                placeholder="All rates"
+                value={gstRate}
+                onChange={(event) => setGstRate(event.target.value)}
+              />
+            </div>
+          </div>
+
+          <div className="summary-box">
+            <p className="eyebrow">Net tax</p>
+            <p className="summary-box__value">
+              {formatCurrency(taxLedger?.totals.net_total_tax ?? 0, activeCurrencyCode)}
+            </p>
+            <p className="muted-text">
+              Dr {formatCurrency(taxLedger?.totals.debit_total_tax ?? 0, activeCurrencyCode)} · Cr {formatCurrency(taxLedger?.totals.credit_total_tax ?? 0, activeCurrencyCode)}
+            </p>
+          </div>
+        </article>
+
+        <article className="panel stack">
+          <div className="panel__header">
+            <div>
+              <p className="eyebrow">Summary</p>
+              <h2 className="nav-panel__title">GST bucket balances</h2>
+            </div>
+          </div>
+
+          <div className="field-grid">
+            <div className="summary-box">
+              <p className="eyebrow">CGST net</p>
+              <p className="summary-box__value">{formatCurrency(taxLedger?.totals.net_cgst ?? 0, activeCurrencyCode)}</p>
+              <p className="muted-text">Dr {formatCurrency(taxLedger?.totals.debit_cgst ?? 0, activeCurrencyCode)} · Cr {formatCurrency(taxLedger?.totals.credit_cgst ?? 0, activeCurrencyCode)}</p>
+            </div>
+            <div className="summary-box">
+              <p className="eyebrow">SGST net</p>
+              <p className="summary-box__value">{formatCurrency(taxLedger?.totals.net_sgst ?? 0, activeCurrencyCode)}</p>
+              <p className="muted-text">Dr {formatCurrency(taxLedger?.totals.debit_sgst ?? 0, activeCurrencyCode)} · Cr {formatCurrency(taxLedger?.totals.credit_sgst ?? 0, activeCurrencyCode)}</p>
+            </div>
+            <div className="summary-box">
+              <p className="eyebrow">IGST net</p>
+              <p className="summary-box__value">{formatCurrency(taxLedger?.totals.net_igst ?? 0, activeCurrencyCode)}</p>
+              <p className="muted-text">Dr {formatCurrency(taxLedger?.totals.debit_igst ?? 0, activeCurrencyCode)} · Cr {formatCurrency(taxLedger?.totals.credit_igst ?? 0, activeCurrencyCode)}</p>
+            </div>
+          </div>
+        </article>
+      </section>
+
+      <section className="panel stack">
+        <div className="panel__header">
+          <div>
+            <p className="eyebrow">Entries</p>
+            <h2 className="nav-panel__title">Invoice + GST rate ledger rows</h2>
+          </div>
+        </div>
+
+        {loading ? <div className="empty-state">Loading tax ledger...</div> : null}
+        {!loading && (!taxLedger || taxLedger.entries.length === 0) ? <div className="empty-state">No tax entries found for this filter.</div> : null}
+
+        {!loading && taxLedger && taxLedger.entries.length > 0 ? (
+          <div className="table-wrap">
+            <table className="table table--compact">
+              <thead>
+                <tr>
+                  <th>Date</th>
+                  <th>Reference</th>
+                  <th>Ledger</th>
+                  <th>Type</th>
+                  <th>GST %</th>
+                  <th className="text-right">Taxable</th>
+                  <th className="text-right">Dr SGST</th>
+                  <th className="text-right">Dr CGST</th>
+                  <th className="text-right">Dr IGST</th>
+                  <th className="text-right">Cr SGST</th>
+                  <th className="text-right">Cr CGST</th>
+                  <th className="text-right">Cr IGST</th>
+                </tr>
+              </thead>
+              <tbody>
+                {taxLedger.entries.map((entry) => (
+                  <tr key={`${entry.entry_type}-${entry.entry_id}-${entry.gst_rate}`}>
+                    <td>{new Date(entry.date).toLocaleDateString()}</td>
+                    <td>
+                      <strong>{entry.reference_number}</strong>
+                      <div className="table-subtext">{entry.particulars}</div>
+                    </td>
+                    <td>{entry.ledger_name}</td>
+                    <td>{entry.voucher_type}</td>
+                    <td>{entry.gst_rate.toFixed(2)}%</td>
+                    <td className="text-right">{formatCurrency(entry.taxable_amount, activeCurrencyCode)}</td>
+                    <td className="text-right">{entry.debit_sgst > 0 ? formatCurrency(entry.debit_sgst, activeCurrencyCode) : '-'}</td>
+                    <td className="text-right">{entry.debit_cgst > 0 ? formatCurrency(entry.debit_cgst, activeCurrencyCode) : '-'}</td>
+                    <td className="text-right">{entry.debit_igst > 0 ? formatCurrency(entry.debit_igst, activeCurrencyCode) : '-'}</td>
+                    <td className="text-right">{entry.credit_sgst > 0 ? formatCurrency(entry.credit_sgst, activeCurrencyCode) : '-'}</td>
+                    <td className="text-right">{entry.credit_cgst > 0 ? formatCurrency(entry.credit_cgst, activeCurrencyCode) : '-'}</td>
+                    <td className="text-right">{entry.credit_igst > 0 ? formatCurrency(entry.credit_igst, activeCurrencyCode) : '-'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : null}
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/pages/TaxLedgerPage.tsx
+++ b/frontend/src/pages/TaxLedgerPage.tsx
@@ -197,7 +197,7 @@ export default function TaxLedgerPage() {
 
         {!loading && taxLedger && taxLedger.entries.length > 0 ? (
           <div className="table-wrap">
-            <table className="table table--compact">
+            <table className="invoice-feed-table tax-ledger-table">
               <thead>
                 <tr>
                   <th>Date</th>
@@ -215,25 +215,35 @@ export default function TaxLedgerPage() {
                 </tr>
               </thead>
               <tbody>
-                {taxLedger.entries.map((entry) => (
-                  <tr key={`${entry.entry_type}-${entry.entry_id}-${entry.gst_rate}`}>
-                    <td>{new Date(entry.date).toLocaleDateString()}</td>
-                    <td>
-                      <strong>{entry.reference_number}</strong>
-                      <div className="table-subtext">{entry.particulars}</div>
-                    </td>
-                    <td>{entry.ledger_name}</td>
-                    <td>{entry.voucher_type}</td>
-                    <td>{entry.gst_rate.toFixed(2)}%</td>
-                    <td className="text-right">{formatCurrency(entry.taxable_amount, activeCurrencyCode)}</td>
-                    <td className="text-right">{entry.debit_sgst > 0 ? formatCurrency(entry.debit_sgst, activeCurrencyCode) : '-'}</td>
-                    <td className="text-right">{entry.debit_cgst > 0 ? formatCurrency(entry.debit_cgst, activeCurrencyCode) : '-'}</td>
-                    <td className="text-right">{entry.debit_igst > 0 ? formatCurrency(entry.debit_igst, activeCurrencyCode) : '-'}</td>
-                    <td className="text-right">{entry.credit_sgst > 0 ? formatCurrency(entry.credit_sgst, activeCurrencyCode) : '-'}</td>
-                    <td className="text-right">{entry.credit_cgst > 0 ? formatCurrency(entry.credit_cgst, activeCurrencyCode) : '-'}</td>
-                    <td className="text-right">{entry.credit_igst > 0 ? formatCurrency(entry.credit_igst, activeCurrencyCode) : '-'}</td>
-                  </tr>
-                ))}
+                {taxLedger.entries.map((entry) => {
+                  const rowClass = entry.source_voucher_type === 'sales' ? 'tax-ledger-row--sales' : 'tax-ledger-row--purchase';
+                  const typeBadgeClass = entry.source_voucher_type === 'sales' ? 'invoice-type-badge invoice-type-badge--sales' : 'invoice-type-badge invoice-type-badge--purchase';
+
+                  return (
+                    <tr key={`${entry.entry_type}-${entry.entry_id}-${entry.gst_rate}`} className={rowClass}>
+                      <td>{new Date(entry.date).toLocaleDateString()}</td>
+                      <td>
+                        <strong>{entry.reference_number}</strong>
+                        <div className="table-subtext">{entry.particulars}</div>
+                      </td>
+                      <td>{entry.ledger_name}</td>
+                      <td>
+                        <div className="tax-ledger-type-cell">
+                          <span className={typeBadgeClass}>{entry.source_voucher_type}</span>
+                          {entry.entry_type === 'credit_note' ? <span className="tax-ledger-note-tag">Credit Note</span> : null}
+                        </div>
+                      </td>
+                      <td>{entry.gst_rate.toFixed(2)}%</td>
+                      <td className="text-right">{formatCurrency(entry.taxable_amount, activeCurrencyCode)}</td>
+                      <td className="text-right">{entry.debit_sgst > 0 ? formatCurrency(entry.debit_sgst, activeCurrencyCode) : '-'}</td>
+                      <td className="text-right">{entry.debit_cgst > 0 ? formatCurrency(entry.debit_cgst, activeCurrencyCode) : '-'}</td>
+                      <td className="text-right">{entry.debit_igst > 0 ? formatCurrency(entry.debit_igst, activeCurrencyCode) : '-'}</td>
+                      <td className="text-right">{entry.credit_sgst > 0 ? formatCurrency(entry.credit_sgst, activeCurrencyCode) : '-'}</td>
+                      <td className="text-right">{entry.credit_cgst > 0 ? formatCurrency(entry.credit_cgst, activeCurrencyCode) : '-'}</td>
+                      <td className="text-right">{entry.credit_igst > 0 ? formatCurrency(entry.credit_igst, activeCurrencyCode) : '-'}</td>
+                    </tr>
+                  );
+                })}
               </tbody>
             </table>
           </div>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1611,6 +1611,48 @@ textarea {
   border: 1px solid rgba(255, 139, 139, 0.25);
 }
 
+.tax-ledger-table {
+  min-width: 980px;
+}
+
+.tax-ledger-table tbody tr {
+  cursor: default;
+}
+
+.tax-ledger-table tbody tr:hover {
+  background: rgba(87, 209, 201, 0.04);
+}
+
+.tax-ledger-table tbody tr.tax-ledger-row--sales {
+  box-shadow: inset 3px 0 0 rgba(34, 197, 94, 0.55);
+  background: linear-gradient(90deg, rgba(34, 197, 94, 0.08) 0%, rgba(34, 197, 94, 0.01) 22%, transparent 60%);
+}
+
+.tax-ledger-table tbody tr.tax-ledger-row--purchase {
+  box-shadow: inset 3px 0 0 rgba(251, 146, 60, 0.55);
+  background: linear-gradient(90deg, rgba(251, 146, 60, 0.08) 0%, rgba(251, 146, 60, 0.01) 22%, transparent 60%);
+}
+
+.tax-ledger-type-cell {
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.tax-ledger-note-tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 8px;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #c8d8ff;
+  border: 1px solid rgba(168, 185, 220, 0.28);
+  background: rgba(148, 184, 255, 0.12);
+}
+
 .invoice-compact-card {
   border-radius: 20px;
   border: 1px solid rgba(148, 184, 255, 0.12);

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -370,6 +370,53 @@ export type DayBook = {
   financial_year_id: number | null;
 };
 
+export type TaxLedgerEntry = {
+  entry_id: number;
+  entry_type: 'invoice' | 'credit_note';
+  date: string;
+  voucher_type: string;
+  source_voucher_type: 'sales' | 'purchase';
+  reference_number: string;
+  ledger_name: string;
+  particulars: string;
+  gst_rate: number;
+  taxable_amount: number;
+  debit_cgst: number;
+  debit_sgst: number;
+  debit_igst: number;
+  debit_total_tax: number;
+  credit_cgst: number;
+  credit_sgst: number;
+  credit_igst: number;
+  credit_total_tax: number;
+};
+
+export type TaxLedgerTotals = {
+  debit_cgst: number;
+  debit_sgst: number;
+  debit_igst: number;
+  debit_total_tax: number;
+  credit_cgst: number;
+  credit_sgst: number;
+  credit_igst: number;
+  credit_total_tax: number;
+  net_cgst: number;
+  net_sgst: number;
+  net_igst: number;
+  net_total_tax: number;
+};
+
+export type TaxLedger = {
+  from_date: string;
+  to_date: string;
+  voucher_type: 'sales' | 'purchase' | null;
+  gst_rate: number | null;
+  entries: TaxLedgerEntry[];
+  totals: TaxLedgerTotals;
+  fy_label: string | null;
+  financial_year_id: number | null;
+};
+
 export type PaymentVoucherType = 'receipt' | 'payment' | 'opening_balance';
 
 export type Payment = {

--- a/frontend/src/utils/shortcutDefaults.ts
+++ b/frontend/src/utils/shortcutDefaults.ts
@@ -1,7 +1,7 @@
 export const ACTION_KEYS = [
   'create_invoice', 'save_invoice', 'open_search', 'open_reports',
   'new_customer', 'go_invoices', 'go_ledgers', 'go_products',
-  'go_inventory', 'go_day_book',
+  'go_inventory', 'go_day_book', 'go_tax_ledger',
 ] as const;
 
 export type ActionKey = typeof ACTION_KEYS[number];
@@ -17,6 +17,7 @@ export const DEFAULT_SHORTCUTS: Record<ActionKey, string> = {
   go_products:    'Alt+P',
   go_inventory:   'Alt+V',
   go_day_book:    'Alt+D',
+  go_tax_ledger:  'Alt+T',
 };
 
 export const ACTION_LABELS: Record<ActionKey, string> = {
@@ -30,4 +31,5 @@ export const ACTION_LABELS: Record<ActionKey, string> = {
   go_products:    'Go to Products',
   go_inventory:   'Go to Inventory',
   go_day_book:    'Go to Day Book',
+  go_tax_ledger:  'Go to Tax Ledger',
 };


### PR DESCRIPTION
## Summary

Adds a dedicated GST Tax Ledger that behaves like an account statement for SGST/CGST/IGST. It introduces a backend tax-ledger API with date/rate/type filters, includes credit-note reversals in tax math, and adds a frontend Tax Ledger page with debit/credit/net totals and clear sales vs purchase row distinction.

## Type of change

- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs (documentation)
- [x] test (tests)
- [ ] chore/refactor

## How to test

1. Set `DATABASE_URL=postgresql://simple_user:simple_password@localhost:5432/simple_invoicing`.
2. Run backend test: `cd backend && DATABASE_URL='postgresql://simple_user:simple_password@localhost:5432/simple_invoicing' .venv/bin/python -m pytest tests/api/test_tax_ledger.py -q`.
3. Run frontend build: `cd frontend && npm run build`.
4. Start app, open Tax Ledger from sidebar.
5. Verify sales vs purchase are visually distinguishable in entries table.
6. Verify debit/credit/net totals update with date, voucher type, and GST rate filters.

## Checklist

- [x] My code follows the project style and conventions
- [x] I added/updated tests where appropriate
- [ ] I updated docs where needed
- [x] I ran relevant checks locally
- [x] I verified this does not break existing behavior

## Screenshots (if UI changes)

Not attached in this PR.

## Related issue

Closes #