### PR TITLE
feat(cash-bank): add account debit-credit entries

### DIFF
--- a/CASH_BANK.md
+++ b/CASH_BANK.md
@@ -1,0 +1,72 @@
+# Cash & Bank Entries
+
+This document describes the account-level debit/credit workflow in `/cash-bank`.
+
+## What is supported
+
+- Add debit/credit entries directly under a cash or bank account.
+- Edit existing entries from the register.
+- Delete entries (soft-cancel via payment status).
+- Add a description for every entry using the existing `notes` field.
+
+## Entry behavior
+
+- Debit entry maps to `voucher_type = payment`.
+- Credit entry maps to `voucher_type = receipt`.
+- Description is stored in `notes`.
+- Mode is set from selected account type (`cash` or `bank`).
+- Account-only entries are allowed with:
+  - `account_id` set
+  - `ledger_id` omitted or `null`
+
+## User flow in `/cash-bank`
+
+1. Select an account in the Account filter.
+2. Click `Add Entry` in the register header.
+3. Choose entry type (`Debit` or `Credit`).
+4. Enter amount, date, and description.
+5. Save entry.
+6. Use `Edit` or `Delete` actions on any row when needed.
+
+## Validation rules
+
+- Amount must be greater than 0.
+- For payment creation, at least one of these must exist:
+  - `ledger_id`, or
+  - `account_id`
+- `opening_balance` still requires a `ledger_id`.
+
+## Data model notes
+
+- `payments.buyer_id` is now nullable to support account-only entries.
+- Existing ledger-linked payment flows remain unchanged.
+
+## API examples
+
+### Create account-only debit entry
+
+```json
+{
+  "ledger_id": null,
+  "voucher_type": "payment",
+  "amount": 1200,
+  "account_id": 3,
+  "date": "2026-04-19T10:00:00",
+  "mode": "cash",
+  "notes": "ATM withdrawal"
+}
+```
+
+### Create account-only credit entry
+
+```json
+{
+  "ledger_id": null,
+  "voucher_type": "receipt",
+  "amount": 800,
+  "account_id": 3,
+  "date": "2026-04-20T09:30:00",
+  "mode": "cash",
+  "notes": "Counter deposit"
+}
+```

--- a/backend/migrations/20260419000001_make_payment_ledger_optional.py
+++ b/backend/migrations/20260419000001_make_payment_ledger_optional.py
@@ -1,0 +1,19 @@
+"""
+Allow payments without ledger linkage for account-only cash/bank entries.
+"""
+
+from sqlalchemy import text
+
+
+def up(conn) -> None:
+    conn.execute(text("""
+        ALTER TABLE payments
+        ALTER COLUMN buyer_id DROP NOT NULL
+    """))
+
+
+def down(conn) -> None:
+    conn.execute(text("""
+        ALTER TABLE payments
+        ALTER COLUMN buyer_id SET NOT NULL
+    """))

