### PR TITLE
chore(ci): add k8s CD workflows

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -1,0 +1,65 @@
+name: Backend CD
+
+on:
+  workflow_run:
+    workflows: ["Backend CI"]
+    types:
+      - completed
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: backend-cd-main
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    env:
+      REGISTRY: registry.kube.nikhilbhatia.com
+      IMAGE: registry.kube.nikhilbhatia.com/invoicing-api:latest
+      NAMESPACE: nikhil
+      DEPLOYMENT: invoicing-api
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Build and push backend image
+        uses: docker/build-push-action@v6
+        with:
+          context: backend
+          file: backend/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.IMAGE }}
+
+      - name: Configure kubeconfig
+        run: |
+          mkdir -p ~/.kube
+          printf '%s' "${{ secrets.KUBECONFIG }}" > ~/.kube/config
+          chmod 600 ~/.kube/config
+
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v3
+
+      - name: Restart and verify rollout
+        run: |
+          kubectl rollout restart deployment/${DEPLOYMENT} -n ${NAMESPACE}
+          kubectl rollout status deployment/${DEPLOYMENT} -n ${NAMESPACE} --timeout=120s

--- a/.github/workflows/frontend-cd.yml
+++ b/.github/workflows/frontend-cd.yml
@@ -1,0 +1,65 @@
+name: Frontend CD
+
+on:
+  workflow_run:
+    workflows: ["Frontend CI"]
+    types:
+      - completed
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: frontend-cd-main
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    env:
+      REGISTRY: registry.kube.nikhilbhatia.com
+      IMAGE: registry.kube.nikhilbhatia.com/invoicing:latest
+      NAMESPACE: nikhil
+      DEPLOYMENT: invoicing
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Build and push frontend image
+        uses: docker/build-push-action@v6
+        with:
+          context: frontend
+          file: frontend/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.IMAGE }}
+
+      - name: Configure kubeconfig
+        run: |
+          mkdir -p ~/.kube
+          printf '%s' "${{ secrets.KUBECONFIG }}" > ~/.kube/config
+          chmod 600 ~/.kube/config
+
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v3
+
+      - name: Restart and verify rollout
+        run: |
+          kubectl rollout restart deployment/${DEPLOYMENT} -n ${NAMESPACE}
+          kubectl rollout status deployment/${DEPLOYMENT} -n ${NAMESPACE} --timeout=120s


### PR DESCRIPTION
## Summary

Add GitHub Actions CD pipelines for backend and frontend that deploy to Kubernetes after CI succeeds on main.

## Type of change

- [ ] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs (documentation)
- [ ] test (tests)
- [x] chore/refactor

## How to test

1. Add repository secrets: `KUBECONFIG`, `REGISTRY_USERNAME`, `REGISTRY_PASSWORD`.
2. Push a change that touches backend and confirm `Backend CI` passes.
3. Confirm `Backend CD` runs after CI and pushes `registry.kube.nikhilbhatia.com/invoicing-api:latest`.
4. Verify deployment rollout with `kubectl rollout status deployment/invoicing-api -n nikhil`.
5. Push a change that touches frontend and confirm `Frontend CI` passes.
6. Confirm `Frontend CD` runs after CI and pushes `registry.kube.nikhilbhatia.com/invoicing:latest`.
7. Verify deployment rollout with `kubectl rollout status deployment/invoicing -n nikhil`.

## Checklist

- [x] My code follows the project style and conventions
- [ ] I added/updated tests where appropriate
- [x] I updated docs where needed
- [x] I ran relevant checks locally
- [x] I verified this does not break existing behavior

## Screenshots (if UI changes)

N/A

## Related issue

Closes #