### PR TITLE
feat(invoices): add sales invoice reference notes field

### DIFF
--- a/backend/migrations/20260426000001_add_reference_notes_to_invoices.py
+++ b/backend/migrations/20260426000001_add_reference_notes_to_invoices.py
@@ -1,0 +1,15 @@
+"""
+Add reference_notes field to invoices.
+"""
+
+from sqlalchemy import text
+
+
+def up(conn) -> None:
+    conn.execute(text("""
+        ALTER TABLE invoices ADD COLUMN IF NOT EXISTS reference_notes VARCHAR(255);
+    """))
+
+
+def down(conn) -> None:
+    conn.execute(text("ALTER TABLE invoices DROP COLUMN IF EXISTS reference_notes"))

--- a/backend/src/api/routes/invoices.py
+++ b/backend/src/api/routes/invoices.py
@@ -227,6 +227,7 @@ def _apply_payload_to_invoice(
     invoice.company_ifsc_code = company.ifsc_code if company else None
     invoice.voucher_type = payload.voucher_type
     invoice.supplier_invoice_number = payload.supplier_invoice_number
+    invoice.reference_notes = payload.reference_notes
     if created_by is not None:
         invoice.created_by = created_by
     if financial_year_id is not None:

--- a/backend/src/api/routes/invoices.py
+++ b/backend/src/api/routes/invoices.py
@@ -1190,6 +1190,13 @@ def _build_invoice_html(invoice: Invoice, products: list[Product], invoice_bank_
     )
     tax_breakup_rows = _build_pdf_tax_breakup_rows(invoice, currency)
     payment_details_html = _build_pdf_payment_details_html(invoice_bank_accounts)
+    reference_notes_html = ""
+    if invoice.reference_notes:
+        reference_notes_html = f"""
+  <section class=\"invoice-sheet__reference-notes\">
+    <p class=\"eyebrow\">Reference notes</p>
+    <p class=\"invoice-sheet__reference-notes-value\">{_e(invoice.reference_notes)}</p>
+  </section>"""
 
     html = f"""<!DOCTYPE html>
 <html>
@@ -1274,6 +1281,17 @@ def _build_invoice_html(invoice: Invoice, products: list[Product], invoice_bank_
     font-size: 9px;
     color: #4b5563;
     margin-bottom: 1px;
+  }}
+  .invoice-sheet__reference-notes {{
+    border: 1px dashed #d1d5db;
+    border-radius: 6px;
+    padding: 10px 14px;
+    margin-bottom: 14px;
+    background: #f9fafb;
+  }}
+  .invoice-sheet__reference-notes-value {{
+    font-size: 9px;
+    color: #374151;
   }}
   .invoice-sheet__table {{
     width: 100%;
@@ -1420,6 +1438,8 @@ def _build_invoice_html(invoice: Invoice, products: list[Product], invoice_bank_
     <p>{_e(invoice.ledger_address) or 'Address not provided'}</p>
     <p>{billto_details}</p>
   </section>
+
+  {reference_notes_html}
 
   <section>
     <table class="invoice-sheet__table">

--- a/backend/src/models/invoice.py
+++ b/backend/src/models/invoice.py
@@ -29,6 +29,7 @@ class Invoice(Base):
     company_ifsc_code = Column(String, nullable=True)
     voucher_type = Column(String, nullable=False, default="sales")
     supplier_invoice_number = Column(String, nullable=True)
+    reference_notes = Column(String, nullable=True)
     status = Column(String, nullable=False, default="active")
     credit_status = Column(String, nullable=False, default="not_credited")
     created_by = Column(Integer, ForeignKey("users.id"), nullable=False)

--- a/backend/src/schemas/invoice.py
+++ b/backend/src/schemas/invoice.py
@@ -17,6 +17,7 @@ class InvoiceCreate(BaseModel):
     invoice_date: Optional[date] = None
     due_date: Optional[date] = None
     supplier_invoice_number: str | None = None
+    reference_notes: str | None = None
     tax_inclusive: bool = False
     apply_round_off: bool = False
     items: List[InvoiceItemCreate]
@@ -63,6 +64,7 @@ class InvoiceOut(BaseModel):
     company_ifsc_code: str | None = None
     voucher_type: str
     supplier_invoice_number: str | None = None
+    reference_notes: str | None = None
     status: str = "active"
     credit_status: str = "not_credited"
     ledger: LedgerOut | None = None

--- a/backend/tests/api/test_invoice_reference_notes.py
+++ b/backend/tests/api/test_invoice_reference_notes.py
@@ -1,0 +1,91 @@
+from unittest.mock import patch
+
+
+def _create_ledger(client, name: str, gst: str):
+    response = client.post(
+        "/api/ledgers/",
+        json={
+            "name": name,
+            "address": "Mumbai",
+            "gst": gst,
+            "phone_number": "9999999999",
+            "email": f"{name.lower().replace(' ', '')}@example.com",
+            "website": "",
+            "bank_name": "",
+            "branch_name": "",
+            "account_name": "",
+            "account_number": "",
+            "ifsc_code": "",
+        },
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["id"]
+
+
+def _create_product(client):
+    response = client.post(
+        "/api/products/",
+        json={
+            "sku": "REF-NOTE-001",
+            "name": "Reference Notes Product",
+            "description": "",
+            "hsn_sac": "9988",
+            "price": 100,
+            "gst_rate": 18,
+        },
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["id"]
+
+
+def _add_inventory(client, product_id: int, quantity: int):
+    response = client.post(
+        "/api/inventory/adjust",
+        json={
+            "product_id": product_id,
+            "quantity": quantity,
+        },
+    )
+    assert response.status_code == 200, response.text
+
+
+def test_sales_invoice_reference_notes_round_trip(client):
+    with patch("src.api.routes.invoices._generate_next_number", return_value="SAL-000001"):
+        ledger_id = _create_ledger(client, name="Sales Ledger", gst="27ABCDE9999F1Z5")
+        product_id = _create_product(client)
+        _add_inventory(client, product_id=product_id, quantity=20)
+
+        create_response = client.post(
+            "/api/invoices/",
+            json={
+                "ledger_id": ledger_id,
+                "voucher_type": "sales",
+                "reference_notes": "PO-2026-001",
+                "tax_inclusive": False,
+                "apply_round_off": False,
+                "items": [{"product_id": product_id, "quantity": 2, "unit_price": 100}],
+            },
+        )
+
+        assert create_response.status_code == 200, create_response.text
+        created_invoice = create_response.json()
+        assert created_invoice["reference_notes"] == "PO-2026-001"
+
+        get_response = client.get(f"/api/invoices/{created_invoice['id']}")
+        assert get_response.status_code == 200, get_response.text
+        assert get_response.json()["reference_notes"] == "PO-2026-001"
+
+        update_response = client.put(
+            f"/api/invoices/{created_invoice['id']}",
+            json={
+                "ledger_id": ledger_id,
+                "voucher_type": "sales",
+                "reference_notes": "PO-2026-002",
+                "tax_inclusive": False,
+                "apply_round_off": False,
+                "items": [{"product_id": product_id, "quantity": 2, "unit_price": 100}],
+            },
+        )
+
+        assert update_response.status_code == 200, update_response.text
+        assert update_response.json()["reference_notes"] == "PO-2026-002"

--- a/frontend/e2e/invoices.spec.ts
+++ b/frontend/e2e/invoices.spec.ts
@@ -282,6 +282,22 @@ test.describe('Invoices', () => {
     await expect(page.locator('#invoice-supplier-ref')).not.toBeVisible();
   });
 
+  test('reference notes field is visible for sales invoices', async ({ authedPage: page }) => {
+    await page.click('[href="/invoices"]');
+    await page.waitForTimeout(500);
+
+    await page.selectOption('#invoice-voucher-type', 'sales');
+    await expect(page.locator('#invoice-reference-notes')).toBeVisible();
+  });
+
+  test('reference notes field is hidden for purchase invoices', async ({ authedPage: page }) => {
+    await page.click('[href="/invoices"]');
+    await page.waitForTimeout(500);
+
+    await page.selectOption('#invoice-voucher-type', 'purchase');
+    await expect(page.locator('#invoice-reference-notes')).not.toBeVisible();
+  });
+
   test('supplier invoice # field is visible for purchase invoices', async ({ authedPage: page }) => {
     await page.click('[href="/invoices"]');
     await page.waitForTimeout(500);
@@ -356,6 +372,29 @@ test.describe('Invoices', () => {
 
     // Supplier ref field should be populated
     await expect(page.locator('#invoice-supplier-ref')).toHaveValue(supplierRef);
+  });
+
+  test('edit preserves reference notes for sales invoice', async ({ authedPage: page }) => {
+    const { sku, ledgerName } = await seedInvoiceData(page);
+    const referenceNotes = `PO-${Date.now().toString(36).toUpperCase()}`;
+
+    await page.click('[href="/invoices"]');
+    await page.waitForTimeout(500);
+
+    await page.selectOption('#invoice-voucher-type', 'sales');
+    await selectComboboxOption(page, 'invoice-ledger', ledgerName);
+    const productInputId = (await page.locator('[id^="invoice-product-"]').first().getAttribute('id')) || 'invoice-product-1';
+    await selectComboboxOption(page, productInputId, sku);
+    await page.locator('[id^="invoice-quantity-"]').first().fill('2');
+    await page.fill('#invoice-reference-notes', referenceNotes);
+    await page.click('button:has-text("Create invoice")');
+    await expectSuccess(page, 'Sales invoice created');
+
+    await openInvoiceFeed(page);
+    const invoiceCard = page.locator('.invoice-compact-card', { hasText: ledgerName }).first();
+    await invoiceCard.locator('button[title="Edit"]').click();
+
+    await expect(page.locator('#invoice-reference-notes')).toHaveValue(referenceNotes);
   });
 
   test('tax-inclusive checkbox is unchecked by default', async ({ authedPage: page }) => {

--- a/frontend/src/components/CreateInvoiceModal.tsx
+++ b/frontend/src/components/CreateInvoiceModal.tsx
@@ -49,6 +49,7 @@ export default function CreateInvoiceModal({
   const [dueDateMode, setDueDateMode] = useState<DueDateMode>('none');
   const [dueDate, setDueDate] = useState('');
   const [dueDateDays, setDueDateDays] = useState('');
+  const [referenceNotes, setReferenceNotes] = useState('');
   const [items, setItems] = useState<InvoiceFormItem[]>([createItem(1)]);
   const [nextItemId, setNextItemId] = useState(2);
   const [loading, setLoading] = useState(true);
@@ -140,6 +141,7 @@ export default function CreateInvoiceModal({
         voucher_type: voucherType,
         invoice_date: invoiceDate,
         due_date: resolvedDueDate ?? invoiceDate,
+        reference_notes: voucherType === 'sales' ? (referenceNotes.trim() || null) : null,
         tax_inclusive: taxInclusive,
         items: items.map((item) => ({
           product_id: Number(item.productId),
@@ -267,6 +269,20 @@ export default function CreateInvoiceModal({
                     value={dueDateDays}
                     onChange={(e) => setDueDateDays(e.target.value)}
                     placeholder="0"
+                  />
+                </div>
+              ) : null}
+
+              {voucherType === 'sales' ? (
+                <div className="field" style={{ gridColumn: '1 / -1' }}>
+                  <label htmlFor="modal-inv-reference-notes">Reference Notes</label>
+                  <input
+                    id="modal-inv-reference-notes"
+                    className="input"
+                    type="text"
+                    value={referenceNotes}
+                    onChange={(e) => setReferenceNotes(e.target.value)}
+                    placeholder="PO number or customer reference"
                   />
                 </div>
               ) : null}

--- a/frontend/src/pages/InvoicesPage.tsx
+++ b/frontend/src/pages/InvoicesPage.tsx
@@ -62,6 +62,7 @@ export default function InvoicesPage() {
   const [taxInclusive, setTaxInclusive] = useState(false);
   const [applyRoundOff, setApplyRoundOff] = useState(false);
   const [supplierInvoiceNumber, setSupplierInvoiceNumber] = useState('');
+  const [referenceNotes, setReferenceNotes] = useState('');
   const [paymentMode, setPaymentMode] = useState('cash');
   const [paymentReference, setPaymentReference] = useState('');
   const [selectedPaymentAccountId, setSelectedPaymentAccountId] = useState('');
@@ -273,6 +274,7 @@ export default function InvoicesPage() {
   function resetInvoiceForm() {
     setEditingInvoiceId(null);
     setSupplierInvoiceNumber('');
+    setReferenceNotes('');
     setTaxInclusive(false);
     setApplyRoundOff(false);
     setPaymentMode('cash');
@@ -304,6 +306,7 @@ export default function InvoicesPage() {
     setEditingInvoiceId(invoice.id);
     setVoucherType(invoice.voucher_type);
     setSupplierInvoiceNumber(invoice.supplier_invoice_number ?? '');
+    setReferenceNotes(invoice.voucher_type === 'sales' ? (invoice.reference_notes ?? '') : '');
     setTaxInclusive(invoice.tax_inclusive ?? false);
     setApplyRoundOff(invoice.apply_round_off ?? false);
     setSelectedLedgerId(String(invoice.ledger_id));
@@ -369,6 +372,7 @@ export default function InvoicesPage() {
         invoice_date: invoiceDate,
         due_date: resolvedDueDate ?? invoiceDate,
         supplier_invoice_number: voucherType === 'purchase' ? (supplierInvoiceNumber.trim() || null) : null,
+        reference_notes: voucherType === 'sales' ? (referenceNotes.trim() || null) : null,
         tax_inclusive: taxInclusive,
         apply_round_off: applyRoundOff,
         items: items.map((item) => ({
@@ -760,6 +764,23 @@ export default function InvoicesPage() {
                     onChange={(event) => setSupplierInvoiceNumber(event.target.value)}
                     placeholder="Supplier's invoice number"
                   />
+                </div>
+              ) : null}
+
+              {voucherType === 'sales' ? (
+                <div className="field">
+                  <label htmlFor="invoice-reference-notes">Reference Notes</label>
+                  <input
+                    id="invoice-reference-notes"
+                    className="input"
+                    type="text"
+                    value={referenceNotes}
+                    onChange={(event) => setReferenceNotes(event.target.value)}
+                    placeholder="PO number or customer reference"
+                  />
+                  <p className="muted-text" style={{ marginBottom: 0 }}>
+                    Optional: include PO number or any customer-provided reference.
+                  </p>
                 </div>
               ) : null}
 

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -233,6 +233,7 @@ export type Invoice = {
   apply_round_off: boolean;
   round_off_amount: number;
   supplier_invoice_number?: string | null;
+  reference_notes?: string | null;
   ledger: Ledger | null;
   taxable_amount: number;
   total_tax_amount: number;
@@ -348,6 +349,7 @@ export type InvoiceCreate = {
   invoice_date?: string;
   due_date?: string;
   supplier_invoice_number?: string | null;
+  reference_notes?: string | null;
   tax_inclusive?: boolean;
   apply_round_off?: boolean;
   items: InvoiceItemInput[];


### PR DESCRIPTION
## Summary

Add a new sales invoice field named Reference Notes for customer PO/reference text, persist it end-to-end, and render it on generated sales invoice output.

Implemented in phases:
- Phase 1: backend migration, model, schemas, payload mapping
- Phase 2: sales UI input and PDF rendering
- Phase 3: backend API + e2e test coverage additions

## Type of change

- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs (documentation)
- [x] test (tests)
- [ ] chore/refactor

## How to test

1. `DATABASE_URL=postgresql://simple_user:simple_password@localhost:5432/simple_invoicing /Users/nikhil/Documents/projects/respawn-invoicing/backend/.venv/bin/python -m pytest /Users/nikhil/Documents/projects/respawn-invoicing/backend/tests/api/test_invoice_reference_notes.py -q`
2. `cd /Users/nikhil/Documents/projects/respawn-invoicing/frontend && npm run build`
3. Create a sales invoice with Reference Notes and verify it appears in preview/PDF.
4. Switch to purchase voucher and verify Reference Notes is hidden.

## Checklist

- [x] My code follows the project style and conventions
- [x] I added/updated tests where appropriate
- [ ] I updated docs where needed
- [x] I ran relevant checks locally
- [x] I verified this does not break existing behavior

## Screenshots (if UI changes)

N/A

## Related issue

Closes #