--- a/backend/src/api/routes/payments.py
+++ b/backend/src/api/routes/payments.py
@@ -57,12 +57,15 @@ def _find_existing_opening_balance(
 
 def _ensure_single_opening_balance(
     db: Session,
-    ledger_id: int,
+    ledger_id: int | None,
     voucher_type: str,
     exclude_payment_id: int | None = None,
 ) -> None:
     if voucher_type != "opening_balance":
         return
+
+    if ledger_id is None:
+        raise HTTPException(status_code=400, detail="opening_balance requires ledger_id")
 
     existing = _find_existing_opening_balance(
         db,
@@ -80,11 +83,14 @@ def create_payment(
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles(UserRole.admin, UserRole.manager)),
 ):
-    ledger = db.query(Ledger).filter(Ledger.id == payload.ledger_id).first()
-    if not ledger:
-        raise HTTPException(status_code=404, detail="Ledger not found")
-
     _ensure_single_opening_balance(db, payload.ledger_id, payload.voucher_type)
+
+    if payload.ledger_id is not None:
+        ledger = db.query(Ledger).filter(Ledger.id == payload.ledger_id).first()
+        if not ledger:
+            raise HTTPException(status_code=404, detail="Ledger not found")
+    elif payload.account_id is None:
+        raise HTTPException(status_code=400, detail="Either ledger_id or account_id is required")
 
     selected_account = None
     if payload.account_id is not None:
@@ -178,9 +184,10 @@ def update_payment(
     if not payment:
         raise HTTPException(status_code=404, detail="Payment not found")
 
+    next_ledger_id = payment.ledger_id
     _ensure_single_opening_balance(
         db,
-        payment.ledger_id,
+      next_ledger_id,
         payload.voucher_type,
         exclude_payment_id=payment.id,
     )

--- a/backend/src/models/payment.py
+++ b/backend/src/models/payment.py
@@ -9,7 +9,7 @@ class Payment(Base):
     __tablename__ = "payments"
 
     id = Column(Integer, primary_key=True, index=True)
-    ledger_id = Column("buyer_id", Integer, ForeignKey("buyers.id"), nullable=False)
+    ledger_id = Column("buyer_id", Integer, ForeignKey("buyers.id"), nullable=True)
     voucher_type = Column(String, nullable=False)  # "receipt" or "payment"
     amount = Column(Numeric(10, 2), nullable=False)
     date = Column(DateTime, nullable=False, default=datetime.utcnow)

--- a/backend/src/schemas/payment.py
+++ b/backend/src/schemas/payment.py
@@ -36,7 +36,7 @@ class PaymentUpdate(BaseModel):
 
 
 class PaymentCreate(BaseModel):
-    ledger_id: int
+    ledger_id: int | None = None
     voucher_type: str  # "receipt", "payment" or "opening_balance"
     amount: float
     account_id: int | None = None
@@ -67,7 +67,7 @@ class PaymentCreate(BaseModel):
 
 class PaymentOut(BaseModel):
     id: int
-    ledger_id: int
+    ledger_id: int | None = None
     voucher_type: str
     amount: float
     account_id: int | None = None

--- a/backend/tests/api/test_company_accounts.py
+++ b/backend/tests/api/test_company_accounts.py
@@ -105,3 +105,64 @@ def test_payment_supports_company_account_assignment_and_unassignment(client):
     entries = [entry for entry in day_book_response.json()["entries"] if entry["entry_type"] == "payment"]
     assert len(entries) == 1
     assert entries[0]["account_display_name"] is None
+
+
+def test_account_only_cash_bank_entry_lifecycle(client):
+    account_response = client.post(
+        "/api/company-accounts/",
+        json={
+            "account_type": "cash",
+            "display_name": "Cash Counter",
+            "opening_balance": 0,
+        },
+    )
+    assert account_response.status_code == 200, account_response.text
+    account_id = account_response.json()["id"]
+
+    create_response = client.post(
+        "/api/payments/",
+        json={
+            "voucher_type": "payment",
+            "amount": 1200,
+            "account_id": account_id,
+            "mode": "cash",
+            "notes": "ATM withdrawal",
+            "date": "2026-04-19T10:00:00",
+        },
+    )
+    assert create_response.status_code == 200, create_response.text
+    created = create_response.json()
+    assert created["ledger_id"] is None
+    assert created["account_id"] == account_id
+    assert created["notes"] == "ATM withdrawal"
+
+    update_response = client.put(
+        f"/api/payments/{created['id']}",
+        json={
+            "voucher_type": "receipt",
+            "amount": 800,
+            "account_id": account_id,
+            "mode": "cash",
+            "notes": "Cash deposit",
+            "date": "2026-04-20T09:30:00",
+        },
+    )
+    assert update_response.status_code == 200, update_response.text
+    updated = update_response.json()
+    assert updated["voucher_type"] == "receipt"
+    assert updated["amount"] == 800
+    assert updated["notes"] == "Cash deposit"
+
+    delete_response = client.delete(f"/api/payments/{created['id']}")
+    assert delete_response.status_code == 200, delete_response.text
+
+    list_active_response = client.get("/api/payments/")
+    assert list_active_response.status_code == 200, list_active_response.text
+    active_ids = [item["id"] for item in list_active_response.json()]
+    assert created["id"] not in active_ids
+
+    list_all_response = client.get("/api/payments/", params={"include_cancelled": True})
+    assert list_all_response.status_code == 200, list_all_response.text
+    cancelled = [item for item in list_all_response.json() if item["id"] == created["id"]]
+    assert len(cancelled) == 1
+    assert cancelled[0]["status"] == "cancelled"

--- a/backend/tests/api/test_payments.py
+++ b/backend/tests/api/test_payments.py
@@ -175,3 +175,42 @@ def test_create_opening_balance_skips_payment_series_number_generation():
     payment = db.add.call_args.args[0]
     assert payment.payment_number is None
     assert result.warnings == []
+
+
+def test_create_payment_allows_account_only_entry_without_ledger():
+    payload = PaymentCreate(
+        ledger_id=None,
+        voucher_type="payment",
+        amount=300,
+        account_id=21,
+        date=datetime(2032, 6, 1, 9, 0),
+        mode="cash",
+        notes="Cash withdrawal",
+    )
+    db = MagicMock()
+    db.query().filter().first.return_value = SimpleNamespace(id=21)
+    active_fy = SimpleNamespace(id=20, start_date=date(2032, 4, 1), end_date=date(2033, 3, 31))
+    current_user = SimpleNamespace(id=9)
+
+    with patch("src.api.routes.payments.get_active_fy", return_value=active_fy), patch(
+        "src.api.routes.payments.get_fy_for_date", return_value=active_fy
+    ), patch(
+        "src.api.routes.payments.generate_next_number", return_value="PAY-2032-025"
+    ) as generate_mock, patch(
+        "src.api.routes.payments.PaymentOut.model_validate",
+        return_value=SimpleNamespace(warnings=[]),
+    ):
+        result = create_payment(payload, db=db, current_user=current_user)
+
+    generate_mock.assert_called_once_with(
+        db,
+        "payment",
+        20,
+        date(2032, 6, 1),
+        20,
+    )
+    payment = db.add.call_args.args[0]
+    assert payment.ledger_id is None
+    assert payment.account_id == 21
+    assert payment.notes == "Cash withdrawal"
+    assert result.warnings == []

--- a/frontend/src/pages/CashBankPage.tsx
+++ b/frontend/src/pages/CashBankPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import api, { getApiErrorMessage } from '../api/client';
 import StatusToasts from '../components/StatusToasts';
-import type { CompanyAccount, CompanyProfile, Ledger, Payment } from '../types/api';
+import type { CompanyAccount, CompanyProfile, Ledger, Payment, PaymentCreate, PaymentUpdate } from '../types/api';
 import formatCurrency from '../utils/formatting';
 import { useFY } from '../context/FYContext';
 
@@ -31,6 +31,23 @@ export default function CashBankPage() {
   const [selectedAccountId, setSelectedAccountId] = useState<string>('');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+  const [showEntryModal, setShowEntryModal] = useState(false);
+  const [entrySubmitting, setEntrySubmitting] = useState(false);
+  const [editingEntry, setEditingEntry] = useState<null | {
+    id: number;
+    voucher_type: 'receipt' | 'payment';
+    amount: number;
+    date: string;
+    notes: string;
+  }>(null);
+
+  const [entryForm, setEntryForm] = useState({
+    entryType: 'debit' as 'debit' | 'credit',
+    amount: 0,
+    date: new Date().toISOString().slice(0, 10),
+    description: '',
+  });
 
   const activeCurrencyCode = company?.currency_code || 'USD';
 
@@ -102,14 +119,123 @@ export default function CashBankPage() {
       })
       .map((payment) => ({
         id: payment.id,
+        voucherType: payment.voucher_type,
         date: payment.date,
         voucherLabel: payment.voucher_type === 'receipt' ? 'Receipt' : 'Payment',
-        ledgerName: ledgerNameById.get(payment.ledger_id) || 'Unknown ledger',
+        ledgerName: payment.ledger_id != null ? (ledgerNameById.get(payment.ledger_id) || 'Unknown ledger') : 'Account entry',
         particulars: `${payment.voucher_type === 'receipt' ? 'Receipt' : 'Payment'}${payment.mode ? ` (${payment.mode})` : ''}`,
+        description: payment.notes || '',
         debit: payment.voucher_type === 'payment' ? payment.amount : 0,
         credit: payment.voucher_type === 'receipt' ? payment.amount : 0,
       }));
   }, [payments, selectedAccountId, ledgerNameById, period.fromDate, period.toDate]);
