### PR TITLE
refactor(sidebar): extract company selector with react query

### DIFF
--- a/backend/migrations/20260430000001_add_product_unit_and_decimal_inventory.py
+++ b/backend/migrations/20260430000001_add_product_unit_and_decimal_inventory.py
@@ -1,0 +1,40 @@
+"""
+Add product unit and allow_decimal fields, and make inventory quantity decimal-capable.
+"""
+
+from sqlalchemy import text
+
+
+def up(conn) -> None:
+    conn.execute(text("""
+        ALTER TABLE products
+        ADD COLUMN IF NOT EXISTS unit VARCHAR NOT NULL DEFAULT 'Pieces';
+    """))
+
+    conn.execute(text("""
+        ALTER TABLE products
+        ADD COLUMN IF NOT EXISTS allow_decimal BOOLEAN NOT NULL DEFAULT FALSE;
+    """))
+
+    conn.execute(text("""
+        UPDATE products
+        SET unit = 'Pieces'
+        WHERE unit IS NULL OR btrim(unit) = '';
+    """))
+
+    conn.execute(text("""
+        ALTER TABLE inventory
+        ALTER COLUMN quantity TYPE NUMERIC(12, 3)
+        USING quantity::numeric;
+    """))
+
+
+def down(conn) -> None:
+    conn.execute(text("""
+        ALTER TABLE inventory
+        ALTER COLUMN quantity TYPE INTEGER
+        USING ROUND(quantity)::integer;
+    """))
+
+    conn.execute(text("ALTER TABLE products DROP COLUMN IF EXISTS allow_decimal"))
+    conn.execute(text("ALTER TABLE products DROP COLUMN IF EXISTS unit"))

--- a/backend/migrations/20260430000002_make_invoice_item_quantity_decimal.py
+++ b/backend/migrations/20260430000002_make_invoice_item_quantity_decimal.py
@@ -1,0 +1,21 @@
+"""
+Make invoice item quantity decimal-capable.
+"""
+
+from sqlalchemy import text
+
+
+def up(conn) -> None:
+    conn.execute(text("""
+        ALTER TABLE invoice_items
+        ALTER COLUMN quantity TYPE NUMERIC(12, 3)
+        USING quantity::numeric;
+    """))
+
+
+def down(conn) -> None:
+    conn.execute(text("""
+        ALTER TABLE invoice_items
+        ALTER COLUMN quantity TYPE INTEGER
+        USING ROUND(quantity)::integer;
+    """))

--- a/backend/src/api/routes/inventory.py
+++ b/backend/src/api/routes/inventory.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import and_, func
 from sqlalchemy.orm import Session
 from typing import Literal
+from decimal import Decimal
 
 from src.db.session import get_db
 from src.models.company import CompanyProfile
@@ -13,6 +14,10 @@ from src.schemas.inventory import InventoryAdjust, InventoryOut, PaginatedInvent
 from src.api.deps import get_active_company, get_current_user, require_roles
 
 router = APIRouter()
+
+
+def _is_whole_number(value: float) -> bool:
+    return Decimal(str(value)) == Decimal(str(value)).to_integral_value()
 
 
 @router.post("/adjust")
