### PR TITLE
feat(allocations): add scrollable list and invoice number search in allocation section

### DIFF
--- a/INVOICE_DUE.md
+++ b/INVOICE_DUE.md
@@ -1,0 +1,63 @@
+# Invoice Due Logic
+
+## Overview
+
+Invoice due dates are optional.
+
+- If the user does not select a due date option, `due_date` is stored as `null`.
+- If the user selects an exact date, that value is sent directly.
+- If the user selects a relative number of days, the due date is computed from the invoice date, not from the current date.
+
+## Frontend Behavior
+
+Shared due-date helpers live in `frontend/src/utils/invoiceDueDate.ts`.
+
+- `none`: no due date
+- `exact`: user-selected calendar date
+- `days`: invoice date plus N days
+
+The invoice create flows on the main invoice page and quick-create modal both use the same helper so they resolve due dates consistently.
+
+## Backend Behavior
+
+The backend already stores `invoices.due_date` as a nullable field.
+
+Invoice responses now also expose derived collection fields:
+
+- `paid_amount`
+- `remaining_amount`
+- `outstanding_amount`
+- `payment_status`
+- `due_in_days`
+
+These are calculated from active invoice totals, credit notes, and payment allocations.
+
+## Payment Allocation Rules
+
+Receipt and payment entries can be allocated against invoices through `payment_invoice_allocations`.
+
+- Fully paid invoices are excluded from selection.
+- Partial allocations are allowed.
+- Oldest invoices can be auto-selected through backend suggestions.
+- Editing an existing payment reloads outstanding invoices while excluding the current payment from the outstanding calculation.
+
+## Dues Page Filters
+
+The dues page is available at `/invoice-dues`.
+
+Supported filters:
+
+- overdue invoices
+- next 7 days
+- next 15 days
+- custom number of days ahead
+- exact due date
+- all due invoices
+
+The dues page is backed by `GET /invoices/dues`.
+
+## Notes
+
+- Relative due dates are anchored to invoice date because that was the explicit product decision.
+- The dues page includes overdue invoices as a first-class filter.
+- Payment status is derived, not stored separately.

--- a/backend/migrations/20260419000002_create_payment_invoice_allocations.py
+++ b/backend/migrations/20260419000002_create_payment_invoice_allocations.py
@@ -1,0 +1,30 @@
+"""Create payment_invoice_allocations table for invoice-level receipt/payment allocations."""
+
+from sqlalchemy import text
+
+
+def up(conn) -> None:
+    conn.execute(text("""
+        CREATE TABLE IF NOT EXISTS payment_invoice_allocations (
+            id SERIAL PRIMARY KEY,
+            payment_id INTEGER NOT NULL REFERENCES payments(id) ON DELETE CASCADE,
+            invoice_id INTEGER NOT NULL REFERENCES invoices(id) ON DELETE CASCADE,
+            allocated_amount NUMERIC(10, 2) NOT NULL,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            UNIQUE(payment_id, invoice_id)
+        )
+    """))
+    conn.execute(text("""
+        CREATE INDEX IF NOT EXISTS ix_payment_invoice_allocations_payment_id
+        ON payment_invoice_allocations(payment_id)
+    """))
+    conn.execute(text("""
+        CREATE INDEX IF NOT EXISTS ix_payment_invoice_allocations_invoice_id
+        ON payment_invoice_allocations(invoice_id)
+    """))
+
+
+def down(conn) -> None:
+    conn.execute(text("DROP INDEX IF EXISTS ix_payment_invoice_allocations_invoice_id"))
+    conn.execute(text("DROP INDEX IF EXISTS ix_payment_invoice_allocations_payment_id"))
+    conn.execute(text("DROP TABLE IF EXISTS payment_invoice_allocations"))

--- a/backend/src/api/routes/invoices.py
+++ b/backend/src/api/routes/invoices.py
@@ -25,6 +25,7 @@ from src.schemas.invoice import InvoiceCreate, InvoiceOut, PaginatedInvoiceOut
 from src.api.deps import get_current_user
 from src.services.series import generate_next_number
 from src.services.financial_year import get_active_fy, get_fy_for_date
+from src.services.invoice_payments import build_invoice_payment_summaries
 
 router = APIRouter()
 