+
+  function resetEntryForm() {
+    setEntryForm({
+      entryType: 'debit',
+      amount: 0,
+      date: new Date().toISOString().slice(0, 10),
+      description: '',
+    });
+  }
+
+  function openCreateEntryModal() {
+    resetEntryForm();
+    setEditingEntry(null);
+    setShowEntryModal(true);
+  }
+
+  function openEditEntryModal(entryId: number) {
+    const payment = payments.find((item) => item.id === entryId);
+    if (!payment) {
+      setError('Entry not found');
+      return;
+    }
+
+    setEditingEntry({
+      id: payment.id,
+      voucher_type: payment.voucher_type === 'payment' ? 'payment' : 'receipt',
+      amount: Number(payment.amount),
+      date: payment.date,
+      notes: payment.notes || '',
+    });
+
+    setEntryForm({
+      entryType: payment.voucher_type === 'payment' ? 'debit' : 'credit',
+      amount: Number(payment.amount),
+      date: payment.date.slice(0, 10),
+      description: payment.notes || '',
+    });
+    setShowEntryModal(true);
+  }
+
+  async function handleSubmitEntry(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!selectedAccount) {
+      setError('Select an account to add entry');
+      return;
+    }
+    if (entryForm.amount <= 0) {
+      setError('Amount must be greater than 0');
+      return;
+    }
+
+    const voucherType = entryForm.entryType === 'debit' ? 'payment' : 'receipt';
+    const isoDate = `${entryForm.date}T00:00:00`;
+
+    try {
+      setEntrySubmitting(true);
+      setError('');
+
+      if (editingEntry) {
+        const payload: PaymentUpdate = {
+          voucher_type: voucherType,
+          amount: entryForm.amount,
+          account_id: selectedAccount.id,
+          date: isoDate,
+          mode: selectedAccount.account_type,
+          notes: entryForm.description.trim() || undefined,
+        };
+        await api.put<Payment>(`/payments/${editingEntry.id}`, payload);
+        setSuccess('Entry updated');
+      } else {
+        const payload: PaymentCreate = {
+          ledger_id: null,
+          voucher_type: voucherType,
+          amount: entryForm.amount,
+          account_id: selectedAccount.id,
+          date: isoDate,
+          mode: selectedAccount.account_type,
+          notes: entryForm.description.trim() || undefined,
+        };
+        await api.post<Payment>('/payments/', payload);
+        setSuccess('Entry added');
+      }
+
+      setShowEntryModal(false);
+      setEditingEntry(null);
+      resetEntryForm();
+      await loadData();
+    } catch (err) {
+      setError(getApiErrorMessage(err, 'Unable to save entry'));
+    } finally {
+      setEntrySubmitting(false);
+    }
+  }
+
+  async function handleDeleteEntry(entryId: number) {
+    const confirmed = window.confirm('Delete this entry?');
+    if (!confirmed) return;
+
+    try {
+      setError('');
+      await api.delete(`/payments/${entryId}`);
+      setSuccess('Entry deleted');
+      await loadData();
+    } catch (err) {
+      setError(getApiErrorMessage(err, 'Unable to delete entry'));
+    }
+  }
 
   const totals = useMemo(() => {
     const totalDebit = accountEntries.reduce((sum, entry) => sum + entry.debit, 0);
@@ -147,7 +273,12 @@ export default function CashBankPage() {
         </div>
       </section>
 
-      <StatusToasts error={error} onClearError={() => setError('')} onClearSuccess={() => {}} />
+      <StatusToasts
+        error={error}
+        success={success}
+        onClearError={() => setError('')}
+        onClearSuccess={() => setSuccess('')}
+      />
 
       <section className="content-grid">
         <article className="panel stack">
@@ -215,6 +346,19 @@ export default function CashBankPage() {
                 {selectedAccount ? `${selectedAccount.display_name} entries` : 'Unallocated entries'}
               </h2>
             </div>
+            <div style={{ display: 'flex', gap: '8px' }}>
+              {selectedAccount ? (
+                <button
+                  type="button"
+                  className="button button--primary"
+                  onClick={openCreateEntryModal}
+                  title="Add debit or credit entry"
+                  aria-label="Add debit or credit entry"
+                >
+                  Add Entry
+                </button>
+              ) : null}
+            </div>
           </div>
 
           <div className="invoice-list">
@@ -231,18 +375,135 @@ export default function CashBankPage() {
                         {new Date(entry.date).toLocaleDateString()} · {entry.ledgerName}
                       </span>
                       <span className="table-subtext">{entry.particulars}</span>
+                      {entry.description ? <span className="table-subtext">{entry.description}</span> : null}
                     </div>
-                    <span className="invoice-row__price">
-                      {entry.debit > 0
-                        ? `Dr ${formatCurrency(entry.debit, activeCurrencyCode)}`
-                        : `Cr ${formatCurrency(entry.credit, activeCurrencyCode)}`}
-                    </span>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+                      <span className="invoice-row__price">
+                        {entry.debit > 0
+                          ? `Dr ${formatCurrency(entry.debit, activeCurrencyCode)}`
+                          : `Cr ${formatCurrency(entry.credit, activeCurrencyCode)}`}
+                      </span>
+                      <button
+                        type="button"
+                        className="button button--ghost button--small"
+                        onClick={() => openEditEntryModal(entry.id)}
+                        title="Edit entry"
+                        aria-label="Edit entry"
+                      >
+                        Edit
+                      </button>
+                      <button
+                        type="button"
+                        className="button button--ghost button--small"
+                        onClick={() => void handleDeleteEntry(entry.id)}
+                        title="Delete entry"
+                        aria-label="Delete entry"
+                      >
+                        Delete
+                      </button>
+                    </div>
                   </div>
                 ))
               : null}
           </div>
         </article>
       </section>
+
+      {showEntryModal ? (
+        <div className="modal-overlay" role="dialog" aria-modal="true" onClick={() => setShowEntryModal(false)}>
+          <div className="modal-panel" onClick={(e) => e.stopPropagation()}>
+            <div className="panel stack">
+              <div className="panel__header">
+                <h2 className="nav-panel__title">{editingEntry ? 'Edit entry' : 'Add debit / credit entry'}</h2>
+                <button
+                  type="button"
+                  className="button button--ghost"
+                  onClick={() => setShowEntryModal(false)}
+                  title="Close entry dialog"
+                  aria-label="Close entry dialog"
+                >
+                  ✕
+                </button>
+              </div>
+
+              <form onSubmit={(event) => void handleSubmitEntry(event)} className="stack">
+                <div className="field">
+                  <label htmlFor="entry-type">Type</label>
+                  <select
+                    id="entry-type"
+                    className="input"
+                    value={entryForm.entryType}
+                    onChange={(event) => setEntryForm((current) => ({
+                      ...current,
+                      entryType: event.target.value as 'debit' | 'credit',
+                    }))}
+                  >
+                    <option value="debit">Debit (withdrawal / outflow)</option>
+                    <option value="credit">Credit (deposit / inflow)</option>
+                  </select>
+                </div>
+
+                <div className="field">
+                  <label htmlFor="entry-amount">Amount</label>
+                  <input
+                    id="entry-amount"
+                    className="input"
+                    type="number"
+                    min="0.01"
+                    step="0.01"
+                    value={entryForm.amount || ''}
+                    onChange={(event) => setEntryForm((current) => ({
+                      ...current,
+                      amount: parseFloat(event.target.value) || 0,
+                    }))}
+                    required
+                  />
+                </div>
+
+                <div className="field">
+                  <label htmlFor="entry-date">Date</label>
+                  <input
+                    id="entry-date"
+                    className="input"
+                    type="date"
+                    value={entryForm.date}
+                    onChange={(event) => setEntryForm((current) => ({
+                      ...current,
+                      date: event.target.value,
+                    }))}
+                    required
+                  />
+                </div>
+
+                <div className="field">
+                  <label htmlFor="entry-description">Description</label>
+                  <input
+                    id="entry-description"
+                    className="input"
+                    type="text"
+                    placeholder="e.g. ATM withdrawal, branch cash deposit"
+                    value={entryForm.description}
+                    onChange={(event) => setEntryForm((current) => ({
+                      ...current,
+                      description: event.target.value,
+                    }))}
+                  />
+                </div>
+
+                <button
+                  type="submit"
+                  className="button button--primary"
+                  disabled={entrySubmitting}
+                  title="Save entry"
+                  aria-label="Save entry"
+                >
+                  {entrySubmitting ? 'Saving...' : 'Save entry'}
+                </button>
+              </form>
+            </div>
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -421,7 +421,7 @@ export type PaymentVoucherType = 'receipt' | 'payment' | 'opening_balance';
 
 export type Payment = {
   id: number;
-  ledger_id: number;
+  ledger_id: number | null;
   voucher_type: PaymentVoucherType;
   amount: number;
   account_id?: number | null;
@@ -449,7 +449,7 @@ export type PaymentUpdate = {
 };
 
 export type PaymentCreate = {
-  ledger_id: number;
+  ledger_id?: number | null;
   voucher_type: PaymentVoucherType;
   amount: number;
   account_id?: number | null;


### PR DESCRIPTION
## Summary

Add account-level debit/credit entries in Cash & Bank so users can record withdrawals/deposits with descriptions, and support account-only payment records in the backend.

This PR includes:
- Backend support for account-only payments (`ledger_id` optional when `account_id` is provided)
- Cash & Bank UI to add, edit, and delete debit/credit entries with description
- Documentation for the new flow in `CASH_BANK.md`
- Backend tests for account-only entry lifecycle

## Type of change

- [x] feat (new feature)
- [ ] fix (bug fix)
- [x] docs (documentation)
- [x] test (tests)
- [ ] chore/refactor

## How to test

1. Apply migrations in backend (includes `20260419000001_make_payment_ledger_optional.py`).
2. Start backend and frontend.
3. Open `/cash-bank`.
4. Select an account and click `Add Entry`.
5. Create one Debit entry and one Credit entry with descriptions.
6. Verify entries show in register with Dr/Cr6amounts6. Verify entries show in register with Dr/Cr6amountes are reflected.
8. Delete one entry and verify it no longer appears in active list.
9. Verify existing ledger-linked payment flow still works.

## Checklist

- [x] My code follows the project style and conventions
- [x] I added/updated tests where appropriate
- [x] I updated docs where needed
- [x] I ran relevant checks locally
- [x] I verified this does not break existing behavior

## Screenshots (if UI changes)

UI change included; screenshots can be added in review if needed.

## Related issue

Closes #