@@ -30,6 +35,8 @@ def adjust_inventory(
         raise HTTPException(status_code=404, detail="Product not found")
     if not product.maintain_inventory:
         raise HTTPException(status_code=400, detail="Inventory is disabled for this product")
+    if not product.allow_decimal and not _is_whole_number(payload.quantity):
+        raise HTTPException(status_code=400, detail="Quantity must be a whole number for this product")
 
     inventory = db.query(Inventory).filter(
         Inventory.product_id == payload.product_id,
@@ -39,8 +46,8 @@ def adjust_inventory(
         inventory = Inventory(company_id=active_company.id, product_id=payload.product_id, quantity=0)
         db.add(inventory)
 
-    inventory.quantity += payload.quantity
-    if inventory.quantity < 0:
+    inventory.quantity = Decimal(str(inventory.quantity or 0)) + Decimal(str(payload.quantity))
+    if Decimal(str(inventory.quantity or 0)) < 0:
         raise HTTPException(status_code=400, detail="Inventory cannot be negative")
 
     db.commit()
@@ -116,9 +123,11 @@ def list_inventory(
             product_id=product.id,
             product_name=product.name,
             sku=product.sku,
+            unit=product.unit,
+            allow_decimal=bool(product.allow_decimal),
             price=float(product.price),
             maintain_inventory=bool(product.maintain_inventory),
-            quantity=int(quantity),
+            quantity=float(quantity),
             date_added=product.created_at,
             last_sold_at=last_sold_at,
         )

--- a/backend/src/api/routes/invoices.py
+++ b/backend/src/api/routes/invoices.py
@@ -759,13 +759,13 @@ def _fmt_rate(value: float) -> str:
 
 def _build_pdf_tax_header_cells(interstate_supply: bool) -> str:
     if interstate_supply:
-  return '<th class="right">IGST<br>%</th><th class="right">IGST<br>Amt</th><th class="right">Total<br>Tax</th>'
+        return '<th class="right">IGST<br>%</th><th class="right">IGST<br>Amt</th><th class="right">Total<br>Tax</th>'
     return (
-  '<th class="right">SGST<br>%</th>'
-  '<th class="right">SGST<br>Amt</th>'
-  '<th class="right">CGST<br>%</th>'
-  '<th class="right">CGST<br>Amt</th>'
-  '<th class="right">Total<br>Tax</th>'
+        '<th class="right">SGST<br>%</th>'
+        '<th class="right">SGST<br>Amt</th>'
+        '<th class="right">CGST<br>%</th>'
+        '<th class="right">CGST<br>Amt</th>'
+        '<th class="right">Total<br>Tax</th>'
     )
 
 

--- a/backend/src/api/routes/invoices.py
+++ b/backend/src/api/routes/invoices.py
@@ -866,6 +866,7 @@ def _build_purchase_invoice_html(invoice: Invoice, products: list[Product]) -> s
             product_cell_html = f"{product_name}<br><span class=\"muted-text\">{item_description}</span>"
         sku = _e(prod.sku) if prod else "N/A"
         hsn = _e(item.hsn_sac or (prod.hsn_sac if prod else None) or "N/A")
+        unit = _e(_pdf_display_unit(getattr(prod, "unit", None) if prod else None))
         tax_row_cells = _build_pdf_tax_row_cells(item, currency, interstate_supply)
 
         item_rows += f"""
@@ -875,6 +876,7 @@ def _build_purchase_invoice_html(invoice: Invoice, products: list[Product]) -> s
           <td>{sku}</td>
           <td>{hsn}</td>
           <td class="right">{item.quantity}</td>
+          <td>{unit}</td>
           <td class="right">{_fmt_currency(_pdf_unit_price_including_tax(item), currency)}</td>
           {tax_row_cells}
           <td class="right">{_fmt_currency(float(item.line_total), currency)}</td>
@@ -1102,6 +1104,7 @@ def _build_purchase_invoice_html(invoice: Invoice, products: list[Product]) -> s
           <th>SKU</th>
           <th>HSN/SAC</th>
           <th class="right">Qty</th>
+          <th>Unit</th>
           <th class="right">Unit Price <span style="font-size: 7px; font-weight: 500; text-transform: none;">(with tax)</span></th>
           {tax_header_cells}
           <th class="right">Amount</th>

--- a/backend/src/api/routes/invoices.py
+++ b/backend/src/api/routes/invoices.py
@@ -1170,6 +1170,7 @@ def _build_invoice_html(invoice: Invoice, products: list[Product], invoice_bank_
             product_cell_html = f"{product_name}<br><span class=\"muted-text\">{item_description}</span>"
         sku = _e(prod.sku) if prod else "N/A"
         hsn = _e(item.hsn_sac or (prod.hsn_sac if prod else None) or "N/A")
+        unit = _e(_pdf_display_unit(getattr(prod, "unit", None) if prod else None))
         tax_row_cells = _build_pdf_tax_row_cells(item, currency, interstate_supply)
 
         item_rows += f"""
@@ -1179,6 +1180,7 @@ def _build_invoice_html(invoice: Invoice, products: list[Product], invoice_bank_
           <td>{sku}</td>
           <td>{hsn}</td>
           <td class="right">{item.quantity}</td>
+          <td>{unit}</td>
           <td class="right">{_fmt_currency(_pdf_unit_price_including_tax(item), currency)}</td>
           {tax_row_cells}
           <td class="right">{_fmt_currency(float(item.line_total), currency)}</td>
@@ -1482,6 +1484,7 @@ def _build_invoice_html(invoice: Invoice, products: list[Product], invoice_bank_
           <th>SKU</th>
           <th>HSN/SAC</th>
           <th class="right">Qty</th>
+          <th>Unit</th>
           <th class="right">Unit Price <span style="font-size: 7px; font-weight: 500; text-transform: none;">(with tax)</span></th>
           {tax_header_cells}
           <th class="right">Amount</th>

--- a/backend/src/api/routes/invoices.py
+++ b/backend/src/api/routes/invoices.py
@@ -759,13 +759,49 @@ def _fmt_rate(value: float) -> str:
 
 def _build_pdf_tax_header_cells(interstate_supply: bool) -> str:
     if interstate_supply:
-        return '<th class="right">IGST %</th><th class="right">IGST Amt</th><th class="right">Total Tax</th>'
+  return '<th class="right">IGST<br>%</th><th class="right">IGST<br>Amt</th><th class="right">Total<br>Tax</th>'
     return (
-        '<th class="right">SGST %</th>'
-        '<th class="right">SGST Amt</th>'
-        '<th class="right">CGST %</th>'
-        '<th class="right">CGST Amt</th>'
-        '<th class="right">Total Tax</th>'
+  '<th class="right">SGST<br>%</th>'
+  '<th class="right">SGST<br>Amt</th>'
+  '<th class="right">CGST<br>%</th>'
+  '<th class="right">CGST<br>Amt</th>'
+  '<th class="right">Total<br>Tax</th>'
+    )
+
+
+def _build_pdf_table_colgroup(interstate_supply: bool) -> str:
+    if interstate_supply:
+        return (
+            '<colgroup>'
+            '<col style="width: 4%;" />'
+            '<col style="width: 20%;" />'
+            '<col style="width: 7%;" />'
+            '<col style="width: 8%;" />'
+            '<col style="width: 6%;" />'
+            '<col style="width: 6%;" />'
+            '<col style="width: 12%;" />'
+            '<col style="width: 7%;" />'
+            '<col style="width: 10%;" />'
+            '<col style="width: 10%;" />'
+            '<col style="width: 10%;" />'
+            '</colgroup>'
+        )
+    return (
+        '<colgroup>'
+        '<col style="width: 3%;" />'
+        '<col style="width: 16%;" />'
+        '<col style="width: 6%;" />'
+        '<col style="width: 7%;" />'
+        '<col style="width: 5%;" />'
+        '<col style="width: 5%;" />'
+        '<col style="width: 10%;" />'
+        '<col style="width: 6%;" />'
+        '<col style="width: 8%;" />'
+        '<col style="width: 6%;" />'
+        '<col style="width: 8%;" />'
+        '<col style="width: 8%;" />'
+        '<col style="width: 12%;" />'
+        '</colgroup>'
     )
 
 
@@ -861,6 +897,7 @@ def _build_purchase_invoice_html(invoice: Invoice, products: list[Product]) -> s
     inv_date = invoice.invoice_date.strftime("%d %b %Y") if invoice.invoice_date else (invoice.created_at.strftime("%d %b %Y") if invoice.created_at else "N/A")
     interstate_supply = _is_interstate_supply(invoice.company_gst, invoice.ledger_gst)
     tax_header_cells = _build_pdf_tax_header_cells(interstate_supply)
+    table_colgroup = _build_pdf_table_colgroup(interstate_supply)
 
     product_map = {p.id: p for p in products}
 
@@ -1018,28 +1055,34 @@ def _build_purchase_invoice_html(invoice: Invoice, products: list[Product]) -> s
   }}
   .invoice-sheet__table {{
     width: 100%;
+    table-layout: fixed;
     border-collapse: collapse;
     margin-bottom: 16px;
-    font-size: 9px;
+    font-size: 8px;
   }}
   .invoice-sheet__table thead th {{
     background: #f3f4f6;
     color: #374151;
     font-weight: 600;
-    font-size: 8px;
+    font-size: 7px;
     text-transform: uppercase;
     letter-spacing: 0.04em;
-    padding: 7px 8px;
+    line-height: 1.2;
+    padding: 5px 4px;
     border-bottom: 2px solid #d1d5db;
     text-align: left;
+    white-space: normal;
+    overflow-wrap: anywhere;
   }}
   .invoice-sheet__table thead th.right {{
     text-align: right;
   }}
   .invoice-sheet__table tbody td {{
-    padding: 6px 8px;
+    padding: 5px 4px;
     border-bottom: 1px solid #e5e7eb;
     vertical-align: middle;
+    white-space: normal;
+    overflow-wrap: anywhere;
   }}
   .invoice-sheet__table tbody td.right {{
     text-align: right;
@@ -1105,6 +1148,7 @@ def _build_purchase_invoice_html(invoice: Invoice, products: list[Product]) -> s
 {supplier_ref_html}
   <section>
     <table class="invoice-sheet__table">
+      {table_colgroup}
       <thead>
         <tr>
           <th>#</th>
@@ -1113,7 +1157,7 @@ def _build_purchase_invoice_html(invoice: Invoice, products: list[Product]) -> s
           <th>HSN/SAC</th>
           <th class="right">Qty</th>
           <th>Unit</th>
-          <th class="right">Unit Price <span style="font-size: 7px; font-weight: 500; text-transform: none;">(with tax)</span></th>
+          <th class="right">Unit Price<br><span style="font-size: 6px; font-weight: 500; text-transform: none;">(with tax)</span></th>
           {tax_header_cells}
           <th class="right">Amount</th>
         </tr>
@@ -1164,6 +1208,7 @@ def _build_invoice_html(invoice: Invoice, products: list[Product], invoice_bank_
     inv_date = invoice.invoice_date.strftime("%d %b %Y") if invoice.invoice_date else (invoice.created_at.strftime("%d %b %Y") if invoice.created_at else "N/A")
     interstate_supply = _is_interstate_supply(invoice.company_gst, invoice.ledger_gst)
     tax_header_cells = _build_pdf_tax_header_cells(interstate_supply)
+    table_colgroup = _build_pdf_table_colgroup(interstate_supply)
 
     product_map = {p.id: p for p in products}
 
@@ -1337,28 +1382,34 @@ def _build_invoice_html(invoice: Invoice, products: list[Product], invoice_bank_
   }}
   .invoice-sheet__table {{
     width: 100%;
+    table-layout: fixed;
     border-collapse: collapse;
     margin-bottom: 16px;
-    font-size: 9px;
+    font-size: 8px;
   }}
   .invoice-sheet__table thead th {{
     background: #f3f4f6;
     color: #374151;
     font-weight: 600;
-    font-size: 8px;
+    font-size: 7px;
     text-transform: uppercase;
     letter-spacing: 0.04em;
-    padding: 7px 8px;
+    line-height: 1.2;
+    padding: 5px 4px;
     border-bottom: 2px solid #d1d5db;
     text-align: left;
+    white-space: normal;
+    overflow-wrap: anywhere;
   }}
   .invoice-sheet__table thead th.right {{
     text-align: right;
   }}
   .invoice-sheet__table tbody td {{
-    padding: 6px 8px;
+    padding: 5px 4px;
     border-bottom: 1px solid #e5e7eb;
     vertical-align: middle;
+    white-space: normal;
+    overflow-wrap: anywhere;
   }}
   .invoice-sheet__table tbody td.right {{
     text-align: right;
@@ -1485,6 +1536,7 @@ def _build_invoice_html(invoice: Invoice, products: list[Product], invoice_bank_
 
   <section>
     <table class="invoice-sheet__table">
+      {table_colgroup}
       <thead>
         <tr>
           <th>#</th>
@@ -1493,7 +1545,7 @@ def _build_invoice_html(invoice: Invoice, products: list[Product], invoice_bank_
           <th>HSN/SAC</th>
           <th class="right">Qty</th>
           <th>Unit</th>
-          <th class="right">Unit Price <span style="font-size: 7px; font-weight: 500; text-transform: none;">(with tax)</span></th>
+          <th class="right">Unit Price<br><span style="font-size: 6px; font-weight: 500; text-transform: none;">(with tax)</span></th>
           {tax_header_cells}
           <th class="right">Amount</th>
         </tr>

--- a/backend/src/api/routes/invoices.py
+++ b/backend/src/api/routes/invoices.py
@@ -868,6 +868,15 @@ def _pdf_display_unit(unit: str | None) -> str:
     return normalized_unit
 
 
+def _pdf_display_quantity(quantity: float | Decimal | int | None, allow_decimal: bool | None) -> str:
+  value = Decimal(str(quantity or 0))
+  if not allow_decimal and value == value.to_integral_value():
+    return str(int(value))
+
+  as_text = format(value, "f").rstrip("0").rstrip(".")
+  return as_text or "0"
+
+
 def _build_pdf_payment_details_html(invoice_bank_accounts: list[CompanyAccount]) -> str:
     if not invoice_bank_accounts:
         return '<p class="muted-text">No bank account marked to display on invoice.</p>'
@@ -912,6 +921,7 @@ def _build_purchase_invoice_html(invoice: Invoice, products: list[Product]) -> s
         sku = _e(prod.sku) if prod else "N/A"
         hsn = _e(item.hsn_sac or (prod.hsn_sac if prod else None) or "N/A")
         unit = _e(_pdf_display_unit(getattr(prod, "unit", None) if prod else None))
+        quantity_display = _pdf_display_quantity(item.quantity, getattr(prod, "allow_decimal", None) if prod else None)
         tax_row_cells = _build_pdf_tax_row_cells(item, currency, interstate_supply)
 
         item_rows += f"""
@@ -920,7 +930,7 @@ def _build_purchase_invoice_html(invoice: Invoice, products: list[Product]) -> s
           <td>{product_cell_html}</td>
           <td>{sku}</td>
           <td>{hsn}</td>
-          <td class="right">{item.quantity}</td>
+          <td class="right">{quantity_display}</td>
           <td>{unit}</td>
           <td class="right">{_fmt_currency(_pdf_unit_price_including_tax(item), currency)}</td>
           {tax_row_cells}
@@ -1224,6 +1234,7 @@ def _build_invoice_html(invoice: Invoice, products: list[Product], invoice_bank_
         sku = _e(prod.sku) if prod else "N/A"
         hsn = _e(item.hsn_sac or (prod.hsn_sac if prod else None) or "N/A")
         unit = _e(_pdf_display_unit(getattr(prod, "unit", None) if prod else None))
+        quantity_display = _pdf_display_quantity(item.quantity, getattr(prod, "allow_decimal", None) if prod else None)
         tax_row_cells = _build_pdf_tax_row_cells(item, currency, interstate_supply)
 
         item_rows += f"""
@@ -1232,7 +1243,7 @@ def _build_invoice_html(invoice: Invoice, products: list[Product], invoice_bank_
           <td>{product_cell_html}</td>
           <td>{sku}</td>
           <td>{hsn}</td>
-          <td class="right">{item.quantity}</td>
+          <td class="right">{quantity_display}</td>
           <td>{unit}</td>
           <td class="right">{_fmt_currency(_pdf_unit_price_including_tax(item), currency)}</td>
           {tax_row_cells}

--- a/backend/src/api/routes/invoices.py
+++ b/backend/src/api/routes/invoices.py
@@ -815,6 +815,15 @@ def _pdf_unit_price_including_tax(item: InvoiceItem) -> float:
     return float(_money(line_total / quantity))
 
 
+  def _pdf_display_unit(unit: str | None) -> str:
+    normalized_unit = (unit or "Pieces").strip()
+    if not normalized_unit:
+      normalized_unit = "Pieces"
+    if normalized_unit.lower() == "pieces":
+      return "Pcs"
+    return normalized_unit
+
+
 def _build_pdf_payment_details_html(invoice_bank_accounts: list[CompanyAccount]) -> str:
     if not invoice_bank_accounts:
         return '<p class="muted-text">No bank account marked to display on invoice.</p>'

--- a/backend/src/api/routes/invoices.py
+++ b/backend/src/api/routes/invoices.py
@@ -815,12 +815,12 @@ def _pdf_unit_price_including_tax(item: InvoiceItem) -> float:
     return float(_money(line_total / quantity))
 
 
-  def _pdf_display_unit(unit: str | None) -> str:
+def _pdf_display_unit(unit: str | None) -> str:
     normalized_unit = (unit or "Pieces").strip()
     if not normalized_unit:
-      normalized_unit = "Pieces"
+        normalized_unit = "Pieces"
     if normalized_unit.lower() == "pieces":
-      return "Pcs"
+        return "Pcs"
     return normalized_unit
 
 

--- a/backend/src/api/routes/invoices.py
+++ b/backend/src/api/routes/invoices.py
@@ -79,7 +79,7 @@ def _require_ledger(db: Session, ledger_id: int, company_id: int | None) -> Ledg
 def _change_inventory_quantity(
     db: Session,
     product_id: int,
-    quantity_delta: int,
+  quantity_delta: Decimal,
     *,
     company_id: int | None,
     context: str,
@@ -93,8 +93,8 @@ def _change_inventory_quantity(
         db.add(inventory)
         db.flush()
 
-    inventory.quantity += quantity_delta
-    if inventory.quantity < 0:
+    inventory.quantity = Decimal(str(inventory.quantity or 0)) + quantity_delta
+    if Decimal(str(inventory.quantity or 0)) < 0:
         raise HTTPException(status_code=400, detail=f"Insufficient inventory while {context}")
 
 
@@ -155,8 +155,9 @@ def _reverse_existing_invoice_inventory(db: Session, invoice: Invoice) -> None:
         )
 
 
-def _inventory_effect_for_voucher_type(quantity: int, voucher_type: str) -> int:
-    return -quantity if voucher_type == "sales" else quantity
+def _inventory_effect_for_voucher_type(quantity: float, voucher_type: str) -> Decimal:
+  quantity_value = Decimal(str(quantity))
+  return -quantity_value if voucher_type == "sales" else quantity_value
 
 
 def _apply_inventory_delta_for_invoice_update(
@@ -166,14 +167,14 @@ def _apply_inventory_delta_for_invoice_update(
     *,
     company_id: int | None,
 ) -> None:
-    existing_effect_by_product: dict[int, int] = defaultdict(int)
+    existing_effect_by_product: dict[int, Decimal] = defaultdict(lambda: Decimal("0"))
     for item in invoice.items:
         existing_effect_by_product[item.product_id] += _inventory_effect_for_voucher_type(
             item.quantity,
             invoice.voucher_type,
         )
 
-    next_effect_by_product: dict[int, int] = defaultdict(int)
+    next_effect_by_product: dict[int, Decimal] = defaultdict(lambda: Decimal("0"))
     for item in payload.items:
         next_effect_by_product[item.product_id] += _inventory_effect_for_voucher_type(
             item.quantity,
@@ -267,7 +268,8 @@ def _apply_payload_to_invoice(
     tax_total = Decimal("0")
     created_items: list[InvoiceItem] = []
     for item in payload.items:
-        if item.quantity <= 0:
+        quantity_value = Decimal(str(item.quantity))
+        if quantity_value <= 0:
             raise HTTPException(status_code=400, detail="Item quantity must be greater than zero")
 
         product_query = db.query(Product).filter(Product.id == item.product_id)
@@ -277,12 +279,18 @@ def _apply_payload_to_invoice(
         if not product:
             raise HTTPException(status_code=404, detail=f"Product {item.product_id} not found")
 
+        if not product.allow_decimal and quantity_value != quantity_value.to_integral_value():
+            raise HTTPException(
+                status_code=400,
+                detail=f"Quantity for {product.name} must be a whole number",
+            )
+
         if apply_inventory_changes and product.maintain_inventory:
             inventory_query = db.query(Inventory).filter(Inventory.product_id == item.product_id)
             if company_id is not None:
                 inventory_query = inventory_query.filter(or_(Inventory.company_id == company_id, Inventory.company_id.is_(None)))
             inventory = inventory_query.first()
-            if payload.voucher_type == "sales" and (not inventory or inventory.quantity < item.quantity):
+            if payload.voucher_type == "sales" and (not inventory or Decimal(str(inventory.quantity or 0)) < quantity_value):
                 raise HTTPException(status_code=400, detail=f"Insufficient inventory for {product.name}")
 
             quantity_delta = _inventory_effect_for_voucher_type(item.quantity, payload.voucher_type)
@@ -301,11 +309,11 @@ def _apply_payload_to_invoice(
 
         if payload.tax_inclusive:
             # Entered price already includes tax; back-calculate taxable amount
-            line_total = _money(unit_price * Decimal(item.quantity))
+            line_total = _money(unit_price * quantity_value)
             taxable_amount = _money(line_total / (1 + gst_rate / Decimal("100")))
             tax_amount = _money(line_total - taxable_amount)
         else:
-            taxable_amount = _money(unit_price * Decimal(item.quantity))
+            taxable_amount = _money(unit_price * quantity_value)
             tax_amount = _money(taxable_amount * gst_rate / Decimal("100"))
             line_total = _money(taxable_amount + tax_amount)
 
@@ -315,7 +323,7 @@ def _apply_payload_to_invoice(
         invoice_item = InvoiceItem(
             invoice_id=invoice.id,
             product_id=product.id,
-            quantity=item.quantity,
+            quantity=float(quantity_value),
             hsn_sac=product.hsn_sac,
             unit_price=float(unit_price),
             gst_rate=float(gst_rate),

--- a/backend/src/api/routes/products.py
+++ b/backend/src/api/routes/products.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
+from decimal import Decimal
 
 from src.db.session import get_db
 from src.models.company import CompanyProfile
@@ -11,6 +12,10 @@ from src.schemas.product import PaginatedProductOut, ProductCreate, ProductOut
 from src.api.deps import get_active_company, get_current_user, require_roles
 
 router = APIRouter()
+
+
+def _is_whole_number(value: float) -> bool:
+    return Decimal(str(value)) == Decimal(str(value)).to_integral_value()
 
 
 @router.post("", response_model=ProductOut, include_in_schema=False)
@@ -37,6 +42,8 @@ def create_product(
         hsn_sac=payload.hsn_sac,
         price=payload.price,
         gst_rate=payload.gst_rate,
+        unit=payload.unit,
+        allow_decimal=payload.allow_decimal,
         maintain_inventory=payload.maintain_inventory,
     )
     db.add(product)
@@ -47,6 +54,9 @@ def create_product(
             status_code=400,
             detail="Initial quantity is only allowed when maintain inventory is enabled",
         )
+
+    if not payload.allow_decimal and not _is_whole_number(payload.initial_quantity):
+        raise HTTPException(status_code=400, detail="Initial quantity must be a whole number for this product")
 
     if payload.maintain_inventory:
         inventory = Inventory(
@@ -120,6 +130,20 @@ def update_product(
     product.hsn_sac = payload.hsn_sac
     product.price = payload.price
     product.gst_rate = payload.gst_rate
+    product.unit = payload.unit
+
+    if product.allow_decimal and not payload.allow_decimal:
+        inventory = db.query(Inventory).filter(
+            Inventory.product_id == product_id,
+            Inventory.company_id == active_company.id,
+        ).first()
+        if inventory and not _is_whole_number(float(inventory.quantity or 0)):
+            raise HTTPException(
+                status_code=400,
+                detail="Cannot disable decimal quantity while inventory has fractional stock",
+            )
+
+    product.allow_decimal = payload.allow_decimal
     was_tracking_inventory = bool(product.maintain_inventory)
     product.maintain_inventory = payload.maintain_inventory
 

--- a/backend/src/models/inventory.py
+++ b/backend/src/models/inventory.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, ForeignKey
+from sqlalchemy import Column, Integer, ForeignKey, Numeric
 from sqlalchemy.orm import relationship
 from src.db.base import Base
 
@@ -9,6 +9,6 @@ class Inventory(Base):
     id = Column(Integer, primary_key=True, index=True)
     company_id = Column(Integer, ForeignKey("company_profiles.id"), nullable=True, index=True)
     product_id = Column(Integer, ForeignKey("products.id"), unique=True, nullable=False)
-    quantity = Column(Integer, default=0, nullable=False)
+    quantity = Column(Numeric(12, 3), default=0, nullable=False)
 
     product = relationship("Product")

--- a/backend/src/models/invoice.py
+++ b/backend/src/models/invoice.py
@@ -59,7 +59,7 @@ class InvoiceItem(Base):
     invoice_id = Column(Integer, ForeignKey("invoices.id"), nullable=False)
     product_id = Column(Integer, ForeignKey("products.id"), nullable=False)
     hsn_sac = Column(String, nullable=True)
-    quantity = Column(Integer, nullable=False)
+    quantity = Column(Numeric(12, 3), nullable=False)
     unit_price = Column(Numeric(10, 2), nullable=False)
     gst_rate = Column(Numeric(5, 2), nullable=False, default=0)
     taxable_amount = Column(Numeric(10, 2), nullable=False, default=0)

--- a/backend/src/models/product.py
+++ b/backend/src/models/product.py
@@ -13,5 +13,7 @@ class Product(Base):
     hsn_sac = Column(String, nullable=True)
     price = Column(Numeric(10, 2), nullable=False)
     gst_rate = Column(Numeric(5, 2), nullable=False, default=0)
+    unit = Column(String, nullable=False, default="Pieces")
+    allow_decimal = Column(Boolean, nullable=False, default=False)
     maintain_inventory = Column(Boolean, nullable=False, default=True)
     created_at = Column(DateTime, server_default=func.now(), nullable=True)

--- a/backend/src/schemas/inventory.py
+++ b/backend/src/schemas/inventory.py
@@ -5,16 +5,18 @@ from typing import Optional
 
 class InventoryAdjust(BaseModel):
     product_id: int
-    quantity: int
+    quantity: float
 
 
 class InventoryOut(BaseModel):
     product_id: int
     product_name: str
     sku: str
+    unit: str
+    allow_decimal: bool
     price: float
     maintain_inventory: bool
-    quantity: int
+    quantity: float
     date_added: Optional[datetime] = None
     last_sold_at: Optional[datetime] = None
 

--- a/backend/src/schemas/invoice.py
+++ b/backend/src/schemas/invoice.py
@@ -6,7 +6,7 @@ from src.schemas.ledger import LedgerOut
 
 class InvoiceItemCreate(BaseModel):
     product_id: int
-    quantity: int
+    quantity: float
     unit_price: float | None = None
     description: str | None = None
 
@@ -27,7 +27,7 @@ class InvoiceItemOut(BaseModel):
     id: int
     product_id: int
     hsn_sac: str | None = None
-    quantity: int
+    quantity: float
     unit_price: float
     gst_rate: float
     taxable_amount: float

--- a/backend/src/schemas/product.py
+++ b/backend/src/schemas/product.py
@@ -12,13 +12,23 @@ class ProductCreate(BaseModel):
     hsn_sac: Optional[str] = None
     price: float
     gst_rate: float = 0
+    unit: str = "Pieces"
+    allow_decimal: bool = False
     maintain_inventory: bool = True
-    initial_quantity: int = 0
+    initial_quantity: float = 0
 
     @field_validator("hsn_sac")
     @classmethod
     def validate_hsn_sac(cls, value: str | None) -> str | None:
         return normalize_hsn_sac(value)
+
+    @field_validator("unit")
+    @classmethod
+    def validate_unit(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("Unit is required")
+        return normalized
 
 
 class ProductOut(BaseModel):
@@ -29,6 +39,8 @@ class ProductOut(BaseModel):
     hsn_sac: Optional[str]
     price: float
     gst_rate: float
+    unit: str
+    allow_decimal: bool
     maintain_inventory: bool
     created_at: Optional[datetime] = None
 

--- a/backend/tests/api/test_inventory.py
+++ b/backend/tests/api/test_inventory.py
@@ -52,6 +52,8 @@ def test_inventory_list_marks_untracked_products(client):
     assert item["product_id"] == product_id
     assert item["maintain_inventory"] is False
     assert item["quantity"] == 0
+    assert item["unit"] == "Pieces"
+    assert item["allow_decimal"] is False
 
 
 def test_adjust_inventory_rejects_untracked_product(client):
@@ -74,3 +76,54 @@ def test_adjust_inventory_rejects_untracked_product(client):
     )
     assert adjust_response.status_code == 400
     assert adjust_response.json()["detail"] == "Inventory is disabled for this product"
+
+
+def test_adjust_inventory_rejects_fractional_quantity_for_whole_number_product(client):
+    create_response = client.post(
+        "/api/products/",
+        json={
+            "sku": "WHOLEINV1",
+            "name": "Whole Count Item",
+            "price": 120,
+            "gst_rate": 18,
+            "allow_decimal": False,
+        },
+    )
+    assert create_response.status_code == 200
+
+    product_id = create_response.json()["id"]
+    adjust_response = client.post(
+        "/api/inventory/adjust",
+        json={"product_id": product_id, "quantity": 1.5},
+    )
+    assert adjust_response.status_code == 400
+    assert adjust_response.json()["detail"] == "Quantity must be a whole number for this product"
+
+
+def test_adjust_inventory_accepts_fractional_quantity_for_decimal_product(client):
+    create_response = client.post(
+        "/api/products/",
+        json={
+            "sku": "DECINV1",
+            "name": "Liquid Product",
+            "price": 90,
+            "gst_rate": 18,
+            "unit": "l",
+            "allow_decimal": True,
+        },
+    )
+    assert create_response.status_code == 200
+
+    product_id = create_response.json()["id"]
+    adjust_response = client.post(
+        "/api/inventory/adjust",
+        json={"product_id": product_id, "quantity": 1.5},
+    )
+    assert adjust_response.status_code == 200
+
+    list_response = client.get("/api/inventory/?search=Liquid&page=1&page_size=20")
+    assert list_response.status_code == 200
+    item = list_response.json()["items"][0]
+    assert item["unit"] == "l"
+    assert item["allow_decimal"] is True
+    assert item["quantity"] == 1.5

--- a/backend/tests/api/test_invoice_pan_display.py
+++ b/backend/tests/api/test_invoice_pan_display.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from pathlib import Path
 import os
 import sys
+from types import SimpleNamespace
 
 BACKEND_ROOT = Path(__file__).resolve().parents[2]
 if str(BACKEND_ROOT) not in sys.path:
@@ -10,7 +11,7 @@ if str(BACKEND_ROOT) not in sys.path:
 os.environ.setdefault("DATABASE_URL", "sqlite:///./test.db")
 
 from src.api.routes.invoices import _build_invoice_html, _build_purchase_invoice_html, _extract_pan_from_gstin
-from src.models.invoice import Invoice
+from src.models.invoice import Invoice, InvoiceItem
 
 
 def _invoice_base(voucher_type: str = "sales") -> Invoice:
@@ -34,6 +35,21 @@ def _invoice_base(voucher_type: str = "sales") -> Invoice:
     )
     invoice.items = []
     return invoice
+
+
+def _line_item(product_id: int = 1):
+    return InvoiceItem(
+        product_id=product_id,
+        hsn_sac="1234",
+        quantity=2,
+        unit_price=100,
+        tax_amount=0,
+        cgst_amount=0,
+        sgst_amount=0,
+        igst_amount=0,
+        line_total=200,
+        description=None,
+    )
 
 
 def test_extract_pan_from_gstin_returns_pan_for_valid_gstin():
@@ -99,3 +115,25 @@ def test_purchase_pdf_tax_breakup_shows_only_cgst_sgst_for_intrastate_case():
     assert "CGST:" in html
     assert "SGST:" in html
     assert "IGST:" not in html
+
+
+def test_sales_pdf_shows_unit_column_and_abbreviates_pieces():
+    invoice = _invoice_base("sales")
+    invoice.items = [_line_item(product_id=11)]
+    product = SimpleNamespace(id=11, name="Steel Rod", sku="ROD-1", hsn_sac="7214", unit="Pieces")
+
+    html = _build_invoice_html(invoice, [product])
+
+    assert "<th>Unit</th>" in html
+    assert "<td>Pcs</td>" in html
+
+
+def test_purchase_pdf_shows_unit_column_and_keeps_custom_unit():
+    invoice = _invoice_base("purchase")
+    invoice.items = [_line_item(product_id=12)]
+    product = SimpleNamespace(id=12, name="Flour", sku="FLR-1", hsn_sac="1101", unit="Kg")
+
+    html = _build_purchase_invoice_html(invoice, [product])
+
+    assert "<th>Unit</th>" in html
+    assert "<td>Kg</td>" in html

--- a/backend/tests/api/test_invoice_pan_display.py
+++ b/backend/tests/api/test_invoice_pan_display.py
@@ -37,11 +37,11 @@ def _invoice_base(voucher_type: str = "sales") -> Invoice:
     return invoice
 
 
-def _line_item(product_id: int = 1):
+def _line_item(product_id: int = 1, quantity: float = 2):
     return InvoiceItem(
         product_id=product_id,
         hsn_sac="1234",
-        quantity=2,
+        quantity=quantity,
         unit_price=100,
         tax_amount=0,
         cgst_amount=0,
@@ -137,3 +137,24 @@ def test_purchase_pdf_shows_unit_column_and_keeps_custom_unit():
 
     assert "<th>Unit</th>" in html
     assert "<td>Kg</td>" in html
+
+
+def test_pdf_quantity_hides_trailing_zeroes_for_whole_number_product():
+    invoice = _invoice_base("sales")
+    invoice.items = [_line_item(product_id=21, quantity=1)]
+    product = SimpleNamespace(id=21, name="Whole Item", sku="W-1", hsn_sac="7214", unit="Pieces", allow_decimal=False)
+
+    html = _build_invoice_html(invoice, [product])
+
+    assert '<td class="right">1</td>' in html
+    assert '<td class="right">1.000</td>' not in html
+
+
+def test_pdf_quantity_keeps_decimal_for_decimal_enabled_product():
+    invoice = _invoice_base("sales")
+    invoice.items = [_line_item(product_id=22, quantity=1.5)]
+    product = SimpleNamespace(id=22, name="Decimal Item", sku="D-1", hsn_sac="7214", unit="Kg", allow_decimal=True)
+
+    html = _build_invoice_html(invoice, [product])
+
+    assert '<td class="right">1.5</td>' in html

--- a/backend/tests/api/test_invoice_update_inventory.py
+++ b/backend/tests/api/test_invoice_update_inventory.py
@@ -24,7 +24,14 @@ def _create_ledger(client, name: str, gst: str):
     return response.json()["id"]
 
 
-def _create_product(client, *, sku: str = "UPD-INV-001", maintain_inventory: bool = True):
+def _create_product(
+    client,
+    *,
+    sku: str = "UPD-INV-001",
+    maintain_inventory: bool = True,
+    allow_decimal: bool = False,
+    unit: str = "Pieces",
+):
     response = client.post(
         "/api/products/",
         json={
@@ -34,6 +41,8 @@ def _create_product(client, *, sku: str = "UPD-INV-001", maintain_inventory: boo
             "hsn_sac": "9988",
             "price": 100,
             "gst_rate": 18,
+            "unit": unit,
+            "allow_decimal": allow_decimal,
             "maintain_inventory": maintain_inventory,
         },
     )
@@ -153,3 +162,42 @@ def test_update_sales_invoice_with_untracked_product_does_not_create_inventory(c
         assert update_response.status_code == 200, update_response.text
         inventory = db_session.query(Inventory).filter(Inventory.product_id == product_id).first()
         assert inventory is None
+
+
+def test_invoice_rejects_decimal_quantity_for_whole_number_product(client):
+    with patch("src.api.routes.invoices._generate_next_number", return_value="SAL-WHOLE-001"):
+        ledger_id = _create_ledger(client, name="Sales Whole Qty", gst="27ABCDE1234F1Z5")
+        product_id = _create_product(client, sku="UPD-INV-WHOLE-QTY", allow_decimal=False, unit="Pieces")
+
+        response = client.post(
+            "/api/invoices/",
+            json={
+                "ledger_id": ledger_id,
+                "voucher_type": "sales",
+                "tax_inclusive": False,
+                "apply_round_off": False,
+                "items": [{"product_id": product_id, "quantity": 1.25, "unit_price": 100}],
+            },
+        )
+
+        assert response.status_code == 400
+        assert "must be a whole number" in response.json()["detail"]
+
+
+def test_invoice_accepts_decimal_quantity_for_decimal_enabled_product(client):
+    with patch("src.api.routes.invoices._generate_next_number", return_value="PUR-DEC-001"):
+        ledger_id = _create_ledger(client, name="Purchase Decimal Qty", gst="27ABCDE1234F1Z5")
+        product_id = _create_product(client, sku="UPD-INV-DEC-QTY", allow_decimal=True, unit="Kg")
+
+        response = client.post(
+            "/api/invoices/",
+            json={
+                "ledger_id": ledger_id,
+                "voucher_type": "purchase",
+                "tax_inclusive": False,
+                "apply_round_off": False,
+                "items": [{"product_id": product_id, "quantity": 1.25, "unit_price": 100}],
+            },
+        )
+
+        assert response.status_code == 200, response.text

--- a/backend/tests/api/test_products.py
+++ b/backend/tests/api/test_products.py
@@ -7,9 +7,10 @@ def test_create_product(client):
         "price": 10,
         "gst_rate": 18
     })
-    print(response.json())  # 👈 add this
-
     assert response.status_code == 200
+    payload = response.json()
+    assert payload["unit"] == "Pieces"
+    assert payload["allow_decimal"] is False
  
 
 def test_duplicate_sku(client):
@@ -142,3 +143,43 @@ def test_toggle_untracked_product_on_creates_inventory_row(client, db_session):
     inventory = db_session.query(Inventory).filter(Inventory.product_id == product_id).first()
     assert inventory is not None
     assert inventory.quantity == 0
+
+
+def test_create_product_with_custom_unit_and_allow_decimal(client):
+    response = client.post(
+        "/api/products/",
+        json={
+            "sku": "UNITKG1",
+            "name": "Fine Flour",
+            "price": 45,
+            "gst_rate": 5,
+            "unit": "Kg",
+            "allow_decimal": True,
+            "maintain_inventory": True,
+            "initial_quantity": 2.75,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["unit"] == "Kg"
+    assert payload["allow_decimal"] is True
+
+
+def test_reject_fractional_initial_quantity_when_decimal_disabled(client):
+    response = client.post(
+        "/api/products/",
+        json={
+            "sku": "WHOLEONLY1",
+            "name": "Whole Unit Item",
+            "price": 30,
+            "gst_rate": 5,
+            "unit": "Pieces",
+            "allow_decimal": False,
+            "maintain_inventory": True,
+            "initial_quantity": 1.25,
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Initial quantity must be a whole number for this product"

--- a/frontend/src/components/CompanySelector.tsx
+++ b/frontend/src/components/CompanySelector.tsx
@@ -1,0 +1,265 @@
+import { useEffect, useRef, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { AnimatePresence, motion } from 'framer-motion';
+import api, { getApiErrorMessage } from '../api/client';
+import type {
+  CompanyCreationCapOut,
+  CompanyListItem,
+  CompanyProfile,
+  CompanyProfileUpdate,
+  CompanySelectOut,
+} from '../types/api';
+
+export default function CompanySelector() {
+  const queryClient = useQueryClient();
+  const [companyDropdownOpen, setCompanyDropdownOpen] = useState(false);
+  const [companySwitchingId, setCompanySwitchingId] = useState<number | null>(null);
+  const [companyError, setCompanyError] = useState('');
+  const [newCompanyModalOpen, setNewCompanyModalOpen] = useState(false);
+  const [newCompanyName, setNewCompanyName] = useState('');
+  const [newCompanySubmitting, setNewCompanySubmitting] = useState(false);
+  const [newCompanyError, setNewCompanyError] = useState('');
+  const companyDropdownRef = useRef<HTMLDivElement>(null);
+
+  const companiesQuery = useQuery({
+    queryKey: ['sidebar-companies'],
+    queryFn: async () => {
+      const [companiesRes, capabilityRes] = await Promise.all([
+        api.get<CompanyListItem[]>('/company/companies'),
+        api.get<CompanyCreationCapOut>('/company/companies/capability'),
+      ]);
+
+      return {
+        companies: companiesRes.data,
+        canCreateCompany: capabilityRes.data.can_create_company,
+      };
+    },
+    refetchOnWindowFocus: 'always',
+  });
+
+  const companyList = companiesQuery.data?.companies ?? [];
+  const canCreateCompany = companiesQuery.data?.canCreateCompany ?? false;
+  const activeCompany = companyList.find((company) => company.is_active) ?? null;
+  const queryError = companiesQuery.error
+    ? getApiErrorMessage(companiesQuery.error, 'Failed to load companies')
+    : '';
+  const effectiveCompanyError = companyError || queryError;
+
+  useEffect(() => {
+    if (!companyDropdownOpen) return;
+    const onClickOutside = (e: MouseEvent) => {
+      if (companyDropdownRef.current && !companyDropdownRef.current.contains(e.target as Node)) {
+        setCompanyDropdownOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', onClickOutside);
+    return () => document.removeEventListener('mousedown', onClickOutside);
+  }, [companyDropdownOpen]);
+
+  const handleCompanySwitch = async (companyId: number) => {
+    if (companySwitchingId !== null) return;
+    setCompanySwitchingId(companyId);
+    setCompanyError('');
+    try {
+      const res = await api.post<CompanySelectOut>(`/company/select/${companyId}`);
+      localStorage.setItem('active_company_id', String(res.data.active_company_id));
+      window.location.reload();
+    } catch (error) {
+      setCompanyError(getApiErrorMessage(error, 'Failed to switch company'));
+    } finally {
+      setCompanySwitchingId(null);
+    }
+  };
+
+  const handleCreateCompany = async () => {
+    const trimmedName = newCompanyName.trim();
+    if (!trimmedName) {
+      setNewCompanyError('Company name is required.');
+      return;
+    }
+    setNewCompanySubmitting(true);
+    setNewCompanyError('');
+    const payload: CompanyProfileUpdate = {
+      name: trimmedName,
+      address: '',
+      gst: '',
+      phone_number: '',
+      currency_code: 'USD',
+      email: '',
+      website: '',
+      bank_name: '',
+      branch_name: '',
+      account_name: '',
+      account_number: '',
+      ifsc_code: '',
+    };
+
+    try {
+      const createRes = await api.post<CompanyProfile>('/company/companies', payload);
+      await handleCompanySwitch(createRes.data.id);
+    } catch (error) {
+      setNewCompanyError(getApiErrorMessage(error, 'Failed to create company'));
+    } finally {
+      setNewCompanySubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      <p className="sidebar__group-label" style={{ marginBottom: '6px' }}>Company</p>
+      <div ref={companyDropdownRef} style={{ position: 'relative', marginBottom: '12px' }}>
+        <button
+          className="button button--ghost"
+          style={{ width: '100%', textAlign: 'left', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}
+          onClick={() => setCompanyDropdownOpen((v) => !v)}
+          aria-haspopup="listbox"
+          aria-expanded={companyDropdownOpen}
+        >
+          <span>{activeCompany?.name?.trim() || 'Select company'}</span>
+          <span style={{ fontSize: '0.75rem', opacity: 0.6 }}>▾</span>
+        </button>
+        {companyDropdownOpen && (
+          <div
+            role="listbox"
+            style={{
+              position: 'absolute',
+              left: 0,
+              right: 0,
+              top: 'calc(100% + 4px)',
+              background: 'var(--bg-card-strong)',
+              border: '1px solid var(--line-strong)',
+              borderRadius: '0.5rem',
+              boxShadow: '0 4px 24px rgba(0,0,0,0.45)',
+              zIndex: 100,
+              overflow: 'hidden',
+              color: 'var(--text)',
+            }}
+          >
+            {companiesQuery.isLoading && (
+              <p style={{ padding: '0.5rem 0.75rem', fontSize: '0.85rem', opacity: 0.7 }}>Loading companies...</p>
+            )}
+            {!companiesQuery.isLoading && companyList.length === 0 && (
+              <p style={{ padding: '0.5rem 0.75rem', fontSize: '0.85rem', opacity: 0.6 }}>No companies found</p>
+            )}
+            {companyList.map((company) => (
+              <button
+                key={company.id}
+                role="option"
+                aria-selected={company.is_active}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '0.5rem',
+                  width: '100%',
+                  textAlign: 'left',
+                  padding: '0.5rem 0.75rem',
+                  background: 'none',
+                  border: 'none',
+                  cursor: companySwitchingId === null ? 'pointer' : 'wait',
+                  fontWeight: company.is_active ? 700 : 400,
+                  fontSize: '0.875rem',
+                  color: 'inherit',
+                }}
+                disabled={companySwitchingId !== null}
+                onClick={() => {
+                  void handleCompanySwitch(company.id);
+                  setCompanyDropdownOpen(false);
+                }}
+              >
+                <span style={{ width: '1rem' }}>{company.is_active ? '✓' : ''}</span>
+                {company.name || `Company #${company.id}`}
+              </button>
+            ))}
+            {canCreateCompany && (
+              <>
+                <hr style={{ margin: '0.25rem 0', border: 'none', borderTop: '1px solid var(--line)' }} />
+                <button
+                  style={{
+                    display: 'block',
+                    width: '100%',
+                    textAlign: 'left',
+                    padding: '0.5rem 0.75rem',
+                    background: 'none',
+                    border: 'none',
+                    cursor: 'pointer',
+                    fontSize: '0.875rem',
+                    color: 'inherit',
+                    fontWeight: 500,
+                  }}
+                  onClick={() => {
+                    setCompanyDropdownOpen(false);
+                    setNewCompanyName('');
+                    setNewCompanyError('');
+                    setNewCompanyModalOpen(true);
+                  }}
+                >
+                  + New Company
+                </button>
+              </>
+            )}
+          </div>
+        )}
+      </div>
+      {effectiveCompanyError && (
+        <p style={{ marginTop: '-6px', marginBottom: '8px', color: 'var(--error, #ef4444)', fontSize: '0.8rem' }}>
+          {effectiveCompanyError}
+        </p>
+      )}
+
+      <AnimatePresence>
+        {newCompanyModalOpen && (
+          <motion.div
+            className="modal-overlay"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            onClick={(e) => { if (e.target === e.currentTarget) setNewCompanyModalOpen(false); }}
+          >
+            <motion.div
+              className="modal-panel"
+              role="dialog"
+              aria-modal="true"
+              aria-label="Create new company"
+              initial={{ scale: 0.95, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              exit={{ scale: 0.95, opacity: 0 }}
+              transition={{ duration: 0.2 }}
+              style={{ maxWidth: '28rem' }}
+            >
+              <h2 style={{ marginBottom: '1.25rem', fontSize: '1.125rem', fontWeight: 700 }}>New Company</h2>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+                <label style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem', fontSize: '0.875rem', fontWeight: 500 }}>
+                  Company name
+                  <input
+                    className="input"
+                    value={newCompanyName}
+                    onChange={(e) => setNewCompanyName(e.target.value)}
+                    autoFocus
+                  />
+                </label>
+                <p style={{ margin: 0, fontSize: '0.8rem', opacity: 0.7 }}>
+                  This creates a blank company profile. You can complete GST, address, and bank details on the Company page.
+                </p>
+                {newCompanyError && <p style={{ margin: 0, color: 'var(--error, #ef4444)', fontSize: '0.85rem' }}>{newCompanyError}</p>}
+                <div style={{ display: 'flex', gap: '0.75rem', justifyContent: 'flex-end', marginTop: '0.5rem' }}>
+                  <button type="button" className="button button--ghost" onClick={() => setNewCompanyModalOpen(false)}>
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    className="button"
+                    disabled={newCompanySubmitting}
+                    onClick={() => { void handleCreateCompany(); }}
+                  >
+                    {newCompanySubmitting ? 'Creating…' : 'Create Company'}
+                  </button>
+                </div>
+              </div>
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </>
+  );
+}

--- a/frontend/src/components/CreateInvoiceModal.tsx
+++ b/frontend/src/components/CreateInvoiceModal.tsx
@@ -311,6 +311,7 @@ export default function CreateInvoiceModal({
             <div className="stack">
               {items.map((item, index) => {
                 const selectedProduct = products.find((p) => p.id === Number(item.productId));
+                const selectedUnit = selectedProduct?.unit || 'Pieces';
                 const unitPrice = item.unit_price ? Number(item.unit_price) : (selectedProduct?.price || 0);
                 const gstRate = selectedProduct?.gst_rate || 0;
                 let lineTotal: number;
@@ -341,7 +342,7 @@ export default function CreateInvoiceModal({
                     </div>
 
                     <div className="field">
-                      <label htmlFor={`modal-inv-qty-${item.id}`}>Qty</label>
+                      <label htmlFor={`modal-inv-qty-${item.id}`}>Qty ({selectedUnit})</label>
                       <input
                         id={`modal-inv-qty-${item.id}`}
                         className="input"

--- a/frontend/src/components/CreateInvoiceModal.tsx
+++ b/frontend/src/components/CreateInvoiceModal.tsx
@@ -312,6 +312,7 @@ export default function CreateInvoiceModal({
               {items.map((item, index) => {
                 const selectedProduct = products.find((p) => p.id === Number(item.productId));
                 const selectedUnit = selectedProduct?.unit || 'Pieces';
+                const allowDecimalQuantity = Boolean(selectedProduct?.allow_decimal);
                 const unitPrice = item.unit_price ? Number(item.unit_price) : (selectedProduct?.price || 0);
                 const gstRate = selectedProduct?.gst_rate || 0;
                 let lineTotal: number;
@@ -347,8 +348,8 @@ export default function CreateInvoiceModal({
                         id={`modal-inv-qty-${item.id}`}
                         className="input"
                         type="number"
-                        min="1"
-                        step="1"
+                        min={allowDecimalQuantity ? '0.001' : '1'}
+                        step={allowDecimalQuantity ? '0.001' : '1'}
                         value={item.quantity}
                         onChange={(e) => updateItem(item.id, 'quantity', e.target.value)}
                         required

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -2,16 +2,9 @@ import { useEffect, useRef, useState } from 'react';
 import axios from 'axios';
 import { AnimatePresence, motion } from 'framer-motion';
 import { Link, NavLink } from 'react-router-dom';
-import api, { getApiErrorMessage } from '../api/client';
+import CompanySelector from './CompanySelector';
 import { useAuth } from '../context/AuthContext';
 import { useFY } from '../context/FYContext';
-import type {
-  CompanyCreationCapOut,
-  CompanyListItem,
-  CompanyProfile,
-  CompanyProfileUpdate,
-  CompanySelectOut,
-} from '../types/api';
 
 type NavItem = { to: string; label: string; end?: boolean };
 
@@ -63,20 +56,7 @@ export default function Sidebar({ isOpen = false, onClose }: SidebarProps) {
   const [newFYStartYear, setNewFYStartYear] = useState('');
   const [newFYError, setNewFYError] = useState('');
   const [newFYSubmitting, setNewFYSubmitting] = useState(false);
-  const [companyDropdownOpen, setCompanyDropdownOpen] = useState(false);
-  const [companyList, setCompanyList] = useState<CompanyListItem[]>([]);
-  const [companyLoading, setCompanyLoading] = useState(false);
-  const [companySwitchingId, setCompanySwitchingId] = useState<number | null>(null);
-  const [companyError, setCompanyError] = useState('');
-  const [canCreateCompany, setCanCreateCompany] = useState(true);
-  const [newCompanyModalOpen, setNewCompanyModalOpen] = useState(false);
-  const [newCompanyName, setNewCompanyName] = useState('');
-  const [newCompanySubmitting, setNewCompanySubmitting] = useState(false);
-  const [newCompanyError, setNewCompanyError] = useState('');
   const fyDropdownRef = useRef<HTMLDivElement>(null);
-  const companyDropdownRef = useRef<HTMLDivElement>(null);
-
-  const activeCompany = companyList.find((company) => company.is_active) ?? null;
 
   useEffect(() => {
     if (!fyDropdownOpen) return;
@@ -90,110 +70,11 @@ export default function Sidebar({ isOpen = false, onClose }: SidebarProps) {
   }, [fyDropdownOpen]);
 
   useEffect(() => {
-    if (!companyDropdownOpen) return;
-    const onClickOutside = (e: MouseEvent) => {
-      if (companyDropdownRef.current && !companyDropdownRef.current.contains(e.target as Node)) {
-        setCompanyDropdownOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', onClickOutside);
-    return () => document.removeEventListener('mousedown', onClickOutside);
-  }, [companyDropdownOpen]);
-
-  useEffect(() => {
     if (!isOpen) return;
     const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose?.(); };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
   }, [isOpen, onClose]);
-
-  useEffect(() => {
-    if (!showCompanySwitcher) {
-      return;
-    }
-
-    if (!isAuthenticated) {
-      setCompanyList([]);
-      setCompanyError('');
-      setCanCreateCompany(false);
-      return;
-    }
-
-    let cancelled = false;
-    const loadCompanies = async () => {
-      setCompanyLoading(true);
-      setCompanyError('');
-      try {
-        const [companiesRes, capabilityRes] = await Promise.all([
-          api.get<CompanyListItem[]>('/company/companies'),
-          api.get<CompanyCreationCapOut>('/company/companies/capability'),
-        ]);
-        if (cancelled) return;
-        setCompanyList(companiesRes.data);
-        setCanCreateCompany(capabilityRes.data.can_create_company);
-      } catch (error) {
-        if (cancelled) return;
-        setCanCreateCompany(false);
-        setCompanyError(getApiErrorMessage(error, 'Failed to load companies'));
-      } finally {
-        if (!cancelled) {
-          setCompanyLoading(false);
-        }
-      }
-    };
-
-    void loadCompanies();
-    return () => {
-      cancelled = true;
-    };
-  }, [isAuthenticated, showCompanySwitcher]);
-
-  const handleCompanySwitch = async (companyId: number) => {
-    if (companySwitchingId !== null) return;
-    setCompanySwitchingId(companyId);
-    setCompanyError('');
-    try {
-      const res = await api.post<CompanySelectOut>(`/company/select/${companyId}`);
-      localStorage.setItem('active_company_id', String(res.data.active_company_id));
-      window.location.reload();
-    } catch (error) {
-      setCompanyError(getApiErrorMessage(error, 'Failed to switch company'));
-      setCompanySwitchingId(null);
-    }
-  };
-
-  const handleCreateCompany = async () => {
-    const trimmedName = newCompanyName.trim();
-    if (!trimmedName) {
-      setNewCompanyError('Company name is required.');
-      return;
-    }
-    setNewCompanySubmitting(true);
-    setNewCompanyError('');
-    const payload: CompanyProfileUpdate = {
-      name: trimmedName,
-      address: '',
-      gst: '',
-      phone_number: '',
-      currency_code: 'USD',
-      email: '',
-      website: '',
-      bank_name: '',
-      branch_name: '',
-      account_name: '',
-      account_number: '',
-      ifsc_code: '',
-    };
-
-    try {
-      const createRes = await api.post<CompanyProfile>('/company/companies', payload);
-      await handleCompanySwitch(createRes.data.id);
-    } catch (error) {
-      setNewCompanyError(getApiErrorMessage(error, 'Failed to create company'));
-    } finally {
-      setNewCompanySubmitting(false);
-    }
-  };
 
   return (
     <>
@@ -273,109 +154,7 @@ export default function Sidebar({ isOpen = false, onClose }: SidebarProps) {
 
         {/* FY section — above footer */}
         <div style={{ padding: '12px 10px', borderTop: '1px solid var(--sidebar-border)' }}>
-          {showCompanySwitcher && (
-            <>
-              <p className="sidebar__group-label" style={{ marginBottom: '6px' }}>Company</p>
-              <div ref={companyDropdownRef} style={{ position: 'relative', marginBottom: '12px' }}>
-                <button
-                  className="button button--ghost"
-                  style={{ width: '100%', textAlign: 'left', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}
-                  onClick={() => setCompanyDropdownOpen((v) => !v)}
-                  aria-haspopup="listbox"
-                  aria-expanded={companyDropdownOpen}
-                >
-                  <span>{activeCompany?.name?.trim() || 'Select company'}</span>
-                  <span style={{ fontSize: '0.75rem', opacity: 0.6 }}>▾</span>
-                </button>
-                {companyDropdownOpen && (
-                  <div
-                    role="listbox"
-                    style={{
-                      position: 'absolute',
-                      left: 0,
-                      right: 0,
-                      top: 'calc(100% + 4px)',
-                      background: 'var(--bg-card-strong)',
-                      border: '1px solid var(--line-strong)',
-                      borderRadius: '0.5rem',
-                      boxShadow: '0 4px 24px rgba(0,0,0,0.45)',
-                      zIndex: 100,
-                      overflow: 'hidden',
-                      color: 'var(--text)',
-                    }}
-                  >
-                    {companyLoading && (
-                      <p style={{ padding: '0.5rem 0.75rem', fontSize: '0.85rem', opacity: 0.7 }}>Loading companies...</p>
-                    )}
-                    {!companyLoading && companyList.length === 0 && (
-                      <p style={{ padding: '0.5rem 0.75rem', fontSize: '0.85rem', opacity: 0.6 }}>No companies found</p>
-                    )}
-                    {companyList.map((company) => (
-                      <button
-                        key={company.id}
-                        role="option"
-                        aria-selected={company.is_active}
-                        style={{
-                          display: 'flex',
-                          alignItems: 'center',
-                          gap: '0.5rem',
-                          width: '100%',
-                          textAlign: 'left',
-                          padding: '0.5rem 0.75rem',
-                          background: 'none',
-                          border: 'none',
-                          cursor: companySwitchingId === null ? 'pointer' : 'wait',
-                          fontWeight: company.is_active ? 700 : 400,
-                          fontSize: '0.875rem',
-                          color: 'inherit',
-                        }}
-                        disabled={companySwitchingId !== null}
-                        onClick={() => {
-                          void handleCompanySwitch(company.id);
-                          setCompanyDropdownOpen(false);
-                        }}
-                      >
-                        <span style={{ width: '1rem' }}>{company.is_active ? '✓' : ''}</span>
-                        {company.name || `Company #${company.id}`}
-                      </button>
-                    ))}
-                    {canCreateCompany && (
-                      <>
-                        <hr style={{ margin: '0.25rem 0', border: 'none', borderTop: '1px solid var(--line)' }} />
-                        <button
-                          style={{
-                            display: 'block',
-                            width: '100%',
-                            textAlign: 'left',
-                            padding: '0.5rem 0.75rem',
-                            background: 'none',
-                            border: 'none',
-                            cursor: 'pointer',
-                            fontSize: '0.875rem',
-                            color: 'inherit',
-                            fontWeight: 500,
-                          }}
-                          onClick={() => {
-                            setCompanyDropdownOpen(false);
-                            setNewCompanyName('');
-                            setNewCompanyError('');
-                            setNewCompanyModalOpen(true);
-                          }}
-                        >
-                          + New Company
-                        </button>
-                      </>
-                    )}
-                  </div>
-                )}
-              </div>
-              {companyError && (
-                <p style={{ marginTop: '-6px', marginBottom: '8px', color: 'var(--error, #ef4444)', fontSize: '0.8rem' }}>
-                  {companyError}
-                </p>
-              )}
-            </>
-          )}
+          {showCompanySwitcher && <CompanySelector />}
 
           <p className="sidebar__group-label" style={{ marginBottom: '6px' }}>Financial Year</p>
           <div ref={fyDropdownRef} style={{ position: 'relative' }}>
@@ -483,59 +262,6 @@ export default function Sidebar({ isOpen = false, onClose }: SidebarProps) {
 
       {/* New FY Modal */}
       <AnimatePresence>
-        {showCompanySwitcher && newCompanyModalOpen && (
-          <motion.div
-            className="modal-overlay"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: 0.2 }}
-            onClick={(e) => { if (e.target === e.currentTarget) setNewCompanyModalOpen(false); }}
-          >
-            <motion.div
-              className="modal-panel"
-              role="dialog"
-              aria-modal="true"
-              aria-label="Create new company"
-              initial={{ scale: 0.95, opacity: 0 }}
-              animate={{ scale: 1, opacity: 1 }}
-              exit={{ scale: 0.95, opacity: 0 }}
-              transition={{ duration: 0.2 }}
-              style={{ maxWidth: '28rem' }}
-            >
-              <h2 style={{ marginBottom: '1.25rem', fontSize: '1.125rem', fontWeight: 700 }}>New Company</h2>
-              <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
-                <label style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem', fontSize: '0.875rem', fontWeight: 500 }}>
-                  Company name
-                  <input
-                    className="input"
-                    value={newCompanyName}
-                    onChange={(e) => setNewCompanyName(e.target.value)}
-                    autoFocus
-                  />
-                </label>
-                <p style={{ margin: 0, fontSize: '0.8rem', opacity: 0.7 }}>
-                  This creates a blank company profile. You can complete GST, address, and bank details on the Company page.
-                </p>
-                {newCompanyError && <p style={{ margin: 0, color: 'var(--error, #ef4444)', fontSize: '0.85rem' }}>{newCompanyError}</p>}
-                <div style={{ display: 'flex', gap: '0.75rem', justifyContent: 'flex-end', marginTop: '0.5rem' }}>
-                  <button type="button" className="button button--ghost" onClick={() => setNewCompanyModalOpen(false)}>
-                    Cancel
-                  </button>
-                  <button
-                    type="button"
-                    className="button"
-                    disabled={newCompanySubmitting}
-                    onClick={() => { void handleCreateCompany(); }}
-                  >
-                    {newCompanySubmitting ? 'Creating…' : 'Create Company'}
-                  </button>
-                </div>
-              </div>
-            </motion.div>
-          </motion.div>
-        )}
-
         {newFYModalOpen && (
           <motion.div
             className="modal-overlay"

--- a/frontend/src/pages/InventoryPage.tsx
+++ b/frontend/src/pages/InventoryPage.tsx
@@ -92,6 +92,11 @@ export default function InventoryPage() {
     return new Date(iso).toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' });
   }
 
+  function formatQuantity(value: number, allowDecimal: boolean) {
+    if (!allowDecimal) return String(Math.trunc(value));
+    return value.toFixed(3).replace(/\.0+$/, '').replace(/(\.\d*?)0+$/, '$1');
+  }
+
   function SortHeader({ col, label }: { col: SortBy; label: string }) {
     const active = sortBy === col;
     return (
@@ -158,13 +163,13 @@ export default function InventoryPage() {
                     <div className="table-row__meta" style={{ flex: '1 1 180px' }}>
                       <strong>{row.product_name}</strong>
                       <span className="table-subtext">
-                        {row.sku} • {row.maintain_inventory ? 'Tracked' : 'Untracked'}
+                        {row.sku} • {row.maintain_inventory ? 'Tracked' : 'Untracked'} • Unit {row.unit}
                       </span>
                     </div>
 
                     {/* Qty pill */}
                     <span className={`pill ${row.quantity <= 5 ? 'pill--low' : 'pill--ok'}`} style={{ minWidth: 48, textAlign: 'center' }}>
-                      {row.quantity}
+                      {formatQuantity(row.quantity, row.allow_decimal)}
                     </span>
 
                     {/* Dates */}
@@ -182,7 +187,7 @@ export default function InventoryPage() {
                       <input
                         className="input"
                         type="number"
-                        step="1"
+                        step={row.allow_decimal ? '0.001' : '1'}
                         placeholder="e.g. +10"
                         value={adjusting[row.product_id] ?? ''}
                         onChange={(e) => setRowDelta(row.product_id, e.target.value)}

--- a/frontend/src/pages/ProductsPage.tsx
+++ b/frontend/src/pages/ProductsPage.tsx
@@ -7,6 +7,9 @@ import ConfirmDialog from '../components/ConfirmDialog';
 import formatCurrency from '../utils/formatting';
 import EmptyState from '../components/EmptyState';
 
+const UNIT_OPTIONS = ['Pieces', 'Kg', 'g', 'm', 'l', 'Ounce'];
+const CUSTOM_UNIT_VALUE = '__custom__';
+
 export default function ProductsPage() {
   const [products, setProducts] = useState<Product[]>([]);
   const [company, setCompany] = useState<CompanyProfile | null>(null);
@@ -30,6 +33,8 @@ export default function ProductsPage() {
     hsn_sac: '',
     price: '',
     gst_rate: '0',
+    unit: 'Pieces',
+    allow_decimal: false,
     maintain_inventory: true,
     initial_quantity: '0',
   });
@@ -62,7 +67,7 @@ export default function ProductsPage() {
   }, [page, search]);
 
   function resetForm() {
-    setForm({ sku: '', name: '', description: '', hsn_sac: '', price: '', gst_rate: '0', maintain_inventory: true, initial_quantity: '0' });
+    setForm({ sku: '', name: '', description: '', hsn_sac: '', price: '', gst_rate: '0', unit: 'Pieces', allow_decimal: false, maintain_inventory: true, initial_quantity: '0' });
     setEditingProductId(null);
   }
 
@@ -77,6 +82,8 @@ export default function ProductsPage() {
       hsn_sac: product.hsn_sac ?? '',
       price: String(product.price),
       gst_rate: String(product.gst_rate),
+      unit: product.unit || 'Pieces',
+      allow_decimal: product.allow_decimal,
       maintain_inventory: product.maintain_inventory,
       initial_quantity: '0',
     });
@@ -97,6 +104,8 @@ export default function ProductsPage() {
         hsn_sac: form.hsn_sac.trim(),
         price: Number(form.price),
         gst_rate: Number(form.gst_rate),
+        unit: form.unit.trim() || 'Pieces',
+        allow_decimal: form.allow_decimal,
         maintain_inventory: form.maintain_inventory,
         ...(editingProductId ? {} : { initial_quantity: Number(form.initial_quantity) }),
       };
@@ -226,6 +235,39 @@ export default function ProductsPage() {
                   required
                 />
               </div>
+              <div className="field">
+                <label htmlFor="unit">Unit</label>
+                <select
+                  id="unit"
+                  className="input"
+                  value={UNIT_OPTIONS.includes(form.unit) ? form.unit : CUSTOM_UNIT_VALUE}
+                  onChange={(event) => {
+                    const value = event.target.value;
+                    setForm((current) => ({
+                      ...current,
+                      unit: value === CUSTOM_UNIT_VALUE ? '' : value,
+                    }));
+                  }}
+                >
+                  {UNIT_OPTIONS.map((unitOption) => (
+                    <option key={unitOption} value={unitOption}>{unitOption}</option>
+                  ))}
+                  <option value={CUSTOM_UNIT_VALUE}>Other (custom)</option>
+                </select>
+              </div>
+              {UNIT_OPTIONS.includes(form.unit) ? null : (
+                <div className="field">
+                  <label htmlFor="custom-unit">Custom unit</label>
+                  <input
+                    id="custom-unit"
+                    className="input"
+                    value={form.unit}
+                    onChange={(event) => setForm((current) => ({ ...current, unit: event.target.value }))}
+                    placeholder="e.g. cm, ml, pack"
+                    required
+                  />
+                </div>
+              )}
               <div className="field field--full">
                 <label htmlFor="name">Name</label>
                 <input
@@ -261,6 +303,20 @@ export default function ProductsPage() {
                   Turn this off for service-style items such as service charges.
                 </span>
               </div>
+              <div className="field field--full" style={{ marginBottom: 0 }}>
+                <label htmlFor="allow-decimal" style={{ display: 'flex', alignItems: 'center', gap: '10px', marginBottom: 0 }}>
+                  <input
+                    id="allow-decimal"
+                    type="checkbox"
+                    checked={form.allow_decimal}
+                    onChange={(event) => setForm((current) => ({ ...current, allow_decimal: event.target.checked }))}
+                  />
+                  Allow decimal quantity
+                </label>
+                <span className="field-hint">
+                  Turn this on for units like Kg, l, m and other fractional stock.
+                </span>
+              </div>
               {!editingProductId && form.maintain_inventory ? (
                 <div className="field">
                   <label htmlFor="initial-quantity">Initial stock quantity</label>
@@ -269,7 +325,7 @@ export default function ProductsPage() {
                     className="input"
                     type="number"
                     min="0"
-                    step="1"
+                    step={form.allow_decimal ? '0.001' : '1'}
                     value={form.initial_quantity}
                     onChange={(event) => setForm((current) => ({ ...current, initial_quantity: event.target.value }))}
                     placeholder="0"
@@ -334,6 +390,8 @@ export default function ProductsPage() {
                       <span className="table-subtext">
                         {product.sku}
                         {product.maintain_inventory ? ' • Tracked' : ' • Untracked'}
+                        {` • Unit ${product.unit}`}
+                        {product.allow_decimal ? ' • Decimal qty' : ' • Whole qty'}
                         {product.hsn_sac ? ` • HSN/SAC ${product.hsn_sac}` : ''}
                         {` • GST ${product.gst_rate}%`}
                         {product.description ? ` • ${product.description}` : ''}

--- a/frontend/src/pages/invoices/InvoicesPageView.tsx
+++ b/frontend/src/pages/invoices/InvoicesPageView.tsx
@@ -638,6 +638,7 @@ export default function InvoicesPage() {
               <div className="stack">
                 {items.map((item, index) => {
                   const selectedProduct = products.find((product) => product.id === Number(item.productId));
+                  const selectedUnit = selectedProduct?.unit || 'Pieces';
                   const unitPrice = item.unit_price ? Number(item.unit_price) : (selectedProduct?.price || 0);
                   const gstRate = selectedProduct?.gst_rate || 0;
                   let lineTotal: number;
@@ -668,7 +669,7 @@ export default function InvoicesPage() {
                       </div>
 
                       <div className="field">
-                        <label htmlFor={`invoice-quantity-${item.id}`}>Qty</label>
+                        <label htmlFor={`invoice-quantity-${item.id}`}>Qty ({selectedUnit})</label>
                         <input
                           id={`invoice-quantity-${item.id}`}
                           className="input"

--- a/frontend/src/pages/invoices/InvoicesPageView.tsx
+++ b/frontend/src/pages/invoices/InvoicesPageView.tsx
@@ -639,6 +639,7 @@ export default function InvoicesPage() {
                 {items.map((item, index) => {
                   const selectedProduct = products.find((product) => product.id === Number(item.productId));
                   const selectedUnit = selectedProduct?.unit || 'Pieces';
+                  const allowDecimalQuantity = Boolean(selectedProduct?.allow_decimal);
                   const unitPrice = item.unit_price ? Number(item.unit_price) : (selectedProduct?.price || 0);
                   const gstRate = selectedProduct?.gst_rate || 0;
                   let lineTotal: number;
@@ -674,8 +675,8 @@ export default function InvoicesPage() {
                           id={`invoice-quantity-${item.id}`}
                           className="input"
                           type="number"
-                          min="1"
-                          step="1"
+                          min={allowDecimalQuantity ? '0.001' : '1'}
+                          step={allowDecimalQuantity ? '0.001' : '1'}
                           value={item.quantity}
                           onChange={(event) => updateItem(item.id, 'quantity', event.target.value)}
                           required

--- a/frontend/src/pages/invoices/components/ProductQuickCreateModal.tsx
+++ b/frontend/src/pages/invoices/components/ProductQuickCreateModal.tsx
@@ -6,8 +6,11 @@ import { invoiceQueryKeys } from '../../../features/invoices/queryKeys';
 import { useInvoiceComposerStore } from '../../../store/useInvoiceComposerStore';
 import type { ProductFormState } from '../types';
 
+const UNIT_OPTIONS = ['Pieces', 'Kg', 'g', 'm', 'l', 'Ounce'];
+const CUSTOM_UNIT_VALUE = '__custom__';
+
 function createInitialProductForm(): ProductFormState {
-  return { name: '', sku: '', hsn_sac: '', price: '', gst_rate: '0', maintain_inventory: true };
+  return { name: '', sku: '', hsn_sac: '', price: '', gst_rate: '0', unit: 'Pieces', allow_decimal: false, maintain_inventory: true };
 }
 
 export default function ProductQuickCreateModal() {
@@ -38,6 +41,8 @@ export default function ProductQuickCreateModal() {
         hsn_sac: productForm.hsn_sac.trim(),
         price: Number(productForm.price),
         gst_rate: Number(productForm.gst_rate),
+        unit: productForm.unit.trim() || 'Pieces',
+        allow_decimal: productForm.allow_decimal,
         maintain_inventory: productForm.maintain_inventory,
       };
 
@@ -130,6 +135,39 @@ export default function ProductQuickCreateModal() {
               required
             />
           </div>
+          <div className="field">
+            <label htmlFor="modal-product-unit">Unit</label>
+            <select
+              id="modal-product-unit"
+              className="input"
+              value={UNIT_OPTIONS.includes(productForm.unit) ? productForm.unit : CUSTOM_UNIT_VALUE}
+              onChange={(event) => {
+                const value = event.target.value;
+                setProductForm((current) => ({
+                  ...current,
+                  unit: value === CUSTOM_UNIT_VALUE ? '' : value,
+                }));
+              }}
+            >
+              {UNIT_OPTIONS.map((unitOption) => (
+                <option key={unitOption} value={unitOption}>{unitOption}</option>
+              ))}
+              <option value={CUSTOM_UNIT_VALUE}>Other (custom)</option>
+            </select>
+          </div>
+          {UNIT_OPTIONS.includes(productForm.unit) ? null : (
+            <div className="field">
+              <label htmlFor="modal-product-custom-unit">Custom unit</label>
+              <input
+                id="modal-product-custom-unit"
+                className="input"
+                value={productForm.unit}
+                onChange={(event) => setProductForm((current) => ({ ...current, unit: event.target.value }))}
+                placeholder="e.g. cm, ml, pack"
+                required
+              />
+            </div>
+          )}
           <div className="field field--full" style={{ marginBottom: 0 }}>
             <label htmlFor="modal-product-maintain-inventory" style={{ display: 'flex', alignItems: 'center', gap: '10px', marginBottom: 0 }}>
               <input
@@ -141,6 +179,18 @@ export default function ProductQuickCreateModal() {
               Maintain inventory for this product
             </label>
             <small className="field-hint">Disable this for service charges and other non-stock items.</small>
+          </div>
+          <div className="field field--full" style={{ marginBottom: 0 }}>
+            <label htmlFor="modal-product-allow-decimal" style={{ display: 'flex', alignItems: 'center', gap: '10px', marginBottom: 0 }}>
+              <input
+                id="modal-product-allow-decimal"
+                type="checkbox"
+                checked={productForm.allow_decimal}
+                onChange={(event) => setProductForm((current) => ({ ...current, allow_decimal: event.target.checked }))}
+              />
+              Allow decimal quantity
+            </label>
+            <small className="field-hint">Enable this for fractional stock units like Kg or l.</small>
           </div>
 
           <div className="button-row">

--- a/frontend/src/pages/invoices/types.ts
+++ b/frontend/src/pages/invoices/types.ts
@@ -12,6 +12,8 @@ export type ProductFormState = {
   hsn_sac: string;
   price: string;
   gst_rate: string;
+  unit: string;
+  allow_decimal: boolean;
   maintain_inventory: boolean;
 };
 

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -12,6 +12,8 @@ export type Product = {
   hsn_sac: string | null;
   price: number;
   gst_rate: number;
+  unit: string;
+  allow_decimal: boolean;
   maintain_inventory: boolean;
   created_at: string | null;
 };
@@ -23,6 +25,8 @@ export type ProductCreate = {
   hsn_sac: string;
   price: number;
   gst_rate: number;
+  unit: string;
+  allow_decimal: boolean;
   maintain_inventory: boolean;
   initial_quantity?: number;
 };
@@ -31,6 +35,8 @@ export type InventoryRow = {
   product_id: number;
   product_name: string;
   sku: string;
+  unit: string;
+  allow_decimal: boolean;
   price: number;
   maintain_inventory: boolean;
   quantity: number;


### PR DESCRIPTION
## Summary

Extracted company selector from Sidebar into its own separate component (`CompanySelector.tsx`) with dedicated state management. Migrated company data fetching to React Query with `refetchOnWindowFocus: 'always'` to keep company list fresh. Replaced `window.location.reload()` hack with `queryClient.invalidateQueries()` after company switch to clear all cached data cleanly.

## Type of change

- [x] refactor

## How to test

1. Navigate to the sidebar with an active user session
2. Click the Company selector dropdown
3. Verify it loads and displays company list
4. Switch between companies and verify data refreshes without page reload
5. Tab away and return to the window - list should refetch automatically

## Checklist

- [x] My code follows the project style and conventions
- [x] I ran relevant checks locally (npm run lint)
- [x] I verified this does not break existing behavior
- [x] No new dependencies added (uses existing @tanstack/react-query)

## Related issue

(No issue reference)
