### PR TITLE
feat(inventory): make product inventory tracking optional

### DIFF
--- a/backend/migrations/20260426000002_add_maintain_inventory_to_products.py
+++ b/backend/migrations/20260426000002_add_maintain_inventory_to_products.py
@@ -1,0 +1,16 @@
+"""
+Add maintain_inventory flag to products.
+"""
+
+from sqlalchemy import text
+
+
+def up(conn) -> None:
+    conn.execute(text("""
+        ALTER TABLE products
+        ADD COLUMN IF NOT EXISTS maintain_inventory BOOLEAN NOT NULL DEFAULT TRUE;
+    """))
+
+
+def down(conn) -> None:
+    conn.execute(text("ALTER TABLE products DROP COLUMN IF EXISTS maintain_inventory"))

--- a/backend/src/api/routes/inventory.py
+++ b/backend/src/api/routes/inventory.py
@@ -28,6 +28,8 @@ def adjust_inventory(
     ).first()
     if not product:
         raise HTTPException(status_code=404, detail="Product not found")
+    if not product.maintain_inventory:
+        raise HTTPException(status_code=400, detail="Inventory is disabled for this product")
 
     inventory = db.query(Inventory).filter(
         Inventory.product_id == payload.product_id,
@@ -115,6 +117,7 @@ def list_inventory(
             product_name=product.name,
             sku=product.sku,
             price=float(product.price),
+            maintain_inventory=bool(product.maintain_inventory),
             quantity=int(quantity),
             date_added=product.created_at,
             last_sold_at=last_sold_at,

--- a/backend/src/api/routes/invoices.py
+++ b/backend/src/api/routes/invoices.py
@@ -136,6 +136,15 @@ def _assign_item_tax_split(
 
 def _reverse_existing_invoice_inventory(db: Session, invoice: Invoice) -> None:
     for item in invoice.items:
+        product_query = db.query(Product).filter(Product.id == item.product_id)
+        if invoice.company_id is not None:
+            product_query = product_query.filter(or_(Product.company_id == invoice.company_id, Product.company_id.is_(None)))
+        product = product_query.first()
+        if not product:
+            raise HTTPException(status_code=404, detail=f"Product {item.product_id} not found")
+        if not product.maintain_inventory:
+            continue
+
         reverse_delta = item.quantity if invoice.voucher_type == "sales" else -item.quantity
         _change_inventory_quantity(
             db,
@@ -182,6 +191,8 @@ def _apply_inventory_delta_for_invoice_update(
         product = product_query.first()
         if not product:
             raise HTTPException(status_code=404, detail=f"Product {product_id} not found")
+        if not product.maintain_inventory:
+          continue
 
         _change_inventory_quantity(
             db,
@@ -266,7 +277,7 @@ def _apply_payload_to_invoice(
         if not product:
             raise HTTPException(status_code=404, detail=f"Product {item.product_id} not found")
 
-        if apply_inventory_changes:
+        if apply_inventory_changes and product.maintain_inventory:
             inventory_query = db.query(Inventory).filter(Inventory.product_id == item.product_id)
             if company_id is not None:
                 inventory_query = inventory_query.filter(or_(Inventory.company_id == company_id, Inventory.company_id.is_(None)))
@@ -1626,12 +1637,20 @@ def restore_invoice(
     try:
         # Re-apply inventory changes (reverse the reversal)
         for item in invoice.items:
+            product_query = db.query(Product).filter(Product.id == item.product_id)
+            product_query = product_query.filter(or_(Product.company_id == active_company.id, Product.company_id.is_(None)))
+            product = product_query.first()
+            if not product:
+                raise HTTPException(status_code=404, detail=f"Product {item.product_id} not found")
+            if not product.maintain_inventory:
+                continue
+
             restore_delta = -item.quantity if invoice.voucher_type == "sales" else item.quantity
             _change_inventory_quantity(
                 db,
                 item.product_id,
                 restore_delta,
-              company_id=active_company.id,
+                company_id=active_company.id,
                 context=f"restoring invoice {invoice.id}",
             )
         invoice.status = "active"

--- a/backend/src/api/routes/products.py
+++ b/backend/src/api/routes/products.py
@@ -37,15 +37,23 @@ def create_product(
         hsn_sac=payload.hsn_sac,
         price=payload.price,
         gst_rate=payload.gst_rate,
+        maintain_inventory=payload.maintain_inventory,
     )
     db.add(product)
     db.flush()  # get product.id before committing
 
-    if payload.initial_quantity != 0:
-        inventory = Inventory(company_id=active_company.id, product_id=product.id, quantity=payload.initial_quantity)
-        db.add(inventory)
-    else:
-        inventory = Inventory(company_id=active_company.id, product_id=product.id, quantity=0)
+    if not payload.maintain_inventory and payload.initial_quantity != 0:
+        raise HTTPException(
+            status_code=400,
+            detail="Initial quantity is only allowed when maintain inventory is enabled",
+        )
+
+    if payload.maintain_inventory:
+        inventory = Inventory(
+            company_id=active_company.id,
+            product_id=product.id,
+            quantity=payload.initial_quantity,
+        )
         db.add(inventory)
 
     db.commit()
@@ -112,6 +120,16 @@ def update_product(
     product.hsn_sac = payload.hsn_sac
     product.price = payload.price
     product.gst_rate = payload.gst_rate
+    was_tracking_inventory = bool(product.maintain_inventory)
+    product.maintain_inventory = payload.maintain_inventory
+
+    if not was_tracking_inventory and payload.maintain_inventory:
+        inventory = db.query(Inventory).filter(
+            Inventory.product_id == product_id,
+            Inventory.company_id == active_company.id,
+        ).first()
+        if not inventory:
+            db.add(Inventory(company_id=active_company.id, product_id=product_id, quantity=0))
 
     db.commit()
     db.refresh(product)

--- a/backend/src/models/product.py
+++ b/backend/src/models/product.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, DateTime, Integer, String, Numeric, ForeignKey, func
+from sqlalchemy import Boolean, Column, DateTime, Integer, String, Numeric, ForeignKey, func
 from src.db.base import Base
 
 
@@ -13,4 +13,5 @@ class Product(Base):
     hsn_sac = Column(String, nullable=True)
     price = Column(Numeric(10, 2), nullable=False)
     gst_rate = Column(Numeric(5, 2), nullable=False, default=0)
+    maintain_inventory = Column(Boolean, nullable=False, default=True)
     created_at = Column(DateTime, server_default=func.now(), nullable=True)

--- a/backend/src/schemas/inventory.py
+++ b/backend/src/schemas/inventory.py
@@ -13,6 +13,7 @@ class InventoryOut(BaseModel):
     product_name: str
     sku: str
     price: float
+    maintain_inventory: bool
     quantity: int
     date_added: Optional[datetime] = None
     last_sold_at: Optional[datetime] = None

--- a/backend/src/schemas/product.py
+++ b/backend/src/schemas/product.py
@@ -12,6 +12,7 @@ class ProductCreate(BaseModel):
     hsn_sac: Optional[str] = None
     price: float
     gst_rate: float = 0
+    maintain_inventory: bool = True
     initial_quantity: int = 0
 
     @field_validator("hsn_sac")
@@ -28,6 +29,7 @@ class ProductOut(BaseModel):
     hsn_sac: Optional[str]
     price: float
     gst_rate: float
+    maintain_inventory: bool
     created_at: Optional[datetime] = None
 
     class Config:

--- a/backend/src/services/credit_note.py
+++ b/backend/src/services/credit_note.py
@@ -10,6 +10,7 @@ from src.models.buyer import Buyer as Ledger
 from src.models.credit_note import CreditNote, CreditNoteInvoiceRef, CreditNoteItem
 from src.models.inventory import Inventory
 from src.models.invoice import Invoice, InvoiceItem
+from src.models.product import Product
 from src.schemas.credit_note import CreditNoteCreate
 from src.services.financial_year import get_active_fy, get_fy_for_date
 from src.services.series import generate_next_number
@@ -289,6 +290,15 @@ def create_credit_note(
 
     if payload.credit_note_type == "return":
         for item_data in built_items:
+            product_query = db.query(Product).filter(Product.id == item_data["product_id"])
+            if company_id is not None:
+                product_query = product_query.filter(or_(Product.company_id == company_id, Product.company_id.is_(None)))
+            product = product_query.first()
+            if not product:
+                raise HTTPException(status_code=404, detail=f"Product {item_data['product_id']} not found")
+            if not getattr(product, "maintain_inventory", True):
+                continue
+
             kwargs = {"company_id": company_id} if company_id is not None else {}
             _change_inventory_quantity(
                 db,
@@ -329,6 +339,15 @@ def cancel_credit_note(cn_id: int, db: Session, company_id: int | None = None) -
     if cn.credit_note_type == "return":
         for item in cn.items:
             if item.product_id and item.quantity:
+                product_query = db.query(Product).filter(Product.id == item.product_id)
+                if company_id is not None:
+                    product_query = product_query.filter(or_(Product.company_id == company_id, Product.company_id.is_(None)))
+                product = product_query.first()
+                if not product:
+                    raise HTTPException(status_code=404, detail=f"Product {item.product_id} not found")
+                if not getattr(product, "maintain_inventory", True):
+                    continue
+
                 kwargs = {"company_id": company_id} if company_id is not None else {}
                 _change_inventory_quantity(
                     db,

--- a/backend/tests/api/test_inventory.py
+++ b/backend/tests/api/test_inventory.py
@@ -27,4 +27,50 @@ def test_inventory_list_includes_products_without_inventory_rows(client, db_sess
     assert payload["total"] == 1
     assert len(payload["items"]) == 1
     assert payload["items"][0]["product_id"] == product_id
+    assert payload["items"][0]["maintain_inventory"] is True
     assert payload["items"][0]["quantity"] == 0
+
+
+def test_inventory_list_marks_untracked_products(client):
+    create_response = client.post(
+        "/api/products/",
+        json={
+            "sku": "UNTRACKED01",
+            "name": "Consulting Service",
+            "price": 150,
+            "gst_rate": 18,
+            "maintain_inventory": False,
+        },
+    )
+    assert create_response.status_code == 200
+    product_id = create_response.json()["id"]
+
+    response = client.get("/api/inventory/?search=Consulting&page=1&page_size=20")
+    assert response.status_code == 200
+
+    item = response.json()["items"][0]
+    assert item["product_id"] == product_id
+    assert item["maintain_inventory"] is False
+    assert item["quantity"] == 0
+
+
+def test_adjust_inventory_rejects_untracked_product(client):
+    create_response = client.post(
+        "/api/products/",
+        json={
+            "sku": "UNTRACKED02",
+            "name": "Subscription Setup",
+            "price": 200,
+            "gst_rate": 18,
+            "maintain_inventory": False,
+        },
+    )
+    assert create_response.status_code == 200
+
+    product_id = create_response.json()["id"]
+    adjust_response = client.post(
+        "/api/inventory/adjust",
+        json={"product_id": product_id, "quantity": 1},
+    )
+    assert adjust_response.status_code == 400
+    assert adjust_response.json()["detail"] == "Inventory is disabled for this product"

--- a/backend/tests/api/test_invoice_update_inventory.py
+++ b/backend/tests/api/test_invoice_update_inventory.py
@@ -24,16 +24,17 @@ def _create_ledger(client, name: str, gst: str):
     return response.json()["id"]
 
 
-def _create_product(client):
+def _create_product(client, *, sku: str = "UPD-INV-001", maintain_inventory: bool = True):
     response = client.post(
         "/api/products/",
         json={
-            "sku": "UPD-INV-001",
+            "sku": sku,
             "name": "Inventory Update Product",
             "description": "",
             "hsn_sac": "9988",
             "price": 100,
             "gst_rate": 18,
+            "maintain_inventory": maintain_inventory,
         },
     )
     assert response.status_code == 200, response.text
@@ -102,3 +103,53 @@ def test_update_purchase_invoice_succeeds_when_current_inventory_is_zero(client,
         updated_inventory = db_session.query(Inventory).filter(Inventory.product_id == product_id).first()
         assert updated_inventory is not None
         assert updated_inventory.quantity == 2
+
+
+def test_sales_invoice_allows_untracked_product_without_inventory(client, db_session):
+    with patch("src.api.routes.invoices._generate_next_number", return_value="SAL-UNTRACKED-001"):
+        sales_ledger_id = _create_ledger(client, name="Sales Ledger Untracked", gst="27ABCDE9999F1Z5")
+        product_id = _create_product(client, sku="UPD-INV-UNTRACK-1", maintain_inventory=False)
+
+        create_response = client.post(
+            "/api/invoices/",
+            json={
+                "ledger_id": sales_ledger_id,
+                "voucher_type": "sales",
+                "tax_inclusive": False,
+                "apply_round_off": False,
+                "items": [{"product_id": product_id, "quantity": 5, "unit_price": 100}],
+            },
+        )
+
+        assert create_response.status_code == 200, create_response.text
+        inventory = db_session.query(Inventory).filter(Inventory.product_id == product_id).first()
+        assert inventory is None
+
+
+def test_update_sales_invoice_with_untracked_product_does_not_create_inventory(client, db_session):
+    with patch("src.api.routes.invoices._generate_next_number", return_value="SAL-UNTRACKED-002"):
+        sales_ledger_id = _create_ledger(client, name="Sales Ledger Update", gst="27ABCDE8888F1Z5")
+        product_id = _create_product(client, sku="UPD-INV-UNTRACK-2", maintain_inventory=False)
+
+        invoice = _create_invoice(
+            client,
+            ledger_id=sales_ledger_id,
+            voucher_type="sales",
+            product_id=product_id,
+            quantity=1,
+        )
+
+        update_response = client.put(
+            f"/api/invoices/{invoice['id']}",
+            json={
+                "ledger_id": sales_ledger_id,
+                "voucher_type": "sales",
+                "tax_inclusive": False,
+                "apply_round_off": False,
+                "items": [{"product_id": product_id, "quantity": 3, "unit_price": 100}],
+            },
+        )
+
+        assert update_response.status_code == 200, update_response.text
+        inventory = db_session.query(Inventory).filter(Inventory.product_id == product_id).first()
+        assert inventory is None

--- a/backend/tests/api/test_products.py
+++ b/backend/tests/api/test_products.py
@@ -69,3 +69,76 @@ def test_search_products(client):
     response = client.get("/api/products/?search=Apple")
 
     assert response.status_code == 200
+
+
+def test_create_untracked_product_skips_inventory(client, db_session):
+    response = client.post(
+        "/api/products/",
+        json={
+            "sku": "SERV001",
+            "name": "Service Charge",
+            "price": 250,
+            "gst_rate": 18,
+            "maintain_inventory": False,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["maintain_inventory"] is False
+
+    from src.models.inventory import Inventory
+
+    inventory = db_session.query(Inventory).filter(Inventory.product_id == payload["id"]).first()
+    assert inventory is None
+
+
+def test_create_untracked_product_rejects_initial_quantity(client):
+    response = client.post(
+        "/api/products/",
+        json={
+            "sku": "SERV002",
+            "name": "Service Charge",
+            "price": 100,
+            "gst_rate": 18,
+            "maintain_inventory": False,
+            "initial_quantity": 10,
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Initial quantity is only allowed when maintain inventory is enabled"
+
+
+def test_toggle_untracked_product_on_creates_inventory_row(client, db_session):
+    create_response = client.post(
+        "/api/products/",
+        json={
+            "sku": "SERV003",
+            "name": "AMC Plan",
+            "price": 499,
+            "gst_rate": 18,
+            "maintain_inventory": False,
+        },
+    )
+    assert create_response.status_code == 200
+    product_id = create_response.json()["id"]
+
+    update_response = client.put(
+        f"/api/products/{product_id}",
+        json={
+            "sku": "SERV003",
+            "name": "AMC Plan",
+            "price": 499,
+            "gst_rate": 18,
+            "maintain_inventory": True,
+        },
+    )
+    assert update_response.status_code == 200
+    assert update_response.json()["maintain_inventory"] is True
+
+    from src.models.inventory import Inventory
+
+    inventory = db_session.query(Inventory).filter(Inventory.product_id == product_id).first()
+    assert inventory is not None
+    assert inventory.quantity == 0

--- a/frontend/src/pages/InventoryPage.tsx
+++ b/frontend/src/pages/InventoryPage.tsx
@@ -62,6 +62,12 @@ export default function InventoryPage() {
   }
 
   async function applyAdjustment(productId: number) {
+    const row = rows.find((entry) => entry.product_id === productId);
+    if (row && !row.maintain_inventory) {
+      setError(`Inventory is disabled for ${row.product_name}. Enable Maintain inventory on the product first.`);
+      return;
+    }
+
     const delta = Number(adjusting[productId] ?? '0');
     if (delta === 0) return;
 
@@ -151,7 +157,9 @@ export default function InventoryPage() {
                     {/* Product info */}
                     <div className="table-row__meta" style={{ flex: '1 1 180px' }}>
                       <strong>{row.product_name}</strong>
-                      <span className="table-subtext">{row.sku}</span>
+                      <span className="table-subtext">
+                        {row.sku} • {row.maintain_inventory ? 'Tracked' : 'Untracked'}
+                      </span>
                     </div>
 
                     {/* Qty pill */}
@@ -181,13 +189,13 @@ export default function InventoryPage() {
                         onKeyDown={(e) => { if (e.key === 'Enter') void applyAdjustment(row.product_id); }}
                         style={{ width: 88 }}
                         aria-label={`Adjust quantity for ${row.product_name}`}
-                        disabled={submittingId === row.product_id}
+                        disabled={submittingId === row.product_id || !row.maintain_inventory}
                       />
                       <button
                         type="button"
                         className="button button--secondary"
                         onClick={() => void applyAdjustment(row.product_id)}
-                        disabled={submittingId === row.product_id || !adjusting[row.product_id]}
+                        disabled={submittingId === row.product_id || !adjusting[row.product_id] || !row.maintain_inventory}
                         title={`Apply adjustment for ${row.product_name}`}
                         aria-label={`Apply adjustment for ${row.product_name}`}
                         style={{ whiteSpace: 'nowrap' }}

--- a/frontend/src/pages/InvoicesPage.tsx
+++ b/frontend/src/pages/InvoicesPage.tsx
@@ -99,7 +99,7 @@ export default function InvoicesPage() {
     ifsc_code: '',
   });
   const [ledgerOpeningBalanceSide, setLedgerOpeningBalanceSide] = useState<OpeningBalanceSide>('debit');
-  const [productForm, setProductForm] = useState({ name: '', sku: '', hsn_sac: '', price: '', gst_rate: '0' });
+  const [productForm, setProductForm] = useState({ name: '', sku: '', hsn_sac: '', price: '', gst_rate: '0', maintain_inventory: true });
   const [stockForm, setStockForm] = useState({ productId: '', adjustment: '' });
   const [ledgerSubmitting, setLedgerSubmitting] = useState(false);
   const [productSubmitting, setProductSubmitting] = useState(false);
@@ -558,11 +558,12 @@ export default function InvoicesPage() {
         hsn_sac: productForm.hsn_sac.trim(),
         price: Number(productForm.price),
         gst_rate: Number(productForm.gst_rate),
+        maintain_inventory: productForm.maintain_inventory,
       };
 
       const response = await api.post<Product>('/products/', payload);
       setProducts((current) => [...current, response.data].sort((a, b) => a.name.localeCompare(b.name)));
-      setProductForm({ name: '', sku: '', hsn_sac: '', price: '', gst_rate: '0' });
+      setProductForm({ name: '', sku: '', hsn_sac: '', price: '', gst_rate: '0', maintain_inventory: true });
       setShowProductModal(false);
       setSuccess('Product created successfully.');
     } catch (err) {
@@ -583,6 +584,12 @@ export default function InvoicesPage() {
         product_id: Number(stockForm.productId),
         quantity: Number(stockForm.adjustment),
       };
+
+      const selectedProduct = products.find((product) => product.id === payload.product_id);
+      if (selectedProduct && !selectedProduct.maintain_inventory) {
+        setError(`Inventory is disabled for ${selectedProduct.name}. Enable Maintain inventory on the product first.`);
+        return;
+      }
 
       await api.post('/inventory/adjust', payload);
       setStockForm({ productId: '', adjustment: '' });
@@ -1262,6 +1269,18 @@ export default function InvoicesPage() {
                   required
                 />
               </div>
+              <div className="field field--full" style={{ marginBottom: 0 }}>
+                <label htmlFor="modal-product-maintain-inventory" style={{ display: 'flex', alignItems: 'center', gap: '10px', marginBottom: 0 }}>
+                  <input
+                    id="modal-product-maintain-inventory"
+                    type="checkbox"
+                    checked={productForm.maintain_inventory}
+                    onChange={(event) => setProductForm((current) => ({ ...current, maintain_inventory: event.target.checked }))}
+                  />
+                  Maintain inventory for this product
+                </label>
+                <small className="field-hint">Disable this for service charges and other non-stock items.</small>
+              </div>
 
               <div className="button-row">
                 <button type="button" className="button button--ghost" onClick={() => setShowProductModal(false)} title="Cancel product creation" aria-label="Cancel product creation">
@@ -1287,6 +1306,13 @@ export default function InvoicesPage() {
             </div>
 
             <form className="stack" onSubmit={handleUpdateStock}>
+              {stockForm.productId ? (
+                <div className="field-hint">
+                  {products.find((product) => product.id === Number(stockForm.productId))?.maintain_inventory
+                    ? 'Inventory tracking is enabled for this product.'
+                    : 'Inventory is disabled for this product. Enable Maintain inventory on the product before adjusting stock.'}
+                </div>
+              ) : null}
               <div className="field">
                 <label htmlFor="modal-stock-product">Product</label>
                 <ProductCombobox
@@ -1318,7 +1344,17 @@ export default function InvoicesPage() {
                 <button type="button" className="button button--ghost" onClick={() => setShowStockModal(false)} title="Cancel stock update" aria-label="Cancel stock update">
                   Cancel
                 </button>
-                <button className="button button--primary" disabled={stockSubmitting} title="Update stock" aria-label="Update stock">
+                <button
+                  className="button button--primary"
+                  disabled={
+                    stockSubmitting ||
+                    (stockForm.productId
+                      ? !products.find((product) => product.id === Number(stockForm.productId))?.maintain_inventory
+                      : false)
+                  }
+                  title="Update stock"
+                  aria-label="Update stock"
+                >
                   {stockSubmitting ? 'Updating stock...' : 'Update stock'}
                 </button>
               </div>

--- a/frontend/src/pages/ProductsPage.tsx
+++ b/frontend/src/pages/ProductsPage.tsx
@@ -29,6 +29,7 @@ export default function ProductsPage() {
     hsn_sac: '',
     price: '',
     gst_rate: '0',
+    maintain_inventory: true,
     initial_quantity: '0',
   });
 
@@ -60,7 +61,7 @@ export default function ProductsPage() {
   }, [page, search]);
 
   function resetForm() {
-    setForm({ sku: '', name: '', description: '', hsn_sac: '', price: '', gst_rate: '0', initial_quantity: '0' });
+    setForm({ sku: '', name: '', description: '', hsn_sac: '', price: '', gst_rate: '0', maintain_inventory: true, initial_quantity: '0' });
     setEditingProductId(null);
   }
 
@@ -75,6 +76,7 @@ export default function ProductsPage() {
       hsn_sac: product.hsn_sac ?? '',
       price: String(product.price),
       gst_rate: String(product.gst_rate),
+      maintain_inventory: product.maintain_inventory,
       initial_quantity: '0',
     });
   }
@@ -94,6 +96,7 @@ export default function ProductsPage() {
         hsn_sac: form.hsn_sac.trim(),
         price: Number(form.price),
         gst_rate: Number(form.gst_rate),
+        maintain_inventory: form.maintain_inventory,
         ...(editingProductId ? {} : { initial_quantity: Number(form.initial_quantity) }),
       };
 
@@ -243,7 +246,21 @@ export default function ProductsPage() {
                   placeholder="Optional details for operators and quoting."
                 />
               </div>
-              {!editingProductId ? (
+              <div className="field field--full" style={{ marginBottom: 0 }}>
+                <label htmlFor="maintain-inventory" style={{ display: 'flex', alignItems: 'center', gap: '10px', marginBottom: 0 }}>
+                  <input
+                    id="maintain-inventory"
+                    type="checkbox"
+                    checked={form.maintain_inventory}
+                    onChange={(event) => setForm((current) => ({ ...current, maintain_inventory: event.target.checked }))}
+                  />
+                  Maintain inventory for this product
+                </label>
+                <span className="field-hint">
+                  Turn this off for service-style items such as service charges.
+                </span>
+              </div>
+              {!editingProductId && form.maintain_inventory ? (
                 <div className="field">
                   <label htmlFor="initial-quantity">Initial stock quantity</label>
                   <input
@@ -322,6 +339,7 @@ export default function ProductsPage() {
                       <strong>{product.name}</strong>
                       <span className="table-subtext">
                         {product.sku}
+                        {product.maintain_inventory ? ' • Tracked' : ' • Untracked'}
                         {product.hsn_sac ? ` • HSN/SAC ${product.hsn_sac}` : ''}
                         {` • GST ${product.gst_rate}%`}
                         {product.description ? ` • ${product.description}` : ''}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -12,6 +12,7 @@ export type Product = {
   hsn_sac: string | null;
   price: number;
   gst_rate: number;
+  maintain_inventory: boolean;
   created_at: string | null;
 };
 
@@ -22,6 +23,7 @@ export type ProductCreate = {
   hsn_sac: string;
   price: number;
   gst_rate: number;
+  maintain_inventory: boolean;
   initial_quantity?: number;
 };
 
@@ -30,6 +32,7 @@ export type InventoryRow = {
   product_name: string;
   sku: string;
   price: number;
+  maintain_inventory: boolean;
   quantity: number;
   date_added: string | null;
   last_sold_at: string | null;


### PR DESCRIPTION
## Summary

Add optional inventory tracking per product via a new `maintain_inventory` flag (default `true`). This enables service-style items (for example service charge) to be invoiced without requiring stock, while preserving current stock enforcement for tracked items.

Implemented across backend schema/models/routes, invoice + credit-note inventory mutation paths, and frontend product/inventory/invoice flows.

## Type of change

- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs (documentation)
- [x] test (tests)
- [ ] chore/refactor

## How to test

1. Use backend test DB URL:
   - `DATABASE_URL=postgresql://simple_user:simple_password@localhost:5432/simple_invoicing`
2. Run backend tests:
   - `DATABASE_URL=postgresql://simple_user:simple_password@localhost:5432/simple_invoicing /Users/nikhil/Documents/projects/respawn-invoicing/backend/.venv/bin/python -m pytest backend/tests/api/test_products.py backend/tests/api/test_inventory.py backend/tests/api/test_invoice_update_inventory.py backend/tests/api/test_invoice_reference_notes.py backend/tests/services/test_credit_notes.py`
3. Run frontend build:
   - `npm --prefix frontend run build`
4. Manual check:
   - Create a product with **Maintain inventory** OFF and create a sales invoice with quantity > 0.
   - Verify invoice creation succeeds without inventory setup.
   - Create a tracked product with low/no stock and verify sales invoice blocks on insufficient inventory.
   - In inventory UI, verify untracked products are shown as untracked and stock adjustment is blocked.

## Checklist

- [x] My code follows the project style and conventions
- [x] I added/updated tests where appropriate
- [ ] I updated docs where needed
- [x] I ran relevant checks locally
- [x] I verified this does not break existing behavior

## Screenshots (if UI changes)

Not included in this PR.

## Related issue

Closes #