### PR TITLE
feat(invoices): add multi-copy PDF with Original/Duplicate/Triplicate labels

### DIFF
--- a/backend/src/api/routes/invoices.py
+++ b/backend/src/api/routes/invoices.py
@@ -903,7 +903,15 @@ def _build_purchase_invoice_html(invoice: Invoice, products: list[Product]) -> s
     return html
 
 
-def _build_invoice_html(invoice: Invoice, products: list[Product], invoice_bank_accounts: list[CompanyAccount] | None = None) -> str:
+def _copy_label(n: int) -> str:
+    _labels = {1: "Original", 2: "Duplicate", 3: "Triplicate"}
+    if n in _labels:
+        return _labels[n]
+    suffix = ("th" if (n % 100) in (11, 12, 13) else {1: "st", 2: "nd", 3: "rd"}.get(n % 10, "th"))
+    return f"{n}{suffix} Copy"
+
+
+def _build_invoice_html(invoice: Invoice, products: list[Product], invoice_bank_accounts: list[CompanyAccount] | None = None, copy_label: str = "Original") -> str:
     if invoice_bank_accounts is None:
         invoice_bank_accounts = []
     
@@ -1169,6 +1177,15 @@ def _build_invoice_html(invoice: Invoice, products: list[Product], invoice_bank_
     border-bottom: 2px solid #e5e7eb;
     margin-bottom: 16px;
   }}
