### PR TITLE
feat(company): enforce DB-only global company creation cap

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,21 @@ make down                             # Stop all services
 
 See the [Makefile](Makefile) for all available commands.
 
+## Company Creation Cap
+
+Company creation is capped globally and enforced by backend validation.
+
+- The cap value is stored in PostgreSQL table `global_settings` column `max_companies`.
+- The UI does not provide any setting to change this value.
+- To change the allowed number of companies, update PostgreSQL directly:
+
+```sql
+UPDATE global_settings
+SET max_companies = 5,
+	updated_at = NOW()
+WHERE id = 1;
+```
+
 ## Roadmap
 
 - [ ] Multi-currency support

--- a/backend/migrations/20260429000001_create_global_settings_table.py
+++ b/backend/migrations/20260429000001_create_global_settings_table.py
@@ -17,8 +17,8 @@ def up(conn) -> None:
         )
     """))
     conn.execute(text("""
-        INSERT INTO global_settings (id, max_companies)
-        VALUES (1, 1)
+        INSERT INTO global_settings (id, max_companies, created_at, updated_at)
+        VALUES (1, 1, NOW(), NOW())
         ON CONFLICT (id) DO NOTHING
     """))
 

--- a/backend/migrations/20260429000001_create_global_settings_table.py
+++ b/backend/migrations/20260429000001_create_global_settings_table.py
@@ -1,0 +1,27 @@
+"""
+create_global_settings_table
+"""
+
+from sqlalchemy import text
+
+
+def up(conn) -> None:
+    conn.execute(text("""
+        CREATE TABLE IF NOT EXISTS global_settings (
+            id INTEGER PRIMARY KEY,
+            max_companies INTEGER NOT NULL DEFAULT 1,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            CONSTRAINT ck_global_settings_singleton_id CHECK (id = 1),
+            CONSTRAINT ck_global_settings_max_companies_positive CHECK (max_companies > 0)
+        )
+    """))
+    conn.execute(text("""
+        INSERT INTO global_settings (id, max_companies)
+        VALUES (1, 1)
+        ON CONFLICT (id) DO NOTHING
+    """))
+
+
+def down(conn) -> None:
+    conn.execute(text("DROP TABLE IF EXISTS global_settings"))

--- a/backend/src/api/routes/company.py
+++ b/backend/src/api/routes/company.py
@@ -1,13 +1,36 @@
 from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from src.api.deps import get_active_company, get_current_user, require_roles
 from src.db.session import get_db
 from src.models.company import CompanyProfile
+from src.models.global_settings import GlobalSettings
 from src.models.user import User, UserRole
-from src.schemas.company import CompanyListItem, CompanyProfileOut, CompanyProfileUpdate, CompanySelectOut
+from src.schemas.company import (
+    CompanyCreationCapOut,
+    CompanyListItem,
+    CompanyProfileOut,
+    CompanyProfileUpdate,
+    CompanySelectOut,
+)
 
 router = APIRouter()
+
+
+def _get_max_companies(db: Session) -> int:
+    settings_row = db.query(GlobalSettings).filter(GlobalSettings.id == 1).first()
+    return settings_row.max_companies if settings_row else 1
+
+
+def _get_company_creation_capability(db: Session) -> CompanyCreationCapOut:
+    current_companies = db.query(func.count(CompanyProfile.id)).scalar() or 0
+    max_companies = _get_max_companies(db)
+    return CompanyCreationCapOut(
+        max_companies=max_companies,
+        current_companies=current_companies,
+        can_create_company=current_companies < max_companies,
+    )
 
 
 def _create_company_profile(db: Session, payload: CompanyProfileUpdate) -> CompanyProfile:
@@ -82,10 +105,28 @@ def create_company_profile(
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles(UserRole.admin, UserRole.manager)),
 ):
+    cap = _get_company_creation_capability(db)
+    if not cap.can_create_company:
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                "Company creation limit reached. "
+                "Update global_settings.max_companies directly in PostgreSQL to allow more companies."
+            ),
+        )
+
     profile = _create_company_profile(db, payload)
     if current_user.active_company_id is None:
         _set_active_company(db, current_user, profile.id)
     return profile
+
+
+@router.get("/companies/capability", response_model=CompanyCreationCapOut)
+def get_company_creation_capability(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    return _get_company_creation_capability(db)
 
 
 @router.post("/select/{company_id}", response_model=CompanySelectOut)

--- a/backend/src/models/__init__.py
+++ b/backend/src/models/__init__.py
@@ -8,3 +8,4 @@ from src.models.company_account import CompanyAccount
 from src.models.payment import Payment, PaymentInvoiceAllocation
 from src.models.smtp_config import SMTPConfig
 from src.models.user_shortcut import UserShortcut
+from src.models.global_settings import GlobalSettings

--- a/backend/src/models/global_settings.py
+++ b/backend/src/models/global_settings.py
@@ -1,0 +1,19 @@
+from datetime import datetime
+
+from sqlalchemy import CheckConstraint, Column, DateTime, Integer
+
+from src.db.base import Base
+
+
+class GlobalSettings(Base):
+    __tablename__ = "global_settings"
+
+    id = Column(Integer, primary_key=True, default=1)
+    max_companies = Column(Integer, nullable=False, default=1)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
+
+    __table_args__ = (
+        CheckConstraint("id = 1", name="ck_global_settings_singleton_id"),
+        CheckConstraint("max_companies > 0", name="ck_global_settings_max_companies_positive"),
+    )

--- a/backend/src/schemas/company.py
+++ b/backend/src/schemas/company.py
@@ -45,3 +45,9 @@ class CompanyListItem(BaseModel):
 
 class CompanySelectOut(BaseModel):
     active_company_id: int
+
+
+class CompanyCreationCapOut(BaseModel):
+    max_companies: int
+    current_companies: int
+    can_create_company: bool

--- a/backend/tests/api/test_company_switching.py
+++ b/backend/tests/api/test_company_switching.py
@@ -5,6 +5,8 @@ from app_main import app
 from src.api.deps import get_current_user
 from src.db.session import get_db
 from src.models.user import User, UserRole
+from src.models.global_settings import GlobalSettings
+import pytest
 
 
 def _company_payload(name: str, gst: str = ""):
@@ -118,6 +120,66 @@ def test_company_create_list_and_select(client):
         active_after = [item for item in listed_after.json() if item["is_active"]]
         assert len(active_after) == 1
         assert active_after[0]["id"] == company_b_id
+    finally:
+        _restore_user_override(old_override)
+
+
+@pytest.fixture(autouse=True)
+def _set_default_test_company_cap(db_session: Session):
+    settings_row = db_session.query(GlobalSettings).filter(GlobalSettings.id == 1).first()
+    if not settings_row:
+        settings_row = GlobalSettings(id=1, max_companies=10)
+        db_session.add(settings_row)
+    else:
+        settings_row.max_companies = 10
+    db_session.commit()
+
+
+def test_company_creation_is_blocked_when_global_cap_reached(client, db_session: Session):
+    old_override = _with_persistent_user_override()
+    try:
+        settings_row = db_session.query(GlobalSettings).filter(GlobalSettings.id == 1).first()
+        settings_row.max_companies = 1
+        db_session.commit()
+
+        first_create = client.post("/api/company/companies", json=_company_payload("Cap One"))
+        assert first_create.status_code == 200, first_create.text
+
+        blocked_create = client.post("/api/company/companies", json=_company_payload("Cap Two"))
+        assert blocked_create.status_code == 403
+        assert "Company creation limit reached" in blocked_create.text
+    finally:
+        _restore_user_override(old_override)
+
+
+def test_company_creation_capability_endpoint_reports_current_state(client, db_session: Session):
+    old_override = _with_persistent_user_override()
+    try:
+        settings_row = db_session.query(GlobalSettings).filter(GlobalSettings.id == 1).first()
+        settings_row.max_companies = 2
+        db_session.commit()
+
+        first_create = client.post("/api/company/companies", json=_company_payload("Cap State A"))
+        assert first_create.status_code == 200, first_create.text
+
+        capability = client.get("/api/company/companies/capability")
+        assert capability.status_code == 200, capability.text
+        assert capability.json() == {
+            "max_companies": 2,
+            "current_companies": 1,
+            "can_create_company": True,
+        }
+
+        second_create = client.post("/api/company/companies", json=_company_payload("Cap State B"))
+        assert second_create.status_code == 200, second_create.text
+
+        capability_after = client.get("/api/company/companies/capability")
+        assert capability_after.status_code == 200, capability_after.text
+        assert capability_after.json() == {
+            "max_companies": 2,
+            "current_companies": 2,
+            "can_create_company": False,
+        }
     finally:
         _restore_user_override(old_override)
 

--- a/backend/tests/api/test_company_switching.py
+++ b/backend/tests/api/test_company_switching.py
@@ -184,6 +184,36 @@ def test_company_creation_capability_endpoint_reports_current_state(client, db_s
         _restore_user_override(old_override)
 
 
+def test_company_creation_capability_defaults_to_one_without_settings_row(client, db_session: Session):
+    old_override = _with_persistent_user_override()
+    try:
+        settings_row = db_session.query(GlobalSettings).filter(GlobalSettings.id == 1).first()
+        if settings_row:
+            db_session.delete(settings_row)
+            db_session.commit()
+
+        initial_capability = client.get("/api/company/companies/capability")
+        assert initial_capability.status_code == 200, initial_capability.text
+        assert initial_capability.json() == {
+            "max_companies": 1,
+            "current_companies": 0,
+            "can_create_company": True,
+        }
+
+        first_create = client.post("/api/company/companies", json=_company_payload("Fallback One"))
+        assert first_create.status_code == 200, first_create.text
+
+        capped_capability = client.get("/api/company/companies/capability")
+        assert capped_capability.status_code == 200, capped_capability.text
+        assert capped_capability.json() == {
+            "max_companies": 1,
+            "current_companies": 1,
+            "can_create_company": False,
+        }
+    finally:
+        _restore_user_override(old_override)
+
+
 def test_company_header_scopes_ledger_queries(client):
     old_override = _with_persistent_user_override()
     try:

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -5,7 +5,13 @@ import { Link, NavLink } from 'react-router-dom';
 import api, { getApiErrorMessage } from '../api/client';
 import { useAuth } from '../context/AuthContext';
 import { useFY } from '../context/FYContext';
-import type { CompanyListItem, CompanyProfile, CompanyProfileUpdate, CompanySelectOut } from '../types/api';
+import type {
+  CompanyCreationCapOut,
+  CompanyListItem,
+  CompanyProfile,
+  CompanyProfileUpdate,
+  CompanySelectOut,
+} from '../types/api';
 
 type NavItem = { to: string; label: string; end?: boolean };
 
@@ -62,6 +68,7 @@ export default function Sidebar({ isOpen = false, onClose }: SidebarProps) {
   const [companyLoading, setCompanyLoading] = useState(false);
   const [companySwitchingId, setCompanySwitchingId] = useState<number | null>(null);
   const [companyError, setCompanyError] = useState('');
+  const [canCreateCompany, setCanCreateCompany] = useState(true);
   const [newCompanyModalOpen, setNewCompanyModalOpen] = useState(false);
   const [newCompanyName, setNewCompanyName] = useState('');
   const [newCompanySubmitting, setNewCompanySubmitting] = useState(false);
@@ -108,6 +115,7 @@ export default function Sidebar({ isOpen = false, onClose }: SidebarProps) {
     if (!isAuthenticated) {
       setCompanyList([]);
       setCompanyError('');
+      setCanCreateCompany(false);
       return;
     }
 
@@ -116,11 +124,16 @@ export default function Sidebar({ isOpen = false, onClose }: SidebarProps) {
       setCompanyLoading(true);
       setCompanyError('');
       try {
-        const res = await api.get<CompanyListItem[]>('/company/companies');
+        const [companiesRes, capabilityRes] = await Promise.all([
+          api.get<CompanyListItem[]>('/company/companies'),
+          api.get<CompanyCreationCapOut>('/company/companies/capability'),
+        ]);
         if (cancelled) return;
-        setCompanyList(res.data);
+        setCompanyList(companiesRes.data);
+        setCanCreateCompany(capabilityRes.data.can_create_company);
       } catch (error) {
         if (cancelled) return;
+        setCanCreateCompany(false);
         setCompanyError(getApiErrorMessage(error, 'Failed to load companies'));
       } finally {
         if (!cancelled) {
@@ -326,29 +339,33 @@ export default function Sidebar({ isOpen = false, onClose }: SidebarProps) {
                         {company.name || `Company #${company.id}`}
                       </button>
                     ))}
-                    <hr style={{ margin: '0.25rem 0', border: 'none', borderTop: '1px solid var(--line)' }} />
-                    <button
-                      style={{
-                        display: 'block',
-                        width: '100%',
-                        textAlign: 'left',
-                        padding: '0.5rem 0.75rem',
-                        background: 'none',
-                        border: 'none',
-                        cursor: 'pointer',
-                        fontSize: '0.875rem',
-                        color: 'inherit',
-                        fontWeight: 500,
-                      }}
-                      onClick={() => {
-                        setCompanyDropdownOpen(false);
-                        setNewCompanyName('');
-                        setNewCompanyError('');
-                        setNewCompanyModalOpen(true);
-                      }}
-                    >
-                      + New Company
-                    </button>
+                    {canCreateCompany && (
+                      <>
+                        <hr style={{ margin: '0.25rem 0', border: 'none', borderTop: '1px solid var(--line)' }} />
+                        <button
+                          style={{
+                            display: 'block',
+                            width: '100%',
+                            textAlign: 'left',
+                            padding: '0.5rem 0.75rem',
+                            background: 'none',
+                            border: 'none',
+                            cursor: 'pointer',
+                            fontSize: '0.875rem',
+                            color: 'inherit',
+                            fontWeight: 500,
+                          }}
+                          onClick={() => {
+                            setCompanyDropdownOpen(false);
+                            setNewCompanyName('');
+                            setNewCompanyError('');
+                            setNewCompanyModalOpen(true);
+                          }}
+                        >
+                          + New Company
+                        </button>
+                      </>
+                    )}
                   </div>
                 )}
               </div>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -54,8 +54,8 @@ function fyFromStartYear(year: number) {
 }
 
 export default function Sidebar({ isOpen = false, onClose }: SidebarProps) {
-  const showCompanySwitcher = false;
   const { isAdmin, isAuthenticated, userEmail, logout } = useAuth();
+  const showCompanySwitcher = isAuthenticated;
   const { activeFY, fyList, switchFY, createFY } = useFY();
 
   const [fyDropdownOpen, setFyDropdownOpen] = useState(false);

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -150,6 +150,12 @@ export type CompanySelectOut = {
   active_company_id: number;
 };
 
+export type CompanyCreationCapOut = {
+  max_companies: number;
+  current_companies: number;
+  can_create_company: boolean;
+};
+
 export type CompanyProfileUpdate = {
   name: string;
   address: string;


### PR DESCRIPTION
## Summary

Adds a hard cap on company creation that is stored exclusively in PostgreSQL and enforced server-side. The cap value (`max_companies`) can only be changed by updating the `global_settings` table directly in the database — there is no UI or API endpoint to modify it. The frontend hides the `+ New Company` action when the cap is reached.

**Default cap:** 1 company (seeded by migration). To allow more:

```sql
UPDATE global_settings SET max_companies = 5, updated_at = NOW() WHERE id = 1;
```

## Type of change

- [x] feat (new feature)
- [x] fix (bug fix)
- [ ] docs (documentation)
- [x] test (tests)
- [ ] chore/refactor

## How to test

1. Apply the migration: `make migrate` (or `python migrate.py up`)
2. Verify table: `SELECT * FROM global_settings;` — expect `max_companies = 1`
3. Create one company via the UI or `POST /api/company/companies` — should succeed
4. Attempt to create a second company — should be blocked with HTTP 403
5. Check `GET /api/company/companies/capability` — returns `can_create_company: false`
6. Update cap: `UPDATE global_settings SET max_companies = 2 ...`
7. Reload the frontend — `+ New Company` appears in the company switcher
8. Create second company — succeeds; third is blocked again

## Checklist

- [x] My code follows the project style and conventions
- [x] I added/updated tests where appropriate — 3 new backend tests in `test_company_switching.py`, all passing (8/8)
- [x] I updated docs where needed — added "Company Creation Cap" section to README
- [x] I ran relevant checks locally — `pytest tests/api/test_company_switching.py` (8 passed), `npm run lint` (0 errors)
- [x] I verified this does not break existing behavior — autouse fixture sets `max_companies = 10` in test env so all existing multi-company tests continue to pass

## Screenshots (if UI changes)

- Company switcher shows `+ New Company` when `current_companies < max_companies`
- `+ New Company` is hidden (not disabled — fully removed) when cap is reached

## Related issue

Closes #
