### PR TITLE
feat: implement dynamic browser tab titles for all routes

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -21,17 +21,50 @@ export default function Layout({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     const cleanups = [
-      registerAction('go_invoices',  () => navigate('/invoices')),
-      registerAction('go_ledgers',   () => navigate('/ledgers')),
-      registerAction('go_products',  () => navigate('/products')),
+      registerAction('go_invoices', () => navigate('/invoices')),
+      registerAction('go_ledgers', () => navigate('/ledgers')),
+      registerAction('go_products', () => navigate('/products')),
       registerAction('go_inventory', () => navigate('/inventory')),
-      registerAction('go_day_book',  () => navigate('/day-book')),
-      registerAction('go_tax_ledger',() => navigate('/tax-ledger')),
+      registerAction('go_day_book', () => navigate('/day-book')),
+      registerAction('go_tax_ledger', () => navigate('/tax-ledger')),
       registerAction('open_reports', () => navigate('/day-book')),
       registerAction('new_customer', () => navigate('/ledgers/new')),
     ];
     return () => cleanups.forEach(fn => fn());
   }, [registerAction, navigate]);
+
+  useEffect(() => {
+    const routeTitles: Record<string, string> = {
+      '/': 'Dashboard',
+      '/products': 'Products',
+      '/inventory': 'Inventory',
+      '/ledgers': 'Ledgers',
+      '/ledgers/new': 'New Ledger',
+      '/day-book': 'Day Book',
+      '/tax-ledger': 'Tax Ledger',
+      '/cash-bank': 'Cash & Bank',
+      '/cash-bank/accounts': 'Bank Accounts',
+      '/invoices': 'Invoices',
+      '/invoice-dues': 'Invoice Dues',
+      '/invoices-view': 'Advanced Invoice View',
+      '/credit-notes': 'Credit Notes',
+      '/company': 'Company Profile',
+      '/smtp-settings': 'Email Settings',
+      '/backups': 'Database Backups',
+      '/shortcuts': 'Keyboard Shortcuts',
+      '/change-password': 'Security',
+    };
+
+
+    let pageName = 'Simple Invoicing';
+    if (location.pathname.startsWith('/ledgers/')) {
+      pageName = location.pathname.endsWith('/edit') ? 'Edit Ledger' : 'View Ledger';
+    } else {
+      pageName = routeTitles[location.pathname] || 'Simple Invoicing';
+    }
+
+    document.title = `${pageName} | Simple Invoicing`;
+  }, [location.pathname]);
 
   return (
     <div className="app-shell">
@@ -46,32 +79,32 @@ export default function Layout({ children }: { children: React.ReactNode }) {
         />
       )}
       <div className="app-shell__main">
-      <div className="app-shell__backdrop app-shell__backdrop--left" />
-      <div className="app-shell__backdrop app-shell__backdrop--right" />
-      <header className="page-header">
-        <button
-          className="sidebar-toggle"
-          onClick={() => setSidebarOpen(true)}
-          aria-label="Open navigation"
-        >
-          <span className="sidebar-toggle__bar" />
-          <span className="sidebar-toggle__bar" />
-          <span className="sidebar-toggle__bar" />
-        </button>
-        <div className="page-header__shortcut-hint">
-          Press <kbd>?</kbd> for shortcuts
-        </div>
-      </header>
+        <div className="app-shell__backdrop app-shell__backdrop--left" />
+        <div className="app-shell__backdrop app-shell__backdrop--right" />
+        <header className="page-header">
+          <button
+            className="sidebar-toggle"
+            onClick={() => setSidebarOpen(true)}
+            aria-label="Open navigation"
+          >
+            <span className="sidebar-toggle__bar" />
+            <span className="sidebar-toggle__bar" />
+            <span className="sidebar-toggle__bar" />
+          </button>
+          <div className="page-header__shortcut-hint">
+            Press <kbd>?</kbd> for shortcuts
+          </div>
+        </header>
 
-      <motion.main
-        key={location.pathname}
-        initial={{ opacity: 0, y: 18 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.28, ease: 'easeOut' }}
-        className="page-frame"
-      >
-        {children}
-      </motion.main>
+        <motion.main
+          key={location.pathname}
+          initial={{ opacity: 0, y: 18 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.28, ease: 'easeOut' }}
+          className="page-frame"
+        >
+          {children}
+        </motion.main>
       </div>
       <InvoiceCancelDialog />
     </div>

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useState } from 'react';
+import { FormEvent, useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { useNavigate } from 'react-router-dom';
 import { getApiErrorMessage } from '../api/client';
@@ -27,6 +27,10 @@ export default function LoginPage() {
       setSubmitting(false);
     }
   }
+
+  useEffect(() => {
+    document.title = 'Login | Simple Invoicing';
+  }, []);
 
   return (
     <div className="login-page">
@@ -106,7 +110,7 @@ export default function LoginPage() {
             />
           </div>
 
-          <StatusToasts error={error} onClearError={() => setError('')} onClearSuccess={() => {}} />
+          <StatusToasts error={error} onClearError={() => setError('')} onClearSuccess={() => { }} />
 
           <button className="button button--primary" disabled={submitting} title="Open dashboard" aria-label="Open dashboard">
             {submitting ? 'Signing in...' : 'Open dashboard'}


### PR DESCRIPTION
## Summary

### What
Implemented dynamic browser tab titles across the entire application.


### Why

Previously, all pages shared the same generic browser tab title, making it difficult for users to distinguish between multiple open tabs (e.g., having a Ledger Statement and an Invoice open simultaneously).
## Type of change

- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] docs (documentation)
- [ ] test (tests)
- [ ] chore/refactor

## How to test

**1. Test Navigation Titles:**

Log in and navigate between Dashboard, Invoices, and Day Book.

Observe: The browser tab title should update to reflect the current page (e.g., "Invoices | Simple Invoicing").

**2. Test Dynamic Routes:**

Navigate to a specific ledger view (e.g., /ledgers/1).

**Observe:** The title should change to "View Ledger | Simple Invoicing".

**3. Test Login Title:**

Log out and view the login screen.

**Observe:** The title should be "Login | Simple Invoicing".

## Checklist

- [x] My code follows the project style and conventions
- [x] I added/updated tests where appropriate
- [x] I updated docs where needed
- [x] I ran relevant checks locally
- [x] I verified this does not break existing behavior

## Screenshots (if UI changes)


## Related issue

Closes #52 