@@ -161,8 +162,7 @@ def _apply_payload_to_invoice(
     if payload.invoice_date is not None:
         invoice.invoice_date = datetime.combine(payload.invoice_date, datetime.min.time())
 
-    if payload.due_date is not None:
-        invoice.due_date = datetime.combine(payload.due_date, datetime.min.time())
+    invoice.due_date = datetime.combine(payload.due_date, datetime.min.time()) if payload.due_date is not None else None
 
     invoice.tax_inclusive = payload.tax_inclusive
     invoice.apply_round_off = payload.apply_round_off
@@ -267,6 +267,21 @@ def _apply_payload_to_invoice(
         invoice.total_amount = float(raw_total)
 
 
+    def _to_invoice_out(
+      invoice: Invoice,
+      *,
+      payment_summary=None,
+    ) -> InvoiceOut:
+      result = InvoiceOut.model_validate(invoice)
+      if payment_summary is not None:
+        result.paid_amount = payment_summary.paid_amount
+        result.remaining_amount = payment_summary.remaining_amount
+        result.outstanding_amount = payment_summary.outstanding_amount
+        result.payment_status = payment_summary.payment_status
+        result.due_in_days = payment_summary.due_in_days
+      return result
+
+
 @router.post("", response_model=InvoiceOut, include_in_schema=False)
 @router.post("/", response_model=InvoiceOut)
 def create_invoice(
@@ -307,7 +322,8 @@ def create_invoice(
             if not (active_fy.start_date <= inv_date <= active_fy.end_date):
                 warnings.append("invoice_date_outside_fy")
 
-        result = InvoiceOut.model_validate(invoice)
+        summary = build_invoice_payment_summaries(db, [invoice]).get(invoice.id)
+        result = _to_invoice_out(invoice, payment_summary=summary)
         result.warnings = warnings
         return result
     except HTTPException:
@@ -359,7 +375,7 @@ def list_invoices(
         others_total = total_listed - (credit_total + debit_total + cancelled_total)
 
         total = base.count()
-        items = (
+        invoices = (
             base.options(joinedload(Invoice.ledger), joinedload(Invoice.items))
             .order_by(Invoice.id.desc())
             .offset((page - 1) * page_size)
@@ -367,7 +383,10 @@ def list_invoices(
             .all()
         )
 
-        visible_page_total = sum((Decimal(item.total_amount or 0) for item in items), Decimal("0"))
+        payment_summaries = build_invoice_payment_summaries(db, invoices)
+        items = [_to_invoice_out(invoice, payment_summary=payment_summaries.get(invoice.id)) for invoice in invoices]
+
+        visible_page_total = sum((Decimal(str(item.total_amount or 0)) for item in items), Decimal("0"))
 
         return PaginatedInvoiceOut(
             items=items,
@@ -393,6 +412,78 @@ def list_invoices(
         raise HTTPException(status_code=500, detail=str(e))
 
 
+@router.get("/dues", response_model=PaginatedInvoiceOut)
+def list_due_invoices(
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=500),
+    search: str = Query(""),
+    ledger_id: int | None = Query(None),
+    due_date_from: date | None = Query(None),
+    due_date_to: date | None = Query(None),
+    db: Session = Depends(get_db),
+    _: User = Depends(get_current_user),
+):
+    try:
+      base = (
+        db.query(Invoice)
+        .options(joinedload(Invoice.ledger), joinedload(Invoice.items))
+        .filter(
+          Invoice.voucher_type == "sales",
+          Invoice.status == "active",
+          Invoice.due_date.isnot(None),
+        )
+      )
+
+      if ledger_id is not None:
+        base = base.filter(Invoice.ledger_id == ledger_id)
+      if search.strip():
+        base = base.filter(Invoice.ledger_name.ilike(f"%{search.strip()}%"))
+      if due_date_from is not None:
+        base = base.filter(Invoice.due_date >= datetime.combine(due_date_from, datetime.min.time()))
+      if due_date_to is not None:
+        base = base.filter(Invoice.due_date <= datetime.combine(due_date_to, datetime.max.time()))
+
+      invoices = base.order_by(Invoice.due_date.asc(), Invoice.invoice_date.asc(), Invoice.id.asc()).all()
+      payment_summaries = build_invoice_payment_summaries(db, invoices)
+      outstanding_invoices = [
+        invoice
+        for invoice in invoices
+        if payment_summaries[invoice.id].remaining_amount > 0
+      ]
+
+      total = len(outstanding_invoices)
+      page_start = (page - 1) * page_size
+      page_end = page_start + page_size
+      paged_invoices = outstanding_invoices[page_start:page_end]
+      items = [_to_invoice_out(invoice, payment_summary=payment_summaries.get(invoice.id)) for invoice in paged_invoices]
+
+      total_listed = sum((Decimal(str(invoice.total_amount or 0)) for invoice in outstanding_invoices), Decimal("0"))
+      visible_page_total = sum((Decimal(str(item.total_amount or 0)) for item in items), Decimal("0"))
+
+      return PaginatedInvoiceOut(
+        items=items,
+        total=total,
+        page=page,
+        page_size=page_size,
+        total_pages=(total + page_size - 1) // page_size if total > 0 else 1,
+        summary=PaginatedInvoiceOut.SummaryMeta(
+          total_listed=float(total_listed),
+          credit_total=0.0,
+          debit_total=float(total_listed),
+          cancelled_total=0.0,
+          active_total=float(total_listed),
+          others_total=0.0,
+          visible_page_total=float(visible_page_total),
+          visible_page_count=len(items),
+          filtered_count=total,
+          include_cancelled=False,
+          financial_year_id=None,
+        ),
+      )
+    except Exception as e:
+      raise HTTPException(status_code=500, detail=str(e))
+
+
 @router.get("/{invoice_id}", response_model=InvoiceOut)
 def get_invoice(
     invoice_id: int,
@@ -407,7 +498,8 @@ def get_invoice(
     )
     if not invoice:
         raise HTTPException(status_code=404, detail=f"Invoice {invoice_id} not found")
-    return invoice
+    summary = build_invoice_payment_summaries(db, [invoice]).get(invoice.id)
+    return _to_invoice_out(invoice, payment_summary=summary)
 
 
 @router.put("/{invoice_id}", response_model=InvoiceOut)
@@ -449,7 +541,8 @@ def update_invoice(
             if not (active_fy.start_date <= inv_date <= active_fy.end_date):
                 warnings.append("invoice_date_outside_fy")
 
-        result = InvoiceOut.model_validate(invoice)
+        summary = build_invoice_payment_summaries(db, [invoice]).get(invoice.id)
+        result = _to_invoice_out(invoice, payment_summary=summary)
         result.warnings = warnings
         return result
     except HTTPException:

--- a/backend/src/api/routes/invoices.py
+++ b/backend/src/api/routes/invoices.py
@@ -267,19 +267,19 @@ def _apply_payload_to_invoice(
         invoice.total_amount = float(raw_total)
 
 
-    def _to_invoice_out(
-      invoice: Invoice,
-      *,
-      payment_summary=None,
-    ) -> InvoiceOut:
-      result = InvoiceOut.model_validate(invoice)
-      if payment_summary is not None:
+def _to_invoice_out(
+    invoice: Invoice,
+    *,
+    payment_summary=None,
+) -> InvoiceOut:
+    result = InvoiceOut.model_validate(invoice)
+    if payment_summary is not None:
         result.paid_amount = payment_summary.paid_amount
         result.remaining_amount = payment_summary.remaining_amount
         result.outstanding_amount = payment_summary.outstanding_amount
         result.payment_status = payment_summary.payment_status
         result.due_in_days = payment_summary.due_in_days
-      return result
+    return result
 
 
 @router.post("", response_model=InvoiceOut, include_in_schema=False)

--- a/backend/src/api/routes/ledgers.py
+++ b/backend/src/api/routes/ledgers.py
@@ -19,9 +19,11 @@ from src.models.invoice import Invoice
 from src.models.invoice import InvoiceItem
 from src.models.payment import Payment
 from src.models.user import User, UserRole
+from src.schemas.invoice import OutstandingInvoiceOut
 from src.schemas.ledger import DayBookEntry, DayBookOut, LedgerCreate, LedgerOut, LedgerStatementEntry, LedgerStatementOut, PaginatedLedgerOut, TaxLedgerEntry, TaxLedgerOut, TaxLedgerTotals
 from src.services.credit_note_reporting import get_credit_note_ledger_summary
 from src.services.financial_year import get_active_fy
+from src.services.invoice_payments import auto_allocate_outstanding_invoices, get_outstanding_invoices_for_ledger
 
 router = APIRouter()
 
@@ -654,6 +656,44 @@ def get_ledger(
     if not ledger:
         raise HTTPException(status_code=404, detail=f"Ledger {ledger_id} not found")
     return _serialize_ledger(db, ledger)
+
+@router.get("/{ledger_id}/unpaid-invoices", response_model=list[OutstandingInvoiceOut])
+def list_unpaid_invoices(
+    ledger_id: int,
+    voucher_type: str = Query("receipt", pattern="^(receipt|payment)$"),
+    amount: float | None = Query(None, gt=0),
+    payment_id: int | None = Query(None),
+    db: Session = Depends(get_db),
+    _: User = Depends(get_current_user),
+):
+    ledger = db.query(Ledger).filter(Ledger.id == ledger_id).first()
+    if not ledger:
+        raise HTTPException(status_code=404, detail=f"Ledger {ledger_id} not found")
+
+    rows = get_outstanding_invoices_for_ledger(
+        db,
+        ledger_id,
+        voucher_type=voucher_type,
+        exclude_payment_id=payment_id,
+    )
+    suggestions = auto_allocate_outstanding_invoices(rows, amount) if amount is not None else {}
+
+    return [
+        OutstandingInvoiceOut(
+            id=invoice.id,
+            invoice_number=invoice.invoice_number,
+            invoice_date=invoice.invoice_date,
+            due_date=invoice.due_date,
+            total_amount=float(invoice.total_amount or 0),
+            paid_amount=summary.paid_amount,
+            remaining_amount=summary.remaining_amount,
+            outstanding_amount=summary.outstanding_amount,
+            payment_status=summary.payment_status,
+            due_in_days=summary.due_in_days,
+            suggested_allocation_amount=suggestions.get(invoice.id),
+        )
+        for invoice, summary in rows
+    ]
 
 
 @router.put("/{ledger_id}", response_model=LedgerOut)

--- a/backend/src/api/routes/payments.py
+++ b/backend/src/api/routes/payments.py
@@ -4,7 +4,7 @@ from io import BytesIO
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import StreamingResponse
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 
 import weasyprint
 
@@ -13,11 +13,12 @@ from src.db.session import get_db
 from src.models.buyer import Buyer as Ledger
 from src.models.company_account import CompanyAccount
 from src.models.company import CompanyProfile
-from src.models.payment import Payment
+from src.models.payment import Payment, PaymentInvoiceAllocation
 from src.models.user import User, UserRole
 from src.schemas.payment import PaymentCreate, PaymentOut, PaymentUpdate
 from src.services.series import generate_next_number
 from src.services.financial_year import get_active_fy, get_fy_for_date
+from src.services.invoice_payments import sync_payment_allocations
 
 router = APIRouter()
 
@@ -37,6 +38,17 @@ def _to_payment_out(payment: Payment) -> PaymentOut:
     if payment.account is not None:
         result.account_display_name = payment.account.display_name
         result.account_type = payment.account.account_type
+    result.invoice_allocations = [
+        {
+            "id": allocation.id,
+            "invoice_id": allocation.invoice_id,
+            "invoice_number": allocation.invoice.invoice_number if allocation.invoice else None,
+            "invoice_date": allocation.invoice.invoice_date if allocation.invoice else None,
+            "due_date": allocation.invoice.due_date if allocation.invoice else None,
+            "allocated_amount": float(allocation.allocated_amount or 0),
+        }
+        for allocation in payment.invoice_allocations
+    ]
     return result
 
 
@@ -131,6 +143,8 @@ def create_payment(
         created_by=current_user.id,
     )
     db.add(payment)
+    db.flush()
+    sync_payment_allocations(db, payment=payment, invoice_allocations=payload.invoice_allocations)
     db.commit()
     db.refresh(payment)
 
@@ -153,12 +167,15 @@ def list_payments(
     db: Session = Depends(get_db),
     _: User = Depends(get_current_user),
 ):
-    query = db.query(Payment)
-    if ledger_id is not None:
-        query = query.filter(Payment.ledger_id == ledger_id)
-    if not include_cancelled:
-        query = query.filter(Payment.status == "active")
-    return [_to_payment_out(payment) for payment in query.order_by(Payment.date.desc()).all()]
+  query = db.query(Payment).options(
+    joinedload(Payment.account),
+    joinedload(Payment.invoice_allocations).joinedload(PaymentInvoiceAllocation.invoice),
+  )
+  if ledger_id is not None:
+    query = query.filter(Payment.ledger_id == ledger_id)
+  if not include_cancelled:
+    query = query.filter(Payment.status == "active")
+  return [_to_payment_out(payment) for payment in query.order_by(Payment.date.desc()).all()]
 
 
 @router.get("/{payment_id}", response_model=PaymentOut)
@@ -167,7 +184,15 @@ def get_payment(
     db: Session = Depends(get_db),
     _: User = Depends(get_current_user),
 ):
-    payment = db.query(Payment).filter(Payment.id == payment_id).first()
+    payment = (
+        db.query(Payment)
+        .options(
+            joinedload(Payment.account),
+            joinedload(Payment.invoice_allocations).joinedload(PaymentInvoiceAllocation.invoice),
+        )
+        .filter(Payment.id == payment_id)
+        .first()
+    )
     if not payment:
         raise HTTPException(status_code=404, detail="Payment not found")
     return _to_payment_out(payment)
@@ -180,14 +205,19 @@ def update_payment(
     db: Session = Depends(get_db),
     _: User = Depends(get_current_user),
 ):
-    payment = db.query(Payment).filter(Payment.id == payment_id, Payment.status == "active").first()
+    payment = (
+        db.query(Payment)
+        .options(joinedload(Payment.invoice_allocations))
+        .filter(Payment.id == payment_id, Payment.status == "active")
+        .first()
+    )
     if not payment:
         raise HTTPException(status_code=404, detail="Payment not found")
 
     next_ledger_id = payment.ledger_id
     _ensure_single_opening_balance(
         db,
-      next_ledger_id,
+        next_ledger_id,
         payload.voucher_type,
         exclude_payment_id=payment.id,
     )
@@ -204,6 +234,12 @@ def update_payment(
     payment.mode = payload.mode.strip() if payload.mode else None
     payment.reference = payload.reference.strip() if payload.reference else None
     payment.notes = payload.notes.strip() if payload.notes else None
+    sync_payment_allocations(
+      db,
+      payment=payment,
+      invoice_allocations=payload.invoice_allocations,
+      exclude_payment_id=payment.id,
+    )
     db.commit()
     db.refresh(payment)
     result = _to_payment_out(payment)

--- a/backend/src/models/__init__.py
+++ b/backend/src/models/__init__.py
@@ -5,6 +5,6 @@ from src.models.invoice import Invoice, InvoiceItem
 from src.models.buyer import Buyer
 from src.models.company import CompanyProfile
 from src.models.company_account import CompanyAccount
-from src.models.payment import Payment
+from src.models.payment import Payment, PaymentInvoiceAllocation
 from src.models.smtp_config import SMTPConfig
 from src.models.user_shortcut import UserShortcut

--- a/backend/src/models/invoice.py
+++ b/backend/src/models/invoice.py
@@ -47,6 +47,7 @@ class Invoice(Base):
 
     ledger = relationship("Buyer", back_populates="invoices")
     items = relationship("InvoiceItem", back_populates="invoice", cascade="all, delete-orphan")
+    payment_allocations = relationship("PaymentInvoiceAllocation", back_populates="invoice", cascade="all, delete-orphan")
 
 
 class InvoiceItem(Base):

--- a/backend/src/models/payment.py
+++ b/backend/src/models/payment.py
@@ -25,3 +25,17 @@ class Payment(Base):
 
     ledger = relationship("Buyer", backref="payments")
     account = relationship("CompanyAccount", back_populates="payments")
+    invoice_allocations = relationship("PaymentInvoiceAllocation", back_populates="payment", cascade="all, delete-orphan")
+
+
+class PaymentInvoiceAllocation(Base):
+    __tablename__ = "payment_invoice_allocations"
+
+    id = Column(Integer, primary_key=True, index=True)
+    payment_id = Column(Integer, ForeignKey("payments.id"), nullable=False)
+    invoice_id = Column(Integer, ForeignKey("invoices.id"), nullable=False)
+    allocated_amount = Column(Numeric(10, 2), nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    payment = relationship("Payment", back_populates="invoice_allocations")
+    invoice = relationship("Invoice", back_populates="payment_allocations")

--- a/backend/src/schemas/invoice.py
+++ b/backend/src/schemas/invoice.py
@@ -74,6 +74,11 @@ class InvoiceOut(BaseModel):
     total_amount: float
     invoice_date: datetime
     due_date: datetime | None = None
+    paid_amount: float = 0
+    remaining_amount: float = 0
+    outstanding_amount: float = 0
+    payment_status: str = "unpaid"
+    due_in_days: int | None = None
     tax_inclusive: bool = False
     apply_round_off: bool = False
     round_off_amount: float = 0
@@ -106,3 +111,20 @@ class PaginatedInvoiceOut(BaseModel):
     page_size: int
     total_pages: int
     summary: SummaryMeta
+
+
+class OutstandingInvoiceOut(BaseModel):
+    id: int
+    invoice_number: str | None = None
+    invoice_date: datetime
+    due_date: datetime | None = None
+    total_amount: float
+    paid_amount: float = 0
+    remaining_amount: float = 0
+    outstanding_amount: float = 0
+    payment_status: str = "unpaid"
+    due_in_days: int | None = None
+    suggested_allocation_amount: float | None = None
+
+    class Config:
+        from_attributes = True

--- a/backend/src/schemas/payment.py
+++ b/backend/src/schemas/payment.py
@@ -1,9 +1,26 @@
 from datetime import datetime
-from pydantic import BaseModel, field_validator, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 from typing import List, Optional
 
 
 PAYMENT_VOUCHER_TYPES = ("receipt", "payment", "opening_balance")
+
+
+class PaymentInvoiceAllocationCreate(BaseModel):
+    invoice_id: int
+    allocated_amount: float
+
+
+class PaymentInvoiceAllocationOut(BaseModel):
+    id: int | None = None
+    invoice_id: int
+    invoice_number: str | None = None
+    invoice_date: datetime | None = None
+    due_date: datetime | None = None
+    allocated_amount: float
+
+    class Config:
+        from_attributes = True
 
 
 class PaymentUpdate(BaseModel):
@@ -14,6 +31,7 @@ class PaymentUpdate(BaseModel):
     mode: str | None = None
     reference: str | None = None
     notes: str | None = None
+    invoice_allocations: list[PaymentInvoiceAllocationCreate] = Field(default_factory=list)
 
     @field_validator("voucher_type")
     @classmethod
@@ -44,6 +62,7 @@ class PaymentCreate(BaseModel):
     mode: str | None = None
     reference: str | None = None
     notes: str | None = None
+    invoice_allocations: list[PaymentInvoiceAllocationCreate] = Field(default_factory=list)
 
     @field_validator("voucher_type")
     @classmethod
@@ -83,6 +102,7 @@ class PaymentOut(BaseModel):
     warnings: List[str] = []
     created_by: int
     created_at: datetime
+    invoice_allocations: list[PaymentInvoiceAllocationOut] = Field(default_factory=list)
 
     class Config:
         from_attributes = True

--- a/backend/src/services/invoice_payments.py
+++ b/backend/src/services/invoice_payments.py
@@ -1,0 +1,267 @@
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal, ROUND_HALF_UP
+
+from fastapi import HTTPException
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from src.models.credit_note import CreditNote, CreditNoteItem
+from src.models.invoice import Invoice
+from src.models.payment import Payment, PaymentInvoiceAllocation
+
+
+@dataclass
+class InvoicePaymentSummary:
+    invoice_id: int
+    credited_amount: float
+    paid_amount: float
+    remaining_amount: float
+    outstanding_amount: float
+    payment_status: str
+    due_in_days: int | None
+
+
+def _money(value: Decimal) -> Decimal:
+    return value.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+
+def _credit_totals_by_invoice(db: Session, invoice_ids: list[int]) -> dict[int, Decimal]:
+    if not invoice_ids:
+        return {}
+
+    rows = (
+        db.query(CreditNoteItem.invoice_id, func.coalesce(func.sum(CreditNoteItem.line_total), 0))
+        .join(CreditNote, CreditNote.id == CreditNoteItem.credit_note_id)
+        .filter(
+            CreditNote.status == "active",
+            CreditNoteItem.invoice_id.in_(invoice_ids),
+        )
+        .group_by(CreditNoteItem.invoice_id)
+        .all()
+    )
+    return {invoice_id: _money(Decimal(str(total or 0))) for invoice_id, total in rows}
+
+
+def _payment_totals_by_invoice(
+    db: Session,
+    invoice_ids: list[int],
+    *,
+    exclude_payment_id: int | None = None,
+) -> dict[int, Decimal]:
+    if not invoice_ids:
+        return {}
+
+    query = (
+        db.query(PaymentInvoiceAllocation.invoice_id, func.coalesce(func.sum(PaymentInvoiceAllocation.allocated_amount), 0))
+        .join(Payment, Payment.id == PaymentInvoiceAllocation.payment_id)
+        .filter(
+            Payment.status == "active",
+            PaymentInvoiceAllocation.invoice_id.in_(invoice_ids),
+        )
+    )
+    if exclude_payment_id is not None:
+        query = query.filter(Payment.id != exclude_payment_id)
+
+    rows = query.group_by(PaymentInvoiceAllocation.invoice_id).all()
+    return {invoice_id: _money(Decimal(str(total or 0))) for invoice_id, total in rows}
+
+
+def build_invoice_payment_summaries(
+    db: Session,
+    invoices: list[Invoice],
+    *,
+    exclude_payment_id: int | None = None,
+) -> dict[int, InvoicePaymentSummary]:
+    if not invoices:
+        return {}
+
+    invoice_ids = [invoice.id for invoice in invoices]
+    credit_totals = _credit_totals_by_invoice(db, invoice_ids)
+    payment_totals = _payment_totals_by_invoice(db, invoice_ids, exclude_payment_id=exclude_payment_id)
+    today = date.today()
+
+    summaries: dict[int, InvoicePaymentSummary] = {}
+    for invoice in invoices:
+        total_amount = _money(Decimal(str(invoice.total_amount or 0)))
+        credited_amount = credit_totals.get(invoice.id, Decimal("0.00"))
+        paid_amount = payment_totals.get(invoice.id, Decimal("0.00"))
+        remaining_amount = _money(total_amount - credited_amount - paid_amount)
+        if remaining_amount < 0:
+            remaining_amount = Decimal("0.00")
+
+        if remaining_amount <= 0:
+            payment_status = "paid"
+        elif paid_amount > 0:
+            payment_status = "partial"
+        else:
+            payment_status = "unpaid"
+
+        due_in_days = None
+        if invoice.due_date is not None:
+            due_in_days = (invoice.due_date.date() - today).days
+
+        summaries[invoice.id] = InvoicePaymentSummary(
+            invoice_id=invoice.id,
+            credited_amount=float(credited_amount),
+            paid_amount=float(paid_amount),
+            remaining_amount=float(remaining_amount),
+            outstanding_amount=float(remaining_amount),
+            payment_status=payment_status,
+            due_in_days=due_in_days,
+        )
+
+    return summaries
+
+
+def get_outstanding_invoices_for_ledger(
+    db: Session,
+    ledger_id: int,
+    *,
+    voucher_type: str,
+    exclude_payment_id: int | None = None,
+) -> list[tuple[Invoice, InvoicePaymentSummary]]:
+    invoice_voucher_type = "sales" if voucher_type == "receipt" else "purchase"
+    invoices = (
+        db.query(Invoice)
+        .filter(
+            Invoice.ledger_id == ledger_id,
+            Invoice.voucher_type == invoice_voucher_type,
+            Invoice.status == "active",
+        )
+        .order_by(Invoice.invoice_date.asc(), Invoice.id.asc())
+        .all()
+    )
+    summaries = build_invoice_payment_summaries(db, invoices, exclude_payment_id=exclude_payment_id)
+    outstanding_rows = [
+        (invoice, summaries[invoice.id])
+        for invoice in invoices
+        if summaries[invoice.id].remaining_amount > 0
+    ]
+    outstanding_rows.sort(
+        key=lambda row: (
+            row[0].due_date or row[0].invoice_date,
+            row[0].invoice_date,
+            row[0].id,
+        )
+    )
+    return outstanding_rows
+
+
+def auto_allocate_outstanding_invoices(
+    rows: list[tuple[Invoice, InvoicePaymentSummary]],
+    amount: float,
+) -> dict[int, float]:
+    remaining_amount = _money(Decimal(str(amount or 0)))
+    suggestions: dict[int, float] = {}
+
+    for invoice, summary in rows:
+        if remaining_amount <= 0:
+            break
+
+        invoice_remaining = _money(Decimal(str(summary.remaining_amount or 0)))
+        if invoice_remaining <= 0:
+            continue
+
+        allocated_amount = min(remaining_amount, invoice_remaining)
+        if allocated_amount <= 0:
+            continue
+
+        suggestions[invoice.id] = float(allocated_amount)
+        remaining_amount = _money(remaining_amount - allocated_amount)
+
+    return suggestions
+
+
+def validate_payment_allocations(
+    db: Session,
+    *,
+    ledger_id: int | None,
+    voucher_type: str,
+    payment_amount: float,
+    invoice_allocations,
+    exclude_payment_id: int | None = None,
+) -> list[tuple[Invoice, Decimal]]:
+    if not invoice_allocations:
+        return []
+
+    if voucher_type not in {"receipt", "payment"}:
+        raise HTTPException(status_code=400, detail="Only receipts and payments can be allocated to invoices")
+
+    if ledger_id is None:
+        raise HTTPException(status_code=400, detail="Invoice allocations require a ledger")
+
+    invoice_ids = [allocation.invoice_id for allocation in invoice_allocations]
+    if len(set(invoice_ids)) != len(invoice_ids):
+        raise HTTPException(status_code=400, detail="Each invoice may only appear once in invoice_allocations")
+
+    invoices = db.query(Invoice).filter(Invoice.id.in_(invoice_ids)).all()
+    invoice_map = {invoice.id: invoice for invoice in invoices}
+    missing_ids = sorted(set(invoice_ids) - set(invoice_map))
+    if missing_ids:
+        raise HTTPException(status_code=404, detail=f"Invoices not found: {missing_ids}")
+
+    expected_invoice_type = "sales" if voucher_type == "receipt" else "purchase"
+    summaries = build_invoice_payment_summaries(db, invoices, exclude_payment_id=exclude_payment_id)
+
+    normalized: list[tuple[Invoice, Decimal]] = []
+    allocated_total = Decimal("0.00")
+    for allocation in invoice_allocations:
+        invoice = invoice_map[allocation.invoice_id]
+        if invoice.ledger_id != ledger_id:
+            raise HTTPException(status_code=400, detail=f"Invoice {invoice.id} does not belong to ledger {ledger_id}")
+        if invoice.status != "active":
+            raise HTTPException(status_code=400, detail=f"Invoice {invoice.id} is not active")
+        if invoice.voucher_type != expected_invoice_type:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invoice {invoice.id} cannot be allocated to a {voucher_type}",
+            )
+
+        allocated_amount = _money(Decimal(str(allocation.allocated_amount)))
+        if allocated_amount <= 0:
+            raise HTTPException(status_code=400, detail="Allocated amounts must be greater than zero")
+
+        summary = summaries[invoice.id]
+        available_amount = _money(Decimal(str(summary.remaining_amount)))
+        if allocated_amount > available_amount:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invoice {invoice.invoice_number or invoice.id} only has {float(available_amount):.2f} remaining",
+            )
+
+        normalized.append((invoice, allocated_amount))
+        allocated_total = _money(allocated_total + allocated_amount)
+
+    if allocated_total > _money(Decimal(str(payment_amount or 0))):
+        raise HTTPException(status_code=400, detail="Allocated total cannot exceed the receipt/payment amount")
+
+    return normalized
+
+
+def sync_payment_allocations(
+    db: Session,
+    *,
+    payment: Payment,
+    invoice_allocations,
+    exclude_payment_id: int | None = None,
+) -> None:
+    normalized = validate_payment_allocations(
+        db,
+        ledger_id=payment.ledger_id,
+        voucher_type=payment.voucher_type,
+        payment_amount=float(payment.amount or 0),
+        invoice_allocations=invoice_allocations,
+        exclude_payment_id=exclude_payment_id,
+    )
+
+    for existing_allocation in list(payment.invoice_allocations):
+        db.delete(existing_allocation)
+    db.flush()
+
+    for invoice, allocated_amount in normalized:
+        db.add(PaymentInvoiceAllocation(
+            payment_id=payment.id,
+            invoice_id=invoice.id,
+            allocated_amount=float(allocated_amount),
+        ))

--- a/backend/tests/api/test_invoice_dues_allocations.py
+++ b/backend/tests/api/test_invoice_dues_allocations.py
@@ -1,0 +1,178 @@
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+
+def _create_ledger(client):
+    response = client.post(
+        "/api/ledgers/",
+        json={
+            "name": "Dues Ledger",
+            "address": "Mumbai",
+            "gst": "27ABCDE1234F1Z5",
+            "phone_number": "9999999999",
+            "email": "ledger@example.com",
+            "website": "",
+            "bank_name": "",
+            "branch_name": "",
+            "account_name": "",
+            "account_number": "",
+            "ifsc_code": "",
+        },
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["id"]
+
+
+def _create_product(client):
+    response = client.post(
+        "/api/products/",
+        json={
+            "sku": "DUE-001",
+            "name": "Due Product",
+            "description": "",
+            "hsn_sac": "9988",
+            "price": 100,
+            "gst_rate": 0,
+        },
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["id"]
+
+
+def _add_inventory(client, product_id, quantity=50):
+    response = client.post(
+        "/api/inventory/adjust",
+        json={"product_id": product_id, "quantity": quantity},
+    )
+    assert response.status_code == 200, response.text
+
+
+def _create_invoice(client, ledger_id, product_id, unit_price, due_date, invoice_date):
+    response = client.post(
+        "/api/invoices/",
+        json={
+            "ledger_id": ledger_id,
+            "voucher_type": "sales",
+            "tax_inclusive": False,
+            "apply_round_off": False,
+            "invoice_date": invoice_date,
+            "due_date": due_date,
+            "items": [{"product_id": product_id, "quantity": 1, "unit_price": unit_price}],
+        },
+    )
+    assert response.status_code == 200, response.text
+    return response.json()
+
+
+def _create_receipt(client, ledger_id, amount, allocations, dt):
+    response = client.post(
+        "/api/payments/",
+        json={
+            "ledger_id": ledger_id,
+            "voucher_type": "receipt",
+            "amount": amount,
+            "date": dt,
+            "mode": "bank",
+            "invoice_allocations": allocations,
+        },
+    )
+    assert response.status_code == 200, response.text
+    return response.json()
+
+
+def test_dues_endpoint_excludes_fully_paid_invoices(client):
+    today = datetime.utcnow().date()
+    invoice_date = today.isoformat()
+
+    invoice_numbers = iter(["INV-000001", "INV-000002"])
+    with patch(
+        "src.api.routes.invoices._generate_next_number",
+        side_effect=lambda *args, **kwargs: next(invoice_numbers),
+    ), patch(
+        "src.api.routes.payments.generate_next_number",
+        return_value="PAY-000001",
+    ):
+        ledger_id = _create_ledger(client)
+        product_id = _create_product(client)
+        _add_inventory(client, product_id)
+
+        overdue_invoice = _create_invoice(
+            client,
+            ledger_id,
+            product_id,
+            100,
+            (today - timedelta(days=2)).isoformat(),
+            invoice_date,
+        )
+        fully_paid_invoice = _create_invoice(
+            client,
+            ledger_id,
+            product_id,
+            120,
+            (today + timedelta(days=3)).isoformat(),
+            invoice_date,
+        )
+
+        _create_receipt(
+            client,
+            ledger_id,
+            120,
+            [{"invoice_id": fully_paid_invoice["id"], "allocated_amount": 120}],
+            datetime.utcnow().isoformat(),
+        )
+
+        dues_response = client.get(
+            "/api/invoices/dues",
+            params={
+                "page": 1,
+                "page_size": 20,
+            },
+        )
+        assert dues_response.status_code == 200, dues_response.text
+
+        body = dues_response.json()
+        returned_ids = {item["id"] for item in body["items"]}
+        assert overdue_invoice["id"] in returned_ids
+        assert fully_paid_invoice["id"] not in returned_ids
+
+
+def test_unpaid_invoices_returns_oldest_first_suggestions(client):
+    today = datetime.utcnow().date()
+
+    invoice_numbers = iter(["INV-000101", "INV-000102"])
+    with patch(
+        "src.api.routes.invoices._generate_next_number",
+        side_effect=lambda *args, **kwargs: next(invoice_numbers),
+    ):
+        ledger_id = _create_ledger(client)
+        product_id = _create_product(client)
+        _add_inventory(client, product_id)
+
+        oldest = _create_invoice(
+            client,
+            ledger_id,
+            product_id,
+            100,
+            (today - timedelta(days=5)).isoformat(),
+            (today - timedelta(days=10)).isoformat(),
+        )
+        newest = _create_invoice(
+            client,
+            ledger_id,
+            product_id,
+            100,
+            (today + timedelta(days=5)).isoformat(),
+            (today - timedelta(days=1)).isoformat(),
+        )
+
+        response = client.get(
+            f"/api/ledgers/{ledger_id}/unpaid-invoices",
+            params={"voucher_type": "receipt", "amount": 150},
+        )
+        assert response.status_code == 200, response.text
+
+        rows = response.json()
+        by_id = {row["id"]: row for row in rows}
+
+        assert by_id[oldest["id"]]["suggested_allocation_amount"] == 100
+        assert by_id[newest["id"]]["suggested_allocation_amount"] == 50

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import DashboardPage from './pages/DashboardPage';
 import ProductsPage from './pages/ProductsPage';
 import InventoryPage from './pages/InventoryPage';
 import InvoicesPage from './pages/InvoicesPage';
+import InvoiceDuesPage from './pages/InvoiceDuesPage';
 import InvoicesAdvancedView from './pages/InvoicesAdvancedView';
 import CreditNotesPage from './pages/CreditNotesPage';
 import LedgersPage from './pages/LedgersPage';
@@ -105,7 +106,8 @@ function AppRoutes() {
       <Route path="/cash-bank" element={<Protected><CompanyRequired><Layout><CashBankPage /></Layout></CompanyRequired></Protected>} />
       <Route path="/cash-bank/accounts" element={<Protected><CompanyRequired><Layout><CashBankAccountsPage /></Layout></CompanyRequired></Protected>} />
       <Route path="/invoices" element={<Protected><CompanyRequired><Layout><InvoicesPage /></Layout></CompanyRequired></Protected>} />
-        <Route path="/invoices-view" element={<Protected><CompanyRequired><Layout><InvoicesAdvancedView /></Layout></CompanyRequired></Protected>} />
+      <Route path="/invoice-dues" element={<Protected><CompanyRequired><Layout><InvoiceDuesPage /></Layout></CompanyRequired></Protected>} />
+      <Route path="/invoices-view" element={<Protected><CompanyRequired><Layout><InvoicesAdvancedView /></Layout></CompanyRequired></Protected>} />
       <Route path="/credit-notes" element={<Protected><CompanyRequired><Layout><CreditNotesPage /></Layout></CompanyRequired></Protected>} />
       <Route path="/company" element={<Protected><Layout><CompanyPage /></Layout></Protected>} />
       <Route path="/smtp-settings" element={<Protected><CompanyRequired><AdminOnly><Layout><SmtpSettingsPage /></Layout></AdminOnly></CompanyRequired></Protected>} />

--- a/frontend/src/components/CreateInvoiceModal.tsx
+++ b/frontend/src/components/CreateInvoiceModal.tsx
@@ -4,6 +4,7 @@ import api, { getApiErrorMessage } from '../api/client';
 import type { InvoiceCreate, Invoice, Ledger, Product } from '../types/api';
 import { useFY } from '../context/FYContext';
 import formatCurrency from '../utils/formatting';
+import { formatInvoiceDateLabel, resolveDueDate, type DueDateMode } from '../utils/invoiceDueDate.ts';
 import { formatInvoiceTaxBreakdown, isInterstateSupply } from '../utils/invoiceTax';
 import ProductCombobox from './ProductCombobox';
 import LedgerCombobox from './LedgerCombobox';
@@ -45,6 +46,9 @@ export default function CreateInvoiceModal({
   const [voucherType, setVoucherType] = useState<'sales' | 'purchase'>(preselectedVoucherType || 'sales');
   const [taxInclusive, setTaxInclusive] = useState(false);
   const [invoiceDate, setInvoiceDate] = useState(new Date().toISOString().slice(0, 10));
+  const [dueDateMode, setDueDateMode] = useState<DueDateMode>('none');
+  const [dueDate, setDueDate] = useState('');
+  const [dueDateDays, setDueDateDays] = useState('');
   const [items, setItems] = useState<InvoiceFormItem[]>([createItem(1)]);
   const [nextItemId, setNextItemId] = useState(2);
   const [loading, setLoading] = useState(true);
@@ -120,6 +124,12 @@ export default function CreateInvoiceModal({
     (invoiceDate < activeFY.start_date || invoiceDate > activeFY.end_date);
   const selectedLedger = ledgers.find((ledger) => ledger.id === Number(selectedLedgerId));
   const composerInterstateSupply = isInterstateSupply(companyGst, selectedLedger?.gst);
+  const resolvedDueDate = resolveDueDate({
+    mode: dueDateMode,
+    invoiceDate,
+    exactDate: dueDate,
+    daysFromInvoice: dueDateDays,
+  });
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -129,6 +139,7 @@ export default function CreateInvoiceModal({
         ledger_id: Number(selectedLedgerId),
         voucher_type: voucherType,
         invoice_date: invoiceDate,
+        due_date: resolvedDueDate,
         tax_inclusive: taxInclusive,
         items: items.map((item) => ({
           product_id: Number(item.productId),
@@ -215,7 +226,59 @@ export default function CreateInvoiceModal({
                   </p>
                 ) : null}
               </div>
+
+              <div className="field">
+                <label htmlFor="modal-inv-due-mode">Due date</label>
+                <select
+                  id="modal-inv-due-mode"
+                  className="select"
+                  value={dueDateMode}
+                  onChange={(e) => setDueDateMode(e.target.value as DueDateMode)}
+                >
+                  <option value="none">No due date</option>
+                  <option value="exact">Choose exact date</option>
+                  <option value="days">Set days from invoice date</option>
+                </select>
+              </div>
+
+              {dueDateMode === 'exact' ? (
+                <div className="field">
+                  <label htmlFor="modal-inv-due-date">Exact due date</label>
+                  <input
+                    id="modal-inv-due-date"
+                    className="input"
+                    type="date"
+                    value={dueDate}
+                    min={invoiceDate || undefined}
+                    onChange={(e) => setDueDate(e.target.value)}
+                  />
+                </div>
+              ) : null}
+
+              {dueDateMode === 'days' ? (
+                <div className="field">
+                  <label htmlFor="modal-inv-due-days">Days from invoice date</label>
+                  <input
+                    id="modal-inv-due-days"
+                    className="input"
+                    type="number"
+                    min="0"
+                    step="1"
+                    value={dueDateDays}
+                    onChange={(e) => setDueDateDays(e.target.value)}
+                    placeholder="0"
+                  />
+                </div>
+              ) : null}
             </div>
+
+            {dueDateMode !== 'none' ? (
+              <p className="muted-text" style={{ margin: 0 }}>
+                {resolvedDueDate
+                  ? `Resolved due date: ${formatInvoiceDateLabel(resolvedDueDate)}`
+                  : 'Select a valid due date or enter the number of days from the invoice date.'}
+              </p>
+            ) : null}
 
             <div className="field" style={{ display: 'flex', alignItems: 'center', gap: '12px', marginBottom: 0 }}>
               <input

--- a/frontend/src/components/InvoicePreview.tsx
+++ b/frontend/src/components/InvoicePreview.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useEscapeClose } from '../hooks/useEscapeClose';
 import api, { getApiErrorMessage } from '../api/client';
 import type { Invoice } from '../types/api';
+import { formatInvoiceDateLabel } from '../utils/invoiceDueDate.ts';
 import SendEmailModal from './SendEmailModal';
 
 type InvoicePreviewProps = {
@@ -93,6 +94,10 @@ export default function InvoicePreview({ invoice, onClose, onError }: InvoicePre
           <div>
             <p className="eyebrow">Invoice preview</p>
             <h2 id="invoice-preview-title" className="nav-panel__title">PDF invoice {invoice.invoice_number || `#${invoice.id}`}</h2>
+            <p className="muted-text" style={{ margin: '6px 0 0' }}>
+              Invoice date: {formatInvoiceDateLabel(invoice.invoice_date)}
+              {invoice.due_date ? ` · Due date: ${formatInvoiceDateLabel(invoice.due_date)}` : ' · No due date'}
+            </p>
           </div>
           <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
             <label style={{ display: 'flex', alignItems: 'center', gap: '8px', fontSize: '13px', color: '#374151', whiteSpace: 'nowrap', fontWeight: '500' }}>
@@ -116,7 +121,7 @@ export default function InvoicePreview({ invoice, onClose, onError }: InvoicePre
                 }}
                 onBlur={() => {
                   // Set to 1 if empty when leaving the input
-                  if (copies === 0 || copies === '') {
+                  if (copies === 0) {
                     setCopies(1);
                   }
                 }}

--- a/frontend/src/components/InvoicesCompactCard.tsx
+++ b/frontend/src/components/InvoicesCompactCard.tsx
@@ -1,6 +1,7 @@
 import { Eye, Pencil, RotateCcw, Trash2, FileText } from 'lucide-react';
 import type { Invoice } from '../types/api';
 import formatCurrency from '../utils/formatting';
+import { formatInvoiceDateLabel } from '../utils/invoiceDueDate.ts';
 
 interface InvoicesCompactCardProps {
   invoice: Invoice;
@@ -56,8 +57,13 @@ interface InvoicesCompactCardProps {
                 <p className="invoice-compact-card__meta">{invoice.ledger.phone_number}</p>
             )}
               <p className="invoice-compact-card__meta">
-              {new Date(invoice.invoice_date).toLocaleDateString()}
+              Invoice date: {formatInvoiceDateLabel(invoice.invoice_date)}
             </p>
+            {invoice.due_date ? (
+              <p className="invoice-compact-card__meta">
+                Due date: {formatInvoiceDateLabel(invoice.due_date)}
+              </p>
+            ) : null}
           </div>
         </div>
 

--- a/frontend/src/components/InvoicesTable.tsx
+++ b/frontend/src/components/InvoicesTable.tsx
@@ -1,5 +1,6 @@
 import type { Invoice } from '../types/api';
 import formatCurrency from '../utils/formatting';
+import { formatInvoiceDateLabel } from '../utils/invoiceDueDate.ts';
 
 interface InvoicesTableProps {
   invoices: Invoice[];
@@ -15,6 +16,7 @@ export default function InvoicesTable({ invoices, currencyCode, onRowClick }: In
           <tr>
             <th>Invoice #</th>
             <th>Date</th>
+            <th>Due</th>
             <th>Buyer / Supplier</th>
             <th>Amount</th>
             <th>Type</th>
@@ -37,7 +39,10 @@ export default function InvoicesTable({ invoices, currencyCode, onRowClick }: In
                   {invoice.invoice_number}
                 </td>
                 <td>
-                  {new Date(invoice.invoice_date).toLocaleDateString()}
+                  {formatInvoiceDateLabel(invoice.invoice_date)}
+                </td>
+                <td>
+                  {formatInvoiceDateLabel(invoice.due_date)}
                 </td>
                 <td>
                   <div className="invoice-feed-table__ledger">{invoice.ledger?.name || 'Unknown'}</div>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -15,6 +15,7 @@ interface SidebarProps {
 const mainGroup: NavItem[] = [
   { to: '/', label: 'Overview', end: true },
   { to: '/invoices', label: 'Invoices' },
+  { to: '/invoice-dues', label: 'Invoice Dues' },
   { to: '/credit-notes', label: 'Credit Notes' },
   { to: '/day-book', label: 'Day Book' },
   { to: '/tax-ledger', label: 'Tax Ledger' },

--- a/frontend/src/features/invoices/api.ts
+++ b/frontend/src/features/invoices/api.ts
@@ -1,5 +1,5 @@
 import api from '../../api/client';
-import type { CompanyProfile, Invoice, Ledger, PaginatedInvoices, Product } from '../../types/api';
+import type { CompanyProfile, Invoice, Ledger, OutstandingInvoice, PaginatedInvoices, Product } from '../../types/api';
 
 type InvoiceFilters = {
   page: number;
@@ -8,6 +8,15 @@ type InvoiceFilters = {
   showCancelled: boolean;
   financialYearId?: number;
   productId?: number;
+};
+
+export type DueInvoiceFilters = {
+  page: number;
+  pageSize: number;
+  search: string;
+  ledgerId?: number;
+  dueDateFrom?: string;
+  dueDateTo?: string;
 };
 
 function buildInvoiceParams(filters: InvoiceFilters) {
@@ -38,6 +47,48 @@ export async function fetchInvoicePage(filters: InvoiceFilters): Promise<Paginat
   const res = await api.get<PaginatedInvoices>('/invoices/', {
     params: buildInvoiceParams(filters),
   });
+  return res.data;
+}
+
+export async function fetchDueInvoicePage(filters: DueInvoiceFilters): Promise<PaginatedInvoices> {
+  const params: Record<string, string | number> = {
+    page: filters.page,
+    page_size: filters.pageSize,
+    search: filters.search,
+  };
+
+  if (typeof filters.ledgerId === 'number') {
+    params.ledger_id = filters.ledgerId;
+  }
+  if (filters.dueDateFrom) {
+    params.due_date_from = filters.dueDateFrom;
+  }
+  if (filters.dueDateTo) {
+    params.due_date_to = filters.dueDateTo;
+  }
+
+  const res = await api.get<PaginatedInvoices>('/invoices/dues', { params });
+  return res.data;
+}
+
+export async function fetchOutstandingInvoices(input: {
+  ledgerId: number;
+  voucherType: 'receipt' | 'payment';
+  amount?: number;
+  paymentId?: number;
+}): Promise<OutstandingInvoice[]> {
+  const params: Record<string, string | number> = {
+    voucher_type: input.voucherType,
+  };
+
+  if (typeof input.amount === 'number' && input.amount > 0) {
+    params.amount = input.amount;
+  }
+  if (typeof input.paymentId === 'number') {
+    params.payment_id = input.paymentId;
+  }
+
+  const res = await api.get<OutstandingInvoice[]>(`/ledgers/${input.ledgerId}/unpaid-invoices`, { params });
   return res.data;
 }
 

--- a/frontend/src/features/invoices/queryKeys.ts
+++ b/frontend/src/features/invoices/queryKeys.ts
@@ -15,6 +15,20 @@ export const invoiceQueryKeys = {
     financialYearId?: number,
     productId?: number
   ) => ['invoices', 'list', page, pageSize, search, showCancelled, financialYearId ?? 'all', productId ?? 'all'] as const,
+  dues: (
+    page: number,
+    pageSize: number,
+    search: string,
+    ledgerId?: number,
+    dueDateFrom?: string,
+    dueDateTo?: string,
+  ) => ['invoices', 'dues', page, pageSize, search, ledgerId ?? 'all', dueDateFrom ?? 'none', dueDateTo ?? 'none'] as const,
+  outstanding: (
+    ledgerId: number,
+    voucherType: 'receipt' | 'payment',
+    amount?: number,
+    paymentId?: number,
+  ) => ['invoices', 'outstanding', ledgerId, voucherType, amount ?? 'none', paymentId ?? 'none'] as const,
   company: ['company', 'profile'] as const,
   products: ['products', 'lookup'] as const,
 };

--- a/frontend/src/pages/InvoiceDuesPage.tsx
+++ b/frontend/src/pages/InvoiceDuesPage.tsx
@@ -1,0 +1,376 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { fetchCompanyProfile, fetchDueInvoicePage, fetchInvoiceById, fetchLedgers, type DueInvoiceFilters } from '../features/invoices/api';
+import type { CompanyProfile, Invoice, Ledger } from '../types/api';
+import StatusToasts from '../components/StatusToasts';
+import InvoicePreview from '../components/InvoicePreview';
+import formatCurrency from '../utils/formatting';
+import { formatInvoiceDateLabel } from '../utils/invoiceDueDate.ts';
+
+type DueFilterMode = 'all' | 'overdue' | 'next7' | 'next15' | 'custom-days' | 'exact-date';
+
+function addDays(baseDate: Date, days: number) {
+  const next = new Date(baseDate);
+  next.setDate(next.getDate() + days);
+  return next;
+}
+
+function toIsoDate(date: Date) {
+  return date.toISOString().slice(0, 10);
+}
+
+function buildDueWindow(mode: DueFilterMode, customDays: number, exactDate: string) {
+  const today = new Date();
+  const startOfToday = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+
+  switch (mode) {
+    case 'overdue':
+      return { dueDateTo: toIsoDate(addDays(startOfToday, -1)) };
+    case 'next7':
+      return { dueDateFrom: toIsoDate(startOfToday), dueDateTo: toIsoDate(addDays(startOfToday, 7)) };
+    case 'next15':
+      return { dueDateFrom: toIsoDate(startOfToday), dueDateTo: toIsoDate(addDays(startOfToday, 15)) };
+    case 'custom-days':
+      return { dueDateFrom: toIsoDate(startOfToday), dueDateTo: toIsoDate(addDays(startOfToday, Math.max(customDays, 0))) };
+    case 'exact-date':
+      return exactDate ? { dueDateFrom: exactDate, dueDateTo: exactDate } : {};
+    case 'all':
+    default:
+      return {};
+  }
+}
+
+function dueBadgeLabel(dueInDays: number | null) {
+  if (dueInDays === null) return 'No due date';
+  if (dueInDays < 0) return `${Math.abs(dueInDays)} days overdue`;
+  if (dueInDays === 0) return 'Due today';
+  return `Due in ${dueInDays} days`;
+}
+
+export default function InvoiceDuesPage() {
+  const [company, setCompany] = useState<CompanyProfile | null>(null);
+  const [ledgers, setLedgers] = useState<Ledger[]>([]);
+  const [items, setItems] = useState<Invoice[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [pageSize] = useState(20);
+  const [totalPages, setTotalPages] = useState(1);
+  const [search, setSearch] = useState('');
+  const [searchDraft, setSearchDraft] = useState('');
+  const [ledgerId, setLedgerId] = useState<number | undefined>(undefined);
+  const [mode, setMode] = useState<DueFilterMode>('overdue');
+  const [customDays, setCustomDays] = useState(30);
+  const [exactDate, setExactDate] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [previewInvoice, setPreviewInvoice] = useState<Invoice | null>(null);
+
+  const currencyCode = company?.currency_code || 'INR';
+  const dueWindow = useMemo(() => buildDueWindow(mode, customDays, exactDate), [mode, customDays, exactDate]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const [companyProfile, ledgerList] = await Promise.all([fetchCompanyProfile(), fetchLedgers()]);
+        if (cancelled) return;
+        setCompany(companyProfile);
+        setLedgers(ledgerList);
+      } catch (err) {
+        if (!cancelled) {
+          setError('Unable to load dues page filters');
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    (async () => {
+      try {
+        setLoading(true);
+        setError('');
+        const filters: DueInvoiceFilters = {
+          page,
+          pageSize,
+          search,
+          ledgerId,
+          dueDateFrom: dueWindow.dueDateFrom,
+          dueDateTo: dueWindow.dueDateTo,
+        };
+        const response = await fetchDueInvoicePage(filters);
+        if (cancelled) return;
+        setItems(response.items);
+        setTotal(response.total);
+        setTotalPages(response.total_pages);
+      } catch (err) {
+        if (!cancelled) {
+          setItems([]);
+          setTotal(0);
+          setTotalPages(1);
+          setError('Unable to load due invoices');
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [dueWindow.dueDateFrom, dueWindow.dueDateTo, ledgerId, page, pageSize, search]);
+
+  async function handlePreviewInvoice(invoiceId: number) {
+    try {
+      setError('');
+      const invoice = await fetchInvoiceById(invoiceId);
+      setPreviewInvoice(invoice);
+    } catch (err) {
+      setError('Unable to load invoice preview');
+    }
+  }
+
+  const outstandingTotal = items.reduce((sum, invoice) => sum + invoice.outstanding_amount, 0);
+
+  return (
+    <div className="page-grid">
+      <section className="page-hero">
+        <div>
+          <p className="eyebrow">Invoices</p>
+          <h1 className="page-title">Dues</h1>
+          <p className="section-copy">Track overdue and upcoming invoice dues, narrow by ledger, and preview invoices before following up.</p>
+        </div>
+        <div className="status-chip">{total} invoices</div>
+      </section>
+
+      <StatusToasts error={error} onClearError={() => setError('')} onClearSuccess={() => {}} />
+
+      <section className="content-grid">
+        <article className="panel stack">
+          <div className="panel__header">
+            <div>
+              <p className="eyebrow">Filters</p>
+              <h2 className="nav-panel__title">Due window</h2>
+            </div>
+          </div>
+
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px' }}>
+            {[
+              { value: 'overdue', label: 'Overdue' },
+              { value: 'next7', label: 'Next 7 days' },
+              { value: 'next15', label: 'Next 15 days' },
+              { value: 'custom-days', label: 'Custom days' },
+              { value: 'exact-date', label: 'Exact date' },
+              { value: 'all', label: 'All dues' },
+            ].map((option) => (
+              <button
+                key={option.value}
+                type="button"
+                className={mode === option.value ? 'button button--primary button--small' : 'button button--ghost button--small'}
+                onClick={() => {
+                  setMode(option.value as DueFilterMode);
+                  setPage(1);
+                }}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+
+          <div className="field-grid">
+            <div className="field">
+              <label htmlFor="dues-search">Search</label>
+              <input
+                id="dues-search"
+                className="input"
+                type="text"
+                value={searchDraft}
+                placeholder="Invoice number or ledger"
+                onChange={(event) => setSearchDraft(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter') {
+                    setSearch(searchDraft.trim());
+                    setPage(1);
+                  }
+                }}
+              />
+            </div>
+            <div className="field">
+              <label htmlFor="dues-ledger">Ledger</label>
+              <select
+                id="dues-ledger"
+                className="input"
+                value={ledgerId ?? ''}
+                onChange={(event) => {
+                  setLedgerId(event.target.value ? Number(event.target.value) : undefined);
+                  setPage(1);
+                }}
+              >
+                <option value="">All ledgers</option>
+                {ledgers.map((ledger) => (
+                  <option key={ledger.id} value={ledger.id}>{ledger.name}</option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          {mode === 'custom-days' ? (
+            <div className="field">
+              <label htmlFor="dues-custom-days">Days ahead</label>
+              <input
+                id="dues-custom-days"
+                className="input"
+                type="number"
+                min="0"
+                step="1"
+                value={customDays}
+                onChange={(event) => {
+                  setCustomDays(parseInt(event.target.value || '0', 10));
+                  setPage(1);
+                }}
+              />
+            </div>
+          ) : null}
+
+          {mode === 'exact-date' ? (
+            <div className="field">
+              <label htmlFor="dues-exact-date">Exact due date</label>
+              <input
+                id="dues-exact-date"
+                className="input"
+                type="date"
+                value={exactDate}
+                onChange={(event) => {
+                  setExactDate(event.target.value);
+                  setPage(1);
+                }}
+              />
+            </div>
+          ) : null}
+
+          <div style={{ display: 'flex', gap: '10px' }}>
+            <button
+              type="button"
+              className="button button--secondary"
+              onClick={() => {
+                setSearch(searchDraft.trim());
+                setPage(1);
+              }}
+            >
+              Apply search
+            </button>
+            <button
+              type="button"
+              className="button button--ghost"
+              onClick={() => {
+                setMode('overdue');
+                setLedgerId(undefined);
+                setSearch('');
+                setSearchDraft('');
+                setCustomDays(30);
+                setExactDate('');
+                setPage(1);
+              }}
+            >
+              Reset filters
+            </button>
+          </div>
+
+          <div className="summary-box">
+            <p className="eyebrow">Visible outstanding</p>
+            <p className="summary-box__value">{formatCurrency(outstandingTotal, currencyCode)}</p>
+            <p className="muted-text">Current page total across {items.length} invoices</p>
+          </div>
+        </article>
+
+        <article className="panel stack">
+          <div className="panel__header">
+            <div>
+              <p className="eyebrow">Invoices</p>
+              <h2 className="nav-panel__title">Due list</h2>
+            </div>
+            <div className="status-chip">Page {page} of {Math.max(totalPages, 1)}</div>
+          </div>
+
+          <div className="invoice-list">
+            {loading ? <div className="empty-state">Loading due invoices...</div> : null}
+            {!loading && items.length === 0 ? <div className="empty-state">No invoices match the selected due filters.</div> : null}
+            {!loading
+              ? items.map((invoice) => (
+                  <div key={invoice.id} className="invoice-row">
+                    <div className="invoice-row__meta">
+                      <strong>{invoice.invoice_number || `#${invoice.id}`}</strong>
+                      <span className="table-subtext">
+                        {invoice.ledger_name || 'Unknown ledger'}
+                        {' · '}
+                        Invoice {formatInvoiceDateLabel(invoice.invoice_date)}
+                        {' · '}
+                        Due {formatInvoiceDateLabel(invoice.due_date)}
+                      </span>
+                      <span className="table-subtext">
+                        {dueBadgeLabel(invoice.due_in_days)}
+                        {' · '}
+                        Status {invoice.payment_status}
+                        {' · '}
+                        Remaining {formatCurrency(invoice.outstanding_amount, currencyCode)}
+                      </span>
+                    </div>
+                    <span className="invoice-row__price">{formatCurrency(invoice.total_amount, currencyCode)}</span>
+                    <div style={{ display: 'flex', gap: '6px' }}>
+                      {invoice.ledger_id ? (
+                        <Link className="button button--ghost button--small" to={`/ledgers/${invoice.ledger_id}`}>
+                          Ledger
+                        </Link>
+                      ) : null}
+                      <button
+                        type="button"
+                        className="button button--ghost button--small"
+                        onClick={() => void handlePreviewInvoice(invoice.id)}
+                      >
+                        View
+                      </button>
+                    </div>
+                  </div>
+                ))
+              : null}
+          </div>
+
+          <div style={{ display: 'flex', justifyContent: 'space-between', gap: '12px' }}>
+            <button
+              type="button"
+              className="button button--ghost"
+              disabled={page <= 1}
+              onClick={() => setPage((current) => Math.max(current - 1, 1))}
+            >
+              Previous
+            </button>
+            <button
+              type="button"
+              className="button button--ghost"
+              disabled={page >= totalPages}
+              onClick={() => setPage((current) => current + 1)}
+            >
+              Next
+            </button>
+          </div>
+        </article>
+      </section>
+
+      {previewInvoice ? (
+        <InvoicePreview
+          invoice={previewInvoice}
+          onClose={() => setPreviewInvoice(null)}
+          onError={(message) => setError(message)}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/pages/InvoicesPage.tsx
+++ b/frontend/src/pages/InvoicesPage.tsx
@@ -12,6 +12,7 @@ import LedgerCombobox from '../components/LedgerCombobox';
 import { useEscapeClose } from '../hooks/useEscapeClose';
 import formatCurrency from '../utils/formatting';
 import { formatInvoiceTaxBreakdown, isInterstateSupply } from '../utils/invoiceTax';
+import { createDueDateFormState, formatInvoiceDateLabel, resolveDueDate, type DueDateMode } from '../utils/invoiceDueDate.ts';
 import {
   applyOpeningBalanceSide,
   openingBalanceMagnitude,
@@ -68,6 +69,9 @@ export default function InvoicesPage() {
   const [listTab, setListTab] = useState<'invoices' | 'payments'>('invoices');
   const [loadingPayments, setLoadingPayments] = useState(false);
   const [invoiceDate, setInvoiceDate] = useState(new Date().toISOString().slice(0, 10));
+  const [dueDateMode, setDueDateMode] = useState<DueDateMode>('none');
+  const [dueDate, setDueDate] = useState('');
+  const [dueDateDays, setDueDateDays] = useState('');
   const [showLedgerModal, setShowLedgerModal] = useState(false);
   const [showProductModal, setShowProductModal] = useState(false);
   const [showStockModal, setShowStockModal] = useState(false);
@@ -236,6 +240,12 @@ export default function InvoicesPage() {
   const activeCurrencyCode = company?.currency_code || 'USD';
   const selectedLedger = ledgers.find((entry) => entry.id === Number(selectedLedgerId));
   const composerInterstateSupply = isInterstateSupply(company?.gst, selectedLedger?.gst);
+  const resolvedDueDate = resolveDueDate({
+    mode: dueDateMode,
+    invoiceDate,
+    exactDate: dueDate,
+    daysFromInvoice: dueDateDays,
+  });
 
   function addItem() {
     const defaultProduct = products[0];
@@ -264,6 +274,9 @@ export default function InvoicesPage() {
     setItems([createItem(1, String(defaultProduct?.id ?? ''), String(defaultProduct?.price ?? ''))]);
     setNextItemId(2);
     setInvoiceDate(new Date().toISOString().slice(0, 10));
+    setDueDateMode('none');
+    setDueDate('');
+    setDueDateDays('');
   }
 
   function startEditingInvoice(invoice: Invoice) {
@@ -286,6 +299,10 @@ export default function InvoicesPage() {
     setApplyRoundOff(invoice.apply_round_off ?? false);
     setSelectedLedgerId(String(invoice.ledger_id));
     setInvoiceDate(invoice.invoice_date ? invoice.invoice_date.slice(0, 10) : new Date().toISOString().slice(0, 10));
+    const dueDateState = createDueDateFormState(invoice.due_date);
+    setDueDateMode(dueDateState.mode);
+    setDueDate(dueDateState.exactDate);
+    setDueDateDays(dueDateState.daysFromInvoice);
 
     const nextItems = invoice.items.map((line, index) => ({
       id: index + 1,
@@ -341,6 +358,7 @@ export default function InvoicesPage() {
         ledger_id: Number(selectedLedgerId),
         voucher_type: voucherType,
         invoice_date: invoiceDate,
+        due_date: resolvedDueDate,
         supplier_invoice_number: voucherType === 'purchase' ? (supplierInvoiceNumber.trim() || null) : null,
         tax_inclusive: taxInclusive,
         apply_round_off: applyRoundOff,
@@ -663,6 +681,64 @@ export default function InvoicesPage() {
                   </p>
                 ) : null}
               </div>
+
+              {voucherType !== 'payment' ? (
+                <>
+                  <div className="field">
+                    <label htmlFor="invoice-due-mode">Due date</label>
+                    <select
+                      id="invoice-due-mode"
+                      className="select"
+                      value={dueDateMode}
+                      onChange={(event) => setDueDateMode(event.target.value as DueDateMode)}
+                    >
+                      <option value="none">No due date</option>
+                      <option value="exact">Choose exact date</option>
+                      <option value="days">Set days from invoice date</option>
+                    </select>
+                  </div>
+
+                  {dueDateMode === 'exact' ? (
+                    <div className="field">
+                      <label htmlFor="invoice-due-date">Exact due date</label>
+                      <input
+                        id="invoice-due-date"
+                        className="input"
+                        type="date"
+                        value={dueDate}
+                        min={invoiceDate || undefined}
+                        onChange={(event) => setDueDate(event.target.value)}
+                      />
+                    </div>
+                  ) : null}
+
+                  {dueDateMode === 'days' ? (
+                    <div className="field">
+                      <label htmlFor="invoice-due-days">Days from invoice date</label>
+                      <input
+                        id="invoice-due-days"
+                        className="input"
+                        type="number"
+                        min="0"
+                        step="1"
+                        value={dueDateDays}
+                        onChange={(event) => setDueDateDays(event.target.value)}
+                        placeholder="0"
+                      />
+                    </div>
+                  ) : null}
+
+                  {dueDateMode !== 'none' ? (
+                    <div className="field" style={{ gridColumn: '1 / -1' }}>
+                      <p className="muted-text" style={{ margin: 0 }}>
+                        {resolvedDueDate
+                          ? `Resolved due date: ${formatInvoiceDateLabel(resolvedDueDate)}`
+                          : 'Select a valid due date or enter the number of days from the invoice date.'}
+                      </p>
+                    </div>
+                  ) : null}
+                </>
+              ) : null}
 
               {voucherType === 'purchase' ? (
                 <div className="field">

--- a/frontend/src/pages/LedgerViewPage.tsx
+++ b/frontend/src/pages/LedgerViewPage.tsx
@@ -132,6 +132,16 @@ export default function LedgerViewPage() {
   const [submittingEditPayment, setSubmittingEditPayment] = useState(false);
   const [confirmDeletePaymentId, setConfirmDeletePaymentId] = useState<number | null>(null);
   const [deletingPayment, setDeletingPayment] = useState(false);
+  const [allocationCreateSearch, setAllocationCreateSearch] = useState('');
+  const [allocationEditSearch, setAllocationEditSearch] = useState('');
+
+  useEffect(() => {
+    if (!showPaymentForm) setAllocationCreateSearch('');
+  }, [showPaymentForm]);
+
+  useEffect(() => {
+    if (!editingPayment) setAllocationEditSearch('');
+  }, [editingPayment]);
 
   useEffect(() => {
     if (!showActionsDropdown) return;
@@ -273,6 +283,8 @@ export default function LedgerViewPage() {
     voucherType: PaymentCreate['voucher_type'] | PaymentUpdate['voucher_type'];
     onChange: (allocations: PaymentInvoiceAllocation[]) => void;
     title: string;
+    searchQuery: string;
+    onSearchChange: (q: string) => void;
   }) {
     if (input.voucherType !== 'receipt' && input.voucherType !== 'payment') {
       return null;
@@ -280,6 +292,11 @@ export default function LedgerViewPage() {
 
     const allocatedTotal = sumAllocatedAmount(input.allocations);
     const remainingUnallocated = input.amount - allocatedTotal;
+    const filteredInvoices = input.searchQuery.trim()
+      ? input.outstanding.filter((inv) =>
+          (inv.invoice_number ?? '').toLowerCase().includes(input.searchQuery.trim().toLowerCase())
+        )
+      : input.outstanding;
 
     return (
       <div className="summary-box stack" style={{ gap: '12px' }}>
@@ -306,14 +323,28 @@ export default function LedgerViewPage() {
             : `Over-allocated by ${formatCurrency(Math.abs(remainingUnallocated), activeCurrencyCode)}`}
         </p>
 
+        {!input.loading && input.outstanding.length > 0 ? (
+          <input
+            type="search"
+            className="input"
+            placeholder="Search by invoice number…"
+            value={input.searchQuery}
+            onChange={(e) => input.onSearchChange(e.target.value)}
+            aria-label="Search invoices by number"
+          />
+        ) : null}
+
         {input.loading ? <p className="muted-text" style={{ margin: 0 }}>Loading invoice options...</p> : null}
         {!input.loading && input.outstanding.length === 0 ? (
           <p className="muted-text" style={{ margin: 0 }}>No outstanding invoices are available for this ledger.</p>
         ) : null}
+        {!input.loading && input.outstanding.length > 0 && filteredInvoices.length === 0 ? (
+          <p className="muted-text" style={{ margin: 0 }}>No invoices match your search.</p>
+        ) : null}
 
-        {!input.loading && input.outstanding.length > 0 ? (
-          <div className="stack" style={{ gap: '10px' }}>
-            {input.outstanding.map((invoice) => {
+        {!input.loading && filteredInvoices.length > 0 ? (
+          <div className="stack" style={{ gap: '10px', maxHeight: '320px', overflowY: 'auto', paddingRight: '4px' }}>
+            {filteredInvoices.map((invoice) => {
               const existingAllocation = (input.allocations ?? []).find((allocation) => allocation.invoice_id === invoice.id);
               const isSelected = Boolean(existingAllocation);
 
@@ -884,6 +915,8 @@ export default function LedgerViewPage() {
                   voucherType: paymentForm.voucher_type,
                   onChange: (invoice_allocations) => setPaymentForm((current) => ({ ...current, invoice_allocations })),
                   title: 'Allocate against invoices',
+                  searchQuery: allocationCreateSearch,
+                  onSearchChange: setAllocationCreateSearch,
                 })}
                 <button type="submit" className="button button--primary" disabled={submittingPayment} title="Save payment" aria-label="Save payment">
                   {submittingPayment ? 'Saving...' : 'Save'}
@@ -1053,6 +1086,8 @@ export default function LedgerViewPage() {
                   voucherType: editPaymentForm.voucher_type,
                   onChange: (invoice_allocations) => setEditPaymentForm((current) => ({ ...current, invoice_allocations })),
                   title: 'Edit invoice allocations',
+                  searchQuery: allocationEditSearch,
+                  onSearchChange: setAllocationEditSearch,
                 })}
                 <button type="submit" className="button button--primary" disabled={submittingEditPayment} title="Update payment" aria-label="Update payment">
                   {submittingEditPayment ? 'Saving...' : 'Update'}

--- a/frontend/src/pages/LedgerViewPage.tsx
+++ b/frontend/src/pages/LedgerViewPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { ArrowLeft, ChevronDown, FileText, FilePlus, Mail, Pencil, ReceiptText, Trash2 } from 'lucide-react';
 import api, { getApiErrorMessage } from '../api/client';
-import type { CompanyAccount, CompanyProfile, Invoice, Ledger, LedgerStatement, Payment, PaymentCreate, PaymentUpdate, Product } from '../types/api';
+import type { CompanyAccount, CompanyProfile, Invoice, Ledger, LedgerStatement, OutstandingInvoice, Payment, PaymentCreate, PaymentInvoiceAllocation, PaymentUpdate, Product } from '../types/api';
 import InvoicePreview from '../components/InvoicePreview';
 import PaymentReceiptPreview from '../components/PaymentReceiptPreview';
 import StatementPreview from '../components/StatementPreview';
@@ -12,12 +12,84 @@ import SendEmailModal from '../components/SendEmailModal';
 import ConfirmDialog from '../components/ConfirmDialog';
 import formatCurrency from '../utils/formatting';
 import { useFY } from '../context/FYContext';
+import { fetchOutstandingInvoices } from '../features/invoices/api';
+import { formatInvoiceDateLabel } from '../utils/invoiceDueDate.ts';
 
 function defaultDateRange() {
   const today = new Date();
   const firstDay = new Date(today.getFullYear(), today.getMonth(), 1);
   const toIso = (d: Date) => d.toISOString().slice(0, 10);
   return { fromDate: toIso(firstDay), toDate: toIso(today) };
+}
+
+function createDefaultPaymentForm(ledgerId: number): PaymentCreate {
+  return {
+    ledger_id: ledgerId,
+    voucher_type: 'receipt',
+    amount: 0,
+    account_id: null,
+    date: new Date().toISOString().slice(0, 16),
+    mode: '',
+    reference: '',
+    notes: '',
+    invoice_allocations: [],
+  };
+}
+
+function createDefaultEditPaymentForm(): PaymentUpdate {
+  return {
+    voucher_type: 'receipt',
+    amount: 0,
+    account_id: null,
+    date: new Date().toISOString().slice(0, 16),
+    mode: '',
+    reference: '',
+    notes: '',
+    invoice_allocations: [],
+  };
+}
+
+function sumAllocatedAmount(allocations: PaymentInvoiceAllocation[] | undefined): number {
+  return (allocations ?? []).reduce((total, allocation) => total + Number(allocation.allocated_amount || 0), 0);
+}
+
+function buildSuggestedAllocations(invoices: OutstandingInvoice[]): PaymentInvoiceAllocation[] {
+  return invoices
+    .filter((invoice) => (invoice.suggested_allocation_amount || 0) > 0)
+    .map((invoice) => ({
+      invoice_id: invoice.id,
+      invoice_number: invoice.invoice_number,
+      invoice_date: invoice.invoice_date,
+      due_date: invoice.due_date,
+      allocated_amount: invoice.suggested_allocation_amount || 0,
+    }));
+}
+
+function upsertAllocation(
+  allocations: PaymentInvoiceAllocation[] | undefined,
+  invoice: OutstandingInvoice,
+  allocatedAmount: number,
+): PaymentInvoiceAllocation[] {
+  const nextAllocations = [...(allocations ?? [])];
+  const existingIndex = nextAllocations.findIndex((allocation) => allocation.invoice_id === invoice.id);
+  const nextAllocation: PaymentInvoiceAllocation = {
+    invoice_id: invoice.id,
+    invoice_number: invoice.invoice_number,
+    invoice_date: invoice.invoice_date,
+    due_date: invoice.due_date,
+    allocated_amount: allocatedAmount,
+  };
+
+  if (existingIndex >= 0) {
+    nextAllocations[existingIndex] = { ...nextAllocations[existingIndex], ...nextAllocation };
+    return nextAllocations;
+  }
+
+  return [...nextAllocations, nextAllocation];
+}
+
+function removeAllocation(allocations: PaymentInvoiceAllocation[] | undefined, invoiceId: number): PaymentInvoiceAllocation[] {
+  return (allocations ?? []).filter((allocation) => allocation.invoice_id !== invoiceId);
 }
 
 export default function LedgerViewPage() {
@@ -44,16 +116,9 @@ export default function LedgerViewPage() {
   }));
   const [refreshKey, setRefreshKey] = useState(0);
   const [showPaymentForm, setShowPaymentForm] = useState(false);
-  const [paymentForm, setPaymentForm] = useState<PaymentCreate>({
-    ledger_id: ledgerId,
-    voucher_type: 'receipt',
-    amount: 0,
-    account_id: null,
-    date: new Date().toISOString().slice(0, 16),
-    mode: '',
-    reference: '',
-    notes: '',
-  });
+  const [paymentForm, setPaymentForm] = useState<PaymentCreate>(() => createDefaultPaymentForm(ledgerId));
+  const [outstandingInvoices, setOutstandingInvoices] = useState<OutstandingInvoice[]>([]);
+  const [loadingOutstandingInvoices, setLoadingOutstandingInvoices] = useState(false);
   const [submittingPayment, setSubmittingPayment] = useState(false);
   const [showStatementPreview, setShowStatementPreview] = useState(false);
   const [showInvoiceModal, setShowInvoiceModal] = useState(false);
@@ -61,15 +126,9 @@ export default function LedgerViewPage() {
   const [showActionsDropdown, setShowActionsDropdown] = useState(false);
   const actionsDropdownRef = useRef<HTMLDivElement>(null);
   const [editingPayment, setEditingPayment] = useState<Payment | null>(null);
-  const [editPaymentForm, setEditPaymentForm] = useState<PaymentUpdate>({
-    voucher_type: 'receipt',
-    amount: 0,
-    account_id: null,
-    date: new Date().toISOString().slice(0, 16),
-    mode: '',
-    reference: '',
-    notes: '',
-  });
+  const [editPaymentForm, setEditPaymentForm] = useState<PaymentUpdate>(() => createDefaultEditPaymentForm());
+  const [editOutstandingInvoices, setEditOutstandingInvoices] = useState<OutstandingInvoice[]>([]);
+  const [loadingEditOutstandingInvoices, setLoadingEditOutstandingInvoices] = useState(false);
   const [submittingEditPayment, setSubmittingEditPayment] = useState(false);
   const [confirmDeletePaymentId, setConfirmDeletePaymentId] = useState<number | null>(null);
   const [deletingPayment, setDeletingPayment] = useState(false);
@@ -141,7 +200,182 @@ export default function LedgerViewPage() {
     });
   }, [activeFY]);
 
+  useEffect(() => {
+    if (!showPaymentForm) return;
+
+    let cancelled = false;
+    (async () => {
+      try {
+        setLoadingOutstandingInvoices(true);
+        const invoices = await fetchOutstandingInvoices({
+          ledgerId,
+          voucherType: paymentForm.voucher_type as 'receipt' | 'payment',
+          amount: paymentForm.amount > 0 ? paymentForm.amount : undefined,
+        });
+        if (!cancelled) {
+          setOutstandingInvoices(invoices);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(getApiErrorMessage(err, 'Unable to load outstanding invoices'));
+        }
+      } finally {
+        if (!cancelled) {
+          setLoadingOutstandingInvoices(false);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [ledgerId, paymentForm.amount, paymentForm.voucher_type, showPaymentForm]);
+
+  useEffect(() => {
+    if (!editingPayment) return;
+
+    let cancelled = false;
+    (async () => {
+      try {
+        setLoadingEditOutstandingInvoices(true);
+        const invoices = await fetchOutstandingInvoices({
+          ledgerId,
+          voucherType: editPaymentForm.voucher_type as 'receipt' | 'payment',
+          amount: editPaymentForm.amount > 0 ? editPaymentForm.amount : undefined,
+          paymentId: editingPayment.id,
+        });
+        if (!cancelled) {
+          setEditOutstandingInvoices(invoices);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(getApiErrorMessage(err, 'Unable to load invoice allocations'));
+        }
+      } finally {
+        if (!cancelled) {
+          setLoadingEditOutstandingInvoices(false);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [editPaymentForm.amount, editPaymentForm.voucher_type, editingPayment, ledgerId]);
+
   const activeCurrencyCode = company?.currency_code || 'INR';
+
+  function renderAllocationSection(input: {
+    allocations: PaymentInvoiceAllocation[] | undefined;
+    amount: number;
+    outstanding: OutstandingInvoice[];
+    loading: boolean;
+    voucherType: PaymentCreate['voucher_type'] | PaymentUpdate['voucher_type'];
+    onChange: (allocations: PaymentInvoiceAllocation[]) => void;
+    title: string;
+  }) {
+    if (input.voucherType !== 'receipt' && input.voucherType !== 'payment') {
+      return null;
+    }
+
+    const allocatedTotal = sumAllocatedAmount(input.allocations);
+    const remainingUnallocated = input.amount - allocatedTotal;
+
+    return (
+      <div className="summary-box stack" style={{ gap: '12px' }}>
+        <div className="panel__header" style={{ marginBottom: 0 }}>
+          <div>
+            <p className="eyebrow">Invoice Allocation</p>
+            <h3 className="nav-panel__title" style={{ margin: 0 }}>{input.title}</h3>
+          </div>
+          <button
+            type="button"
+            className="button button--secondary button--small"
+            onClick={() => input.onChange(buildSuggestedAllocations(input.outstanding))}
+            disabled={input.loading || input.outstanding.length === 0 || input.amount <= 0}
+          >
+            Auto Select Oldest
+          </button>
+        </div>
+
+        <p className="muted-text" style={{ margin: 0 }}>
+          Allocated {formatCurrency(allocatedTotal, activeCurrencyCode)}
+          {' · '}
+          {remainingUnallocated >= 0
+            ? `Unallocated ${formatCurrency(remainingUnallocated, activeCurrencyCode)}`
+            : `Over-allocated by ${formatCurrency(Math.abs(remainingUnallocated), activeCurrencyCode)}`}
+        </p>
+
+        {input.loading ? <p className="muted-text" style={{ margin: 0 }}>Loading invoice options...</p> : null}
+        {!input.loading && input.outstanding.length === 0 ? (
+          <p className="muted-text" style={{ margin: 0 }}>No outstanding invoices are available for this ledger.</p>
+        ) : null}
+
+        {!input.loading && input.outstanding.length > 0 ? (
+          <div className="stack" style={{ gap: '10px' }}>
+            {input.outstanding.map((invoice) => {
+              const existingAllocation = (input.allocations ?? []).find((allocation) => allocation.invoice_id === invoice.id);
+              const isSelected = Boolean(existingAllocation);
+
+              return (
+                <div key={invoice.id} className="summary-box" style={{ padding: '14px' }}>
+                  <div style={{ display: 'grid', gap: '10px' }}>
+                    <label style={{ display: 'flex', alignItems: 'flex-start', gap: '10px', cursor: 'pointer' }}>
+                      <input
+                        type="checkbox"
+                        checked={isSelected}
+                        onChange={(event) => {
+                          if (!event.target.checked) {
+                            input.onChange(removeAllocation(input.allocations, invoice.id));
+                            return;
+                          }
+
+                          const defaultAmount = invoice.suggested_allocation_amount || invoice.remaining_amount;
+                          input.onChange(upsertAllocation(input.allocations, invoice, defaultAmount));
+                        }}
+                      />
+                      <div style={{ display: 'grid', gap: '4px', flex: 1 }}>
+                        <strong>{invoice.invoice_number || `#${invoice.id}`}</strong>
+                        <span className="table-subtext">
+                          Invoice {formatInvoiceDateLabel(invoice.invoice_date)}
+                          {' · '}
+                          Due {formatInvoiceDateLabel(invoice.due_date)}
+                          {' · '}
+                          Remaining {formatCurrency(invoice.remaining_amount, activeCurrencyCode)}
+                        </span>
+                        <span className="table-subtext">
+                          Status {invoice.payment_status}
+                          {typeof invoice.due_in_days === 'number' ? ` · ${invoice.due_in_days} days` : ''}
+                        </span>
+                      </div>
+                    </label>
+
+                    {isSelected ? (
+                      <div className="field" style={{ marginLeft: '28px' }}>
+                        <label htmlFor={`allocation-${input.title}-${invoice.id}`}>Allocated amount</label>
+                        <input
+                          id={`allocation-${input.title}-${invoice.id}`}
+                          className="input"
+                          type="number"
+                          min="0.01"
+                          step="0.01"
+                          value={existingAllocation?.allocated_amount || ''}
+                          onChange={(event) => {
+                            const nextAmount = parseFloat(event.target.value) || 0;
+                            input.onChange(upsertAllocation(input.allocations, invoice, nextAmount));
+                          }}
+                        />
+                      </div>
+                    ) : null}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        ) : null}
+      </div>
+    );
+  }
 
   async function handleViewInvoice(invoiceId: number) {
     try {
@@ -164,16 +398,8 @@ export default function LedgerViewPage() {
       setError('');
       const res = await api.post<Payment>('/payments/', paymentForm);
       setShowPaymentForm(false);
-      setPaymentForm({
-        ledger_id: ledgerId,
-        voucher_type: 'receipt',
-        amount: 0,
-        account_id: null,
-        date: new Date().toISOString().slice(0, 16),
-        mode: '',
-        reference: '',
-        notes: '',
-      });
+      setPaymentForm(createDefaultPaymentForm(ledgerId));
+      setOutstandingInvoices([]);
       // Refresh statement
       setRefreshKey((k) => k + 1);
       if (res.data.warnings?.includes('invoice_date_outside_fy') && activeFY) {
@@ -201,6 +427,14 @@ export default function LedgerViewPage() {
         mode: res.data.mode || '',
         reference: res.data.reference || '',
         notes: res.data.notes || '',
+        invoice_allocations: (res.data.invoice_allocations ?? []).map((allocation) => ({
+          id: allocation.id,
+          invoice_id: allocation.invoice_id,
+          invoice_number: allocation.invoice_number,
+          invoice_date: allocation.invoice_date,
+          due_date: allocation.due_date,
+          allocated_amount: allocation.allocated_amount,
+        })),
       });
     } catch (err) {
       setError(getApiErrorMessage(err, 'Unable to load payment'));
@@ -219,6 +453,7 @@ export default function LedgerViewPage() {
       setError('');
       await api.put<Payment>(`/payments/${editingPayment.id}`, editPaymentForm);
       setEditingPayment(null);
+      setEditOutstandingInvoices([]);
       setRefreshKey((k) => k + 1);
     } catch (err) {
       setError(getApiErrorMessage(err, 'Unable to update payment'));
@@ -641,6 +876,15 @@ export default function LedgerViewPage() {
                     onChange={(e) => setPaymentForm((f) => ({ ...f, notes: e.target.value }))}
                   />
                 </div>
+                {renderAllocationSection({
+                  allocations: paymentForm.invoice_allocations,
+                  amount: paymentForm.amount,
+                  outstanding: outstandingInvoices,
+                  loading: loadingOutstandingInvoices,
+                  voucherType: paymentForm.voucher_type,
+                  onChange: (invoice_allocations) => setPaymentForm((current) => ({ ...current, invoice_allocations })),
+                  title: 'Allocate against invoices',
+                })}
                 <button type="submit" className="button button--primary" disabled={submittingPayment} title="Save payment" aria-label="Save payment">
                   {submittingPayment ? 'Saving...' : 'Save'}
                 </button>
@@ -801,6 +1045,15 @@ export default function LedgerViewPage() {
                     onChange={(e) => setEditPaymentForm((f) => ({ ...f, notes: e.target.value }))}
                   />
                 </div>
+                {renderAllocationSection({
+                  allocations: editPaymentForm.invoice_allocations,
+                  amount: editPaymentForm.amount ?? 0,
+                  outstanding: editOutstandingInvoices,
+                  loading: loadingEditOutstandingInvoices,
+                  voucherType: editPaymentForm.voucher_type,
+                  onChange: (invoice_allocations) => setEditPaymentForm((current) => ({ ...current, invoice_allocations })),
+                  title: 'Edit invoice allocations',
+                })}
                 <button type="submit" className="button button--primary" disabled={submittingEditPayment} title="Update payment" aria-label="Update payment">
                   {submittingEditPayment ? 'Saving...' : 'Update'}
                 </button>

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -231,9 +231,28 @@ export type Invoice = {
   total_amount: number;
   invoice_date: string;
   due_date: string | null;
+  paid_amount: number;
+  remaining_amount: number;
+  outstanding_amount: number;
+  payment_status: 'unpaid' | 'partial' | 'paid';
+  due_in_days: number | null;
   created_at: string;
   items: InvoiceItem[];
   warnings?: string[];
+};
+
+export type OutstandingInvoice = {
+  id: number;
+  invoice_number: string | null;
+  invoice_date: string;
+  due_date: string | null;
+  total_amount: number;
+  paid_amount: number;
+  remaining_amount: number;
+  outstanding_amount: number;
+  payment_status: 'unpaid' | 'partial' | 'paid';
+  due_in_days: number | null;
+  suggested_allocation_amount: number | null;
 };
 
 export type InvoiceItem = {
@@ -419,6 +438,15 @@ export type TaxLedger = {
 
 export type PaymentVoucherType = 'receipt' | 'payment' | 'opening_balance';
 
+export type PaymentInvoiceAllocation = {
+  id?: number | null;
+  invoice_id: number;
+  invoice_number?: string | null;
+  invoice_date?: string | null;
+  due_date?: string | null;
+  allocated_amount: number;
+};
+
 export type Payment = {
   id: number;
   ledger_id: number | null;
@@ -436,6 +464,7 @@ export type Payment = {
   created_by: number;
   created_at: string;
   warnings?: string[];
+  invoice_allocations: PaymentInvoiceAllocation[];
 };
 
 export type PaymentUpdate = {
@@ -446,6 +475,7 @@ export type PaymentUpdate = {
   mode?: string;
   reference?: string;
   notes?: string;
+  invoice_allocations?: PaymentInvoiceAllocation[];
 };
 
 export type PaymentCreate = {
@@ -457,6 +487,7 @@ export type PaymentCreate = {
   mode?: string;
   reference?: string;
   notes?: string;
+  invoice_allocations?: PaymentInvoiceAllocation[];
 };
 
 export type UserProfile = {

--- a/frontend/src/utils/invoiceDueDate.ts
+++ b/frontend/src/utils/invoiceDueDate.ts
@@ -1,0 +1,72 @@
+export type DueDateMode = 'none' | 'exact' | 'days';
+
+export type DueDateFormState = {
+  mode: DueDateMode;
+  exactDate: string;
+  daysFromInvoice: string;
+};
+
+function parseIsoDateParts(value: string): [number, number, number] | null {
+  const parts = value.split('-').map(Number);
+  if (parts.length !== 3 || parts.some((part) => Number.isNaN(part))) {
+    return null;
+  }
+  return [parts[0], parts[1], parts[2]];
+}
+
+export function addDaysToIsoDate(value: string, days: number): string {
+  const parsed = parseIsoDateParts(value);
+  if (!parsed) {
+    return '';
+  }
+
+  const [year, month, day] = parsed;
+  const nextDate = new Date(Date.UTC(year, month - 1, day));
+  nextDate.setUTCDate(nextDate.getUTCDate() + days);
+  return nextDate.toISOString().slice(0, 10);
+}
+
+export function resolveDueDate(input: {
+  mode: DueDateMode;
+  invoiceDate: string;
+  exactDate: string;
+  daysFromInvoice: string;
+}): string | undefined {
+  if (input.mode === 'none') {
+    return undefined;
+  }
+
+  if (input.mode === 'exact') {
+    return input.exactDate || undefined;
+  }
+
+  const parsedDays = Number.parseInt(input.daysFromInvoice, 10);
+  if (Number.isNaN(parsedDays) || parsedDays < 0 || !input.invoiceDate) {
+    return undefined;
+  }
+
+  return addDaysToIsoDate(input.invoiceDate, parsedDays);
+}
+
+export function createDueDateFormState(dueDate?: string | null): DueDateFormState {
+  if (!dueDate) {
+    return {
+      mode: 'none',
+      exactDate: '',
+      daysFromInvoice: '',
+    };
+  }
+
+  return {
+    mode: 'exact',
+    exactDate: dueDate.slice(0, 10),
+    daysFromInvoice: '',
+  };
+}
+
+export function formatInvoiceDateLabel(value: string | null | undefined): string {
+  if (!value) {
+    return '\u2014';
+  }
+  return new Date(value).toLocaleDateString();
+}


### PR DESCRIPTION
## Summary

The Invoice Allocation section inside the **Record Receipt / Payment** (and Edit Payment) modal could grow very tall when a ledger has many outstanding invoices, making the modal difficult to use. This PR caps it and adds filtering.

**Changes:**
- Invoice list is now scrollable with a `max-height: 320px` — the modal no longer grows unboundedly.
- A **search-by-invoice-number** input is rendered above the list, filtering results in real time as the user types.
- When the search returns no matches, a "No invoices match your search." message is shown.
- Search query resets automatically when either modal is closed.
- Both the **Record Receipt/Payment** and **Edit Payment** modals are updated.

## Type of change

- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs (documentation)
- [ ] test (tests)
- [ ] chore/refactor

## How to test

1. Open a ledger that has several outstanding invoices.
2. Click **Record Receipt / Payment**.
3. Select Receipt or Payment — the Invoice Allocation section should appear.
4. Confirm the list scrolls after ~4–5 invoices rather than expanding.
5. Type a partial invoice number in the search box — the list filters accordingly.
6. Clear the search or close the modal — the search resets.
7. Repeat via **Edit** on an existing payment — same behaviour applies.

## Checklist

- [x] My code follows the project style and conventions
- [ ] I added/updated tests where appropriate
- [x] I updated docs where needed
- [x] I ran relevant checks locally
- [x] I verified this does not break existing behavior

## Screenshots (if UI changes)

Scrollable list + search input shown above invoice rows in the allocation section.

## Related issue

Closes #