+  .copy-label {{
+    text-align: right;
+    font-size: 8px;
+    font-weight: 600;
+    color: #6b7280;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    margin-bottom: 4px;
+  }}
   .invoice-amount-words {{
     font-size: 8px;
     font-style: italic;
@@ -1179,6 +1196,7 @@ def _build_invoice_html(invoice: Invoice, products: list[Product], invoice_bank_
 </head>
 <body>
 <div class="invoice-sheet">
+  <div class="copy-label">{copy_label}</div>
   <div class="invoice-title">{invoice_title}</div>
   <header class="invoice-sheet__header">
     <div>
@@ -1247,8 +1265,39 @@ def _build_invoice_html(invoice: Invoice, products: list[Product], invoice_bank_
     return html
 
 
+def _build_multi_copy_invoice_html(invoice: Invoice, products: list[Product], invoice_bank_accounts: list[CompanyAccount], copies: int) -> str:
+    if invoice.voucher_type == "purchase":
+        return _build_purchase_invoice_html(invoice, products)
+    if copies == 1:
+        return _build_invoice_html(invoice, products, invoice_bank_accounts, copy_label=_copy_label(1))
+
+    pages = []
+    first_html: str | None = None
+    for i in range(1, copies + 1):
+        full_html = _build_invoice_html(invoice, products, invoice_bank_accounts, copy_label=_copy_label(i))
+        if i == 1:
+            first_html = full_html
+        body_open_end = full_html.index('<body>') + len('<body>')
+        body_close_start = full_html.rindex('</body>')
+        body_content = full_html[body_open_end:body_close_start].strip()
+        page_style = '' if i == copies else ' style="break-after: page; page-break-after: always;"'
+        pages.append(f'<div{page_style}>\n{body_content}\n</div>')
+
+    assert first_html is not None
+    body_open_end = first_html.index('<body>') + len('<body>')
+    combined = '\n'.join(pages)
+    return first_html[:body_open_end] + '\n' + combined + '\n</body>\n</html>'
+
+
 def _build_invoice_pdf(invoice: Invoice, products: list[Product], invoice_bank_accounts: list[CompanyAccount]) -> BytesIO:
-    html = _build_invoice_html(invoice, products, invoice_bank_accounts)
+    html = _build_invoice_html(invoice, products, invoice_bank_accounts, copy_label=_copy_label(1))
+    pdf_bytes = weasyprint.HTML(string=html).write_pdf()
+    buf = BytesIO(pdf_bytes)
+    return buf
+
+
+def _build_multi_copy_invoice_pdf(invoice: Invoice, products: list[Product], invoice_bank_accounts: list[CompanyAccount], copies: int) -> BytesIO:
+    html = _build_multi_copy_invoice_html(invoice, products, invoice_bank_accounts, copies)
     pdf_bytes = weasyprint.HTML(string=html).write_pdf()
     buf = BytesIO(pdf_bytes)
     return buf
@@ -1257,6 +1306,7 @@ def _build_invoice_pdf(invoice: Invoice, products: list[Product], invoice_bank_a
 @router.get("/{invoice_id}/pdf")
 def download_invoice_pdf(
     invoice_id: int,
+    copies: int = Query(default=1, ge=1, le=10),
     db: Session = Depends(get_db),
     _: User = Depends(get_current_user),
 ):
@@ -1283,7 +1333,7 @@ def download_invoice_pdf(
       .all()
     )
 
-    pdf_buffer = _build_invoice_pdf(invoice, products, invoice_bank_accounts)
+    pdf_buffer = _build_multi_copy_invoice_pdf(invoice, products, invoice_bank_accounts, copies)
     filename = f"invoice_{invoice.invoice_number or invoice.id}.pdf"
 
     return StreamingResponse(

--- a/frontend/src/components/InvoicePreview.tsx
+++ b/frontend/src/components/InvoicePreview.tsx
@@ -12,6 +12,7 @@ type InvoicePreviewProps = {
 
 export default function InvoicePreview({ invoice, onClose, onError }: InvoicePreviewProps) {
   const [showEmailModal, setShowEmailModal] = useState(false);
+  const [copies, setCopies] = useState(1);
   const [pdfUrl, setPdfUrl] = useState<string | null>(null);
   const [loadingPdf, setLoadingPdf] = useState(true);
   const [pdfError, setPdfError] = useState('');
@@ -29,7 +30,7 @@ export default function InvoicePreview({ invoice, onClose, onError }: InvoicePre
       setPdfUrl(null);
 
       try {
-        const response = await api.get(`/invoices/${invoice.id}/pdf`, {
+        const response = await api.get(`/invoices/${invoice.id}/pdf?copies=${copies}`, {
           responseType: 'blob',
         });
         const nextUrl = window.URL.createObjectURL(response.data as Blob);
@@ -60,11 +61,11 @@ export default function InvoicePreview({ invoice, onClose, onError }: InvoicePre
         window.URL.revokeObjectURL(objectUrlToRevoke);
       }
     };
-  }, [invoice.id]);
+  }, [invoice.id, copies]);
 
   const handleDownloadPdf = async () => {
     try {
-      const response = await api.get(`/invoices/${invoice.id}/pdf`, {
+      const response = await api.get(`/invoices/${invoice.id}/pdf?copies=${copies}`, {
         responseType: 'blob',
       });
       const url = window.URL.createObjectURL(response.data as Blob);
@@ -91,7 +92,19 @@ export default function InvoicePreview({ invoice, onClose, onError }: InvoicePre
             <p className="eyebrow">Invoice preview</p>
             <h2 id="invoice-preview-title" className="nav-panel__title">PDF invoice {invoice.invoice_number || `#${invoice.id}`}</h2>
           </div>
-          <div className="button-row">
+          <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+            <label style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '12px', color: '#6b7280', whiteSpace: 'nowrap' }}>
+              Copies
+              <input
+                type="number"
+                min={1}
+                max={10}
+                value={copies}
+                onChange={(e) => setCopies(Math.min(10, Math.max(1, parseInt(e.target.value) || 1)))}
+                style={{ width: '52px', padding: '4px 6px', border: '1px solid #d1d5db', borderRadius: '6px', fontSize: '12px', textAlign: 'center' }}
+              />
+            </label>
+            <div className="button-row">
             <button type="button" className="button button--secondary" onClick={handlePrintPdf} disabled={!pdfUrl || loadingPdf} title="Print invoice" aria-label="Print invoice">
               Print
             </button>
@@ -116,6 +129,7 @@ export default function InvoicePreview({ invoice, onClose, onError }: InvoicePre
             <button type="button" className="button button--ghost" onClick={onClose} title="Close invoice preview" aria-label="Close invoice preview">
               Close
             </button>
+            </div>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
Add ability to generate multiple copies of an invoice PDF with automatic copy labeling.

## Changes
- **Backend**: New `_copy_label(n)` generates Original, Duplicate, Triplicate, Nth Copy labels. Modified `_build_invoice_html` to accept and render copy labels. Added `_build_multi_copy_invoice_html` to assemble N copies with page breaks. Updated PDF route with `copies` query param (1-10).
- **Frontend**: Added `copies` state to InvoicePreview; PDF re-fetches when copies change. Added compact number input to modal header.

## How to test
1. Open invoice preview modal
2. Change the "Copies" input from 1 to 2-10
3. PDF preview regenerates with multiple pages
4. Each page shows appropriate label: Original (page 1), Duplicate (page 2), etc.
5. Download PDF also uses the selected copies count

## Type
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change