### PR TITLE
feat(inventory): add BOM production workflow and frontend UI

### DIFF
--- a/backend/app_main.py
+++ b/backend/app_main.py
@@ -13,8 +13,6 @@ from src.db.session import engine
 # Import all models to register them with declarative_base
 import src.models  # noqa: F401
 
-Base.metadata.create_all(bind=engine)
-
 
 def run_pending_migrations() -> None:
     """Auto-apply pending migrations on startup (same as `python migrate.py up`)."""
@@ -60,6 +58,10 @@ def run_pending_migrations() -> None:
 
 
 run_pending_migrations()
+
+# Keep a safety net for any non-migrated tables while avoiding migration drift:
+# run migrations first, then create any missing tables.
+Base.metadata.create_all(bind=engine)
 
 app = FastAPI(title="Simple Invoicing API", version="0.1.0")
 

--- a/backend/app_main.py
+++ b/backend/app_main.py
@@ -10,6 +10,8 @@ from src.api.routes import auth, users, products, inventory, invoices, ledgers, 
 from src.api.routes import auth, users, products, inventory, invoices, ledgers, company, payments, smtp, email as email_routes, shortcuts, invoice_series as invoice_series_routes, financial_years as financial_years_routes, credit_notes as credit_notes_routes, backups as backups_routes, company_accounts as company_accounts_routes
 from src.db.base import Base
 from src.db.session import engine
+# Import all models to register them with declarative_base
+import src.models  # noqa: F401
 
 Base.metadata.create_all(bind=engine)
 

--- a/backend/app_main.py
+++ b/backend/app_main.py
@@ -7,7 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy import text
 
 from src.api.routes import auth, users, products, inventory, invoices, ledgers, company, payments, smtp, email as email_routes, shortcuts, invoice_series as invoice_series_routes, financial_years as financial_years_routes
-from src.api.routes import auth, users, products, inventory, invoices, ledgers, company, payments, smtp, email as email_routes, shortcuts, invoice_series as invoice_series_routes, financial_years as financial_years_routes, credit_notes as credit_notes_routes, backups as backups_routes, company_accounts as company_accounts_routes
+from src.api.routes import auth, users, products, inventory, invoices, ledgers, company, payments, smtp, email as email_routes, shortcuts, invoice_series as invoice_series_routes, financial_years as financial_years_routes, credit_notes as credit_notes_routes, backups as backups_routes, company_accounts as company_accounts_routes, bom as bom_routes
 from src.db.base import Base
 from src.db.session import engine
 # Import all models to register them with declarative_base
@@ -91,6 +91,7 @@ app.include_router(auth.router, prefix="/api/auth", tags=["auth"])
 app.include_router(users.router, prefix="/api/users", tags=["users"])
 app.include_router(products.router, prefix="/api/products", tags=["products"])
 app.include_router(inventory.router, prefix="/api/inventory", tags=["inventory"])
+app.include_router(bom_routes.router, prefix="/api/bom", tags=["bom"])
 app.include_router(invoices.router, prefix="/api/invoices", tags=["invoices"])
 app.include_router(ledgers.router, prefix="/api/ledgers", tags=["ledgers"])
 app.include_router(company.router, prefix="/api/company", tags=["company"])

--- a/backend/app_main.py
+++ b/backend/app_main.py
@@ -13,6 +13,8 @@ from src.db.session import engine
 # Import all models to register them with declarative_base
 import src.models  # noqa: F401
 
+Base.metadata.create_all(bind=engine)
+
 
 def run_pending_migrations() -> None:
     """Auto-apply pending migrations on startup (same as `python migrate.py up`)."""
@@ -58,10 +60,6 @@ def run_pending_migrations() -> None:
 
 
 run_pending_migrations()
-
-# Keep a safety net for any non-migrated tables while avoiding migration drift:
-# run migrations first, then create any missing tables.
-Base.metadata.create_all(bind=engine)
 
 app = FastAPI(title="Simple Invoicing API", version="0.1.0")
 

--- a/backend/migrations/20260502000001_add_bom_tables.py
+++ b/backend/migrations/20260502000001_add_bom_tables.py
@@ -1,0 +1,99 @@
+"""
+Add Bill of Materials (BOM) support.
+
+Adds:
+- is_producable and production_cost fields to products
+- bill_of_materials table
+- production_transactions table for audit trail
+"""
+
+from sqlalchemy import text
+
+
+def up(conn) -> None:
+    # Add BOM fields to products table
+    conn.execute(text("""
+        ALTER TABLE products
+        ADD COLUMN is_producable BOOLEAN NOT NULL DEFAULT FALSE;
+    """))
+    
+    conn.execute(text("""
+        ALTER TABLE products
+        ADD COLUMN production_cost NUMERIC(12, 2) DEFAULT NULL;
+    """))
+    
+    # Create bill_of_materials table
+    conn.execute(text("""
+        CREATE TABLE bill_of_materials (
+            id SERIAL PRIMARY KEY,
+            company_id INTEGER NOT NULL,
+            product_id INTEGER NOT NULL,
+            component_product_id INTEGER NOT NULL,
+            quantity_required NUMERIC(12, 3) NOT NULL,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (company_id) REFERENCES company_profiles(id) ON DELETE CASCADE,
+            FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE CASCADE,
+            FOREIGN KEY (component_product_id) REFERENCES products(id) ON DELETE CASCADE,
+            UNIQUE (company_id, product_id, component_product_id)
+        );
+    """))
+    
+    conn.execute(text("""
+        CREATE INDEX idx_bom_company ON bill_of_materials(company_id);
+    """))
+    
+    conn.execute(text("""
+        CREATE INDEX idx_bom_product ON bill_of_materials(product_id);
+    """))
+    
+    conn.execute(text("""
+        CREATE INDEX idx_bom_component ON bill_of_materials(component_product_id);
+    """))
+    
+    # Create production_transactions table
+    conn.execute(text("""
+        CREATE TABLE production_transactions (
+            id SERIAL PRIMARY KEY,
+            company_id INTEGER NOT NULL,
+            product_id INTEGER NOT NULL,
+            quantity_produced NUMERIC(12, 3) NOT NULL,
+            user_id INTEGER NOT NULL,
+            notes TEXT DEFAULT NULL,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (company_id) REFERENCES company_profiles(id) ON DELETE CASCADE,
+            FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE CASCADE,
+            FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+        );
+    """))
+    
+    conn.execute(text("""
+        CREATE INDEX idx_production_company ON production_transactions(company_id);
+    """))
+    
+    conn.execute(text("""
+        CREATE INDEX idx_production_product ON production_transactions(product_id);
+    """))
+    
+    conn.execute(text("""
+        CREATE INDEX idx_production_created ON production_transactions(created_at);
+    """))
+
+
+def down(conn) -> None:
+    conn.execute(text("""
+        DROP TABLE IF EXISTS production_transactions CASCADE;
+    """))
+    
+    conn.execute(text("""
+        DROP TABLE IF EXISTS bill_of_materials CASCADE;
+    """))
+    
+    conn.execute(text("""
+        ALTER TABLE products
+        DROP COLUMN IF EXISTS production_cost;
+    """))
+    
+    conn.execute(text("""
+        ALTER TABLE products
+        DROP COLUMN IF EXISTS is_producable;
+    """))

--- a/backend/migrations/20260502000001_add_bom_tables.py
+++ b/backend/migrations/20260502000001_add_bom_tables.py
@@ -14,17 +14,17 @@ def up(conn) -> None:
     # Add BOM fields to products table
     conn.execute(text("""
         ALTER TABLE products
-        ADD COLUMN is_producable BOOLEAN NOT NULL DEFAULT FALSE;
+        ADD COLUMN IF NOT EXISTS is_producable BOOLEAN NOT NULL DEFAULT FALSE;
     """))
     
     conn.execute(text("""
         ALTER TABLE products
-        ADD COLUMN production_cost NUMERIC(12, 2) DEFAULT NULL;
+        ADD COLUMN IF NOT EXISTS production_cost NUMERIC(12, 2) DEFAULT NULL;
     """))
     
     # Create bill_of_materials table
     conn.execute(text("""
-        CREATE TABLE bill_of_materials (
+        CREATE TABLE IF NOT EXISTS bill_of_materials (
             id SERIAL PRIMARY KEY,
             company_id INTEGER NOT NULL,
             product_id INTEGER NOT NULL,
@@ -39,20 +39,20 @@ def up(conn) -> None:
     """))
     
     conn.execute(text("""
-        CREATE INDEX idx_bom_company ON bill_of_materials(company_id);
+            CREATE INDEX IF NOT EXISTS idx_bom_company ON bill_of_materials(company_id);
     """))
     
     conn.execute(text("""
-        CREATE INDEX idx_bom_product ON bill_of_materials(product_id);
+            CREATE INDEX IF NOT EXISTS idx_bom_product ON bill_of_materials(product_id);
     """))
     
     conn.execute(text("""
-        CREATE INDEX idx_bom_component ON bill_of_materials(component_product_id);
+            CREATE INDEX IF NOT EXISTS idx_bom_component ON bill_of_materials(component_product_id);
     """))
     
     # Create production_transactions table
     conn.execute(text("""
-        CREATE TABLE production_transactions (
+            CREATE TABLE IF NOT EXISTS production_transactions (
             id SERIAL PRIMARY KEY,
             company_id INTEGER NOT NULL,
             product_id INTEGER NOT NULL,
@@ -67,15 +67,15 @@ def up(conn) -> None:
     """))
     
     conn.execute(text("""
-        CREATE INDEX idx_production_company ON production_transactions(company_id);
+            CREATE INDEX IF NOT EXISTS idx_production_company ON production_transactions(company_id);
     """))
     
     conn.execute(text("""
-        CREATE INDEX idx_production_product ON production_transactions(product_id);
+            CREATE INDEX IF NOT EXISTS idx_production_product ON production_transactions(product_id);
     """))
     
     conn.execute(text("""
-        CREATE INDEX idx_production_created ON production_transactions(created_at);
+            CREATE INDEX IF NOT EXISTS idx_production_created ON production_transactions(created_at);
     """))
 
 

--- a/backend/src/api/routes/bom.py
+++ b/backend/src/api/routes/bom.py
@@ -1,0 +1,180 @@
+"""
+BOM (Bill of Materials) API endpoints.
+"""
+
+from decimal import Decimal
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from src.api.dependencies import get_db, get_current_user, require_roles
+from src.models.user import UserRole, User
+from src.models.product import Product
+from src.models.bom import BillOfMaterial
+from src.models.production_transaction import ProductionTransaction
+from src.schemas.bom import (
+    BOMCreate,
+    BOMUpdate,
+    BOMComponentOut,
+    ProduceRequest,
+    ProductionTransactionOut,
+    PaginatedProductionTransactionOut,
+)
+from src.services import bom_service
+
+router = APIRouter()
+
+
+@router.get("/product/{product_id}", response_model=list[BOMComponentOut])
+def get_product_bom(
+    product_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """
+    Get BOM for a producable product.
+    Returns list of components with quantities required.
+    """
+    # Verify product exists and belongs to user's company
+    product = db.query(Product).filter(
+        Product.id == product_id,
+        Product.company_id == current_user.company_id,
+    ).first()
+
+    if not product:
+        raise HTTPException(status_code=404, detail="Product not found")
+
+    if not product.is_producable:
+        raise HTTPException(
+            status_code=400, detail="Product is not marked as producable"
+        )
+
+    components = bom_service.get_bom_components(
+        db, current_user.company_id, product_id
+    )
+    return components
+
+
+@router.post("/", status_code=201, response_model=dict)
+@require_roles(UserRole.admin, UserRole.manager)
+def create_bom_entry(
+    bom_create: BOMCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """
+    Add a component to a product's BOM.
+    """
+    # Verify product exists and is producable
+    product = db.query(Product).filter(
+        Product.id == bom_create.product_id,
+        Product.company_id == current_user.company_id,
+    ).first()
+
+    if not product:
+        raise HTTPException(status_code=404, detail="Product not found")
+
+    if not product.is_producable:
+        raise HTTPException(
+            status_code=400, detail="Product must be marked as producable"
+        )
+
+    # Verify component product exists
+    component = db.query(Product).filter(
+        Product.id == bom_create.component_product_id,
+        Product.company_id == current_user.company_id,
+    ).first()
+
+    if not component:
+        raise HTTPException(status_code=404, detail="Component product not found")
+
+    # Check for circular BOM
+    try:
+        bom_service.validate_no_circular_bom(
+            db,
+            current_user.company_id,
+            bom_create.product_id,
+            bom_create.component_product_id,
+        )
+    except bom_service.CircularBOMError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    # Check if entry already exists
+    existing = db.query(BillOfMaterial).filter(
+        BillOfMaterial.company_id == current_user.company_id,
+        BillOfMaterial.product_id == bom_create.product_id,
+        BillOfMaterial.component_product_id == bom_create.component_product_id,
+    ).first()
+
+    if existing:
+        raise HTTPException(status_code=400, detail="BOM entry already exists")
+
+    # Create BOM entry
+    bom_entry = BillOfMaterial(
+        company_id=current_user.company_id,
+        product_id=bom_create.product_id,
+        component_product_id=bom_create.component_product_id,
+        quantity_required=Decimal(str(bom_create.quantity_required)),
+    )
+
+    db.add(bom_entry)
+    db.commit()
+    db.refresh(bom_entry)
+
+    return {
+        "id": bom_entry.id,
+        "message": f"Added component to BOM",
+    }
+
+
+@router.put("/{bom_id}", response_model=dict)
+@require_roles(UserRole.admin, UserRole.manager)
+def update_bom_entry(
+    bom_id: int,
+    bom_update: BOMUpdate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """
+    Update quantity required for a BOM component.
+    """
+    bom_entry = db.query(BillOfMaterial).filter(
+        BillOfMaterial.id == bom_id,
+        BillOfMaterial.company_id == current_user.company_id,
+    ).first()
+
+    if not bom_entry:
+        raise HTTPException(status_code=404, detail="BOM entry not found")
+
+    bom_entry.quantity_required = Decimal(str(bom_update.quantity_required))
+    db.commit()
+    db.refresh(bom_entry)
+
+    return {"id": bom_entry.id, "message": "BOM entry updated"}
+
+
+@router.delete("/{bom_id}", response_model=dict)
+@require_roles(UserRole.admin, UserRole.manager)
+def delete_bom_entry(
+    bom_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """
+    Remove a component from a product's BOM.
+    """
+    bom_entry = db.query(BillOfMaterial).filter(
+        BillOfMaterial.id == bom_id,
+        BillOfMaterial.company_id == current_user.company_id,
+    ).first()
+
+    if not bom_entry:
+        raise HTTPException(status_code=404, detail="BOM entry not found")
+
+    product_id = bom_entry.product_id
+    db.delete(bom_entry)
+    db.commit()
+
+    return {
+        "message": f"BOM entry deleted",
+        "product_id": product_id,
+    }

--- a/backend/src/api/routes/bom.py
+++ b/backend/src/api/routes/bom.py
@@ -6,7 +6,8 @@ from decimal import Decimal
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
-from src.api.dependencies import get_db, get_current_user, require_roles
+from src.api.deps import get_db, get_current_user, require_roles, get_active_company
+from src.models.company import CompanyProfile
 from src.models.user import UserRole, User
 from src.models.product import Product
 from src.models.bom import BillOfMaterial
@@ -29,6 +30,7 @@ def get_product_bom(
     product_id: int,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
+    active_company: CompanyProfile = Depends(get_active_company),
 ):
     """
     Get BOM for a producable product.
@@ -37,7 +39,7 @@ def get_product_bom(
     # Verify product exists and belongs to user's company
     product = db.query(Product).filter(
         Product.id == product_id,
-        Product.company_id == current_user.company_id,
+        Product.company_id == active_company.id,
     ).first()
 
     if not product:
@@ -49,17 +51,17 @@ def get_product_bom(
         )
 
     components = bom_service.get_bom_components(
-        db, current_user.company_id, product_id
+        db, active_company.id, product_id
     )
     return components
 
 
 @router.post("/", status_code=201, response_model=dict)
-@require_roles(UserRole.admin, UserRole.manager)
 def create_bom_entry(
     bom_create: BOMCreate,
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    _: User = Depends(require_roles(UserRole.admin, UserRole.manager)),
+    active_company: CompanyProfile = Depends(get_active_company),
 ):
     """
     Add a component to a product's BOM.
@@ -67,7 +69,7 @@ def create_bom_entry(
     # Verify product exists and is producable
     product = db.query(Product).filter(
         Product.id == bom_create.product_id,
-        Product.company_id == current_user.company_id,
+        Product.company_id == active_company.id,
     ).first()
 
     if not product:
@@ -81,7 +83,7 @@ def create_bom_entry(
     # Verify component product exists
     component = db.query(Product).filter(
         Product.id == bom_create.component_product_id,
-        Product.company_id == current_user.company_id,
+        Product.company_id == active_company.id,
     ).first()
 
     if not component:
@@ -91,7 +93,7 @@ def create_bom_entry(
     try:
         bom_service.validate_no_circular_bom(
             db,
-            current_user.company_id,
+            active_company.id,
             bom_create.product_id,
             bom_create.component_product_id,
         )
@@ -100,7 +102,7 @@ def create_bom_entry(
 
     # Check if entry already exists
     existing = db.query(BillOfMaterial).filter(
-        BillOfMaterial.company_id == current_user.company_id,
+        BillOfMaterial.company_id == active_company.id,
         BillOfMaterial.product_id == bom_create.product_id,
         BillOfMaterial.component_product_id == bom_create.component_product_id,
     ).first()
@@ -110,7 +112,7 @@ def create_bom_entry(
 
     # Create BOM entry
     bom_entry = BillOfMaterial(
-        company_id=current_user.company_id,
+        company_id=active_company.id,
         product_id=bom_create.product_id,
         component_product_id=bom_create.component_product_id,
         quantity_required=Decimal(str(bom_create.quantity_required)),
@@ -127,19 +129,19 @@ def create_bom_entry(
 
 
 @router.put("/{bom_id}", response_model=dict)
-@require_roles(UserRole.admin, UserRole.manager)
 def update_bom_entry(
     bom_id: int,
     bom_update: BOMUpdate,
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    _: User = Depends(require_roles(UserRole.admin, UserRole.manager)),
+    active_company: CompanyProfile = Depends(get_active_company),
 ):
     """
     Update quantity required for a BOM component.
     """
     bom_entry = db.query(BillOfMaterial).filter(
         BillOfMaterial.id == bom_id,
-        BillOfMaterial.company_id == current_user.company_id,
+        BillOfMaterial.company_id == active_company.id,
     ).first()
 
     if not bom_entry:
@@ -153,18 +155,18 @@ def update_bom_entry(
 
 
 @router.delete("/{bom_id}", response_model=dict)
-@require_roles(UserRole.admin, UserRole.manager)
 def delete_bom_entry(
     bom_id: int,
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    _: User = Depends(require_roles(UserRole.admin, UserRole.manager)),
+    active_company: CompanyProfile = Depends(get_active_company),
 ):
     """
     Remove a component from a product's BOM.
     """
     bom_entry = db.query(BillOfMaterial).filter(
         BillOfMaterial.id == bom_id,
-        BillOfMaterial.company_id == current_user.company_id,
+        BillOfMaterial.company_id == active_company.id,
     ).first()
 
     if not bom_entry:

--- a/backend/src/api/routes/bom.py
+++ b/backend/src/api/routes/bom.py
@@ -3,7 +3,7 @@ BOM (Bill of Materials) API endpoints.
 """
 
 from decimal import Decimal
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
 from src.api.deps import get_db, get_current_user, require_roles, get_active_company
@@ -11,15 +11,7 @@ from src.models.company import CompanyProfile
 from src.models.user import UserRole, User
 from src.models.product import Product
 from src.models.bom import BillOfMaterial
-from src.models.production_transaction import ProductionTransaction
-from src.schemas.bom import (
-    BOMCreate,
-    BOMUpdate,
-    BOMComponentOut,
-    ProduceRequest,
-    ProductionTransactionOut,
-    PaginatedProductionTransactionOut,
-)
+from src.schemas.bom import BOMCreate, BOMUpdate, BOMComponentOut
 from src.services import bom_service
 
 router = APIRouter()

--- a/backend/src/api/routes/inventory.py
+++ b/backend/src/api/routes/inventory.py
@@ -9,9 +9,10 @@ from src.models.company import CompanyProfile
 from src.models.inventory import Inventory
 from src.models.invoice import Invoice, InvoiceItem
 from src.models.product import Product
+from src.models.production_transaction import ProductionTransaction
 from src.models.user import User, UserRole
 from src.schemas.inventory import InventoryAdjust, InventoryOut, PaginatedInventoryOut
-from src.schemas.bom import ProduceRequest
+from src.schemas.bom import ProduceRequest, ProductionTransactionOut, PaginatedProductionTransactionOut
 from src.api.deps import get_active_company, get_current_user, require_roles
 from src.services import bom_service
 
@@ -166,3 +167,43 @@ def produce_item(
         raise HTTPException(status_code=400, detail=result["message"])
 
     return result
+
+
+@router.get("/production-history", response_model=PaginatedProductionTransactionOut)
+def get_production_history(
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=500),
+    db: Session = Depends(get_db),
+    _: User = Depends(get_current_user),
+    active_company: CompanyProfile = Depends(get_active_company),
+):
+    """
+    Get production transaction history for the active company.
+    """
+    query = db.query(ProductionTransaction).filter(
+        ProductionTransaction.company_id == active_company.id
+    ).order_by(ProductionTransaction.created_at.desc())
+
+    total = query.count()
+    transactions = query.offset((page - 1) * page_size).limit(page_size).all()
+
+    items = [
+        ProductionTransactionOut(
+            id=t.id,
+            company_id=t.company_id,
+            product_id=t.product_id,
+            quantity_produced=float(t.quantity_produced),
+            user_id=t.user_id,
+            notes=t.notes,
+            created_at=t.created_at,
+        )
+        for t in transactions
+    ]
+
+    return PaginatedProductionTransactionOut(
+        items=items,
+        total=total,
+        page=page,
+        page_size=page_size,
+        total_pages=(total + page_size - 1) // page_size if total > 0 else 1,
+    )

--- a/backend/src/api/routes/inventory.py
+++ b/backend/src/api/routes/inventory.py
@@ -11,7 +11,9 @@ from src.models.invoice import Invoice, InvoiceItem
 from src.models.product import Product
 from src.models.user import User, UserRole
 from src.schemas.inventory import InventoryAdjust, InventoryOut, PaginatedInventoryOut
+from src.schemas.bom import ProduceRequest
 from src.api.deps import get_active_company, get_current_user, require_roles
+from src.services import bom_service
 
 router = APIRouter()
 
@@ -140,3 +142,27 @@ def list_inventory(
         page_size=page_size,
         total_pages=(total + page_size - 1) // page_size if total > 0 else 1,
     )
+
+
+@router.post("/produce")
+def produce_item(
+    payload: ProduceRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_roles(UserRole.admin, UserRole.manager)),
+    active_company: CompanyProfile = Depends(get_active_company),
+):
+    """
+    Produce an item by consuming its BOM components and increasing inventory.
+    """
+    result = bom_service.execute_production(
+        db,
+        active_company.id,
+        payload.product_id,
+        Decimal(str(payload.quantity)),
+        current_user.id,
+    )
+
+    if not result["success"]:
+        raise HTTPException(status_code=400, detail=result["message"])
+
+    return result

--- a/backend/src/api/routes/products.py
+++ b/backend/src/api/routes/products.py
@@ -79,6 +79,7 @@ def list_products(
     page: int = Query(1, ge=1),
     page_size: int = Query(20, ge=1, le=500),
     search: str = Query(""),
+    is_producable: bool | None = Query(None),
     db: Session = Depends(get_db),
     _: User = Depends(get_current_user),
     active_company: CompanyProfile = Depends(get_active_company),
@@ -86,6 +87,8 @@ def list_products(
     query = db.query(Product).filter(Product.company_id == active_company.id)
     if search.strip():
         query = query.filter(Product.name.ilike(f"%{search.strip()}%"))
+    if is_producable is not None:
+        query = query.filter(Product.is_producable == is_producable)
     total = query.count()
     items = (
         query.order_by(Product.name.asc())

--- a/backend/src/api/routes/products.py
+++ b/backend/src/api/routes/products.py
@@ -45,6 +45,8 @@ def create_product(
         unit=payload.unit,
         allow_decimal=payload.allow_decimal,
         maintain_inventory=payload.maintain_inventory,
+        is_producable=payload.is_producable,
+        production_cost=payload.production_cost,
     )
     db.add(product)
     db.flush()  # get product.id before committing
@@ -131,6 +133,8 @@ def update_product(
     product.price = payload.price
     product.gst_rate = payload.gst_rate
     product.unit = payload.unit
+    product.is_producable = payload.is_producable
+    product.production_cost = payload.production_cost
 
     if product.allow_decimal and not payload.allow_decimal:
         inventory = db.query(Inventory).filter(

--- a/backend/src/models/__init__.py
+++ b/backend/src/models/__init__.py
@@ -9,3 +9,5 @@ from src.models.payment import Payment, PaymentInvoiceAllocation
 from src.models.smtp_config import SMTPConfig
 from src.models.user_shortcut import UserShortcut
 from src.models.global_settings import GlobalSettings
+from src.models.bom import BillOfMaterial
+from src.models.production_transaction import ProductionTransaction

--- a/backend/src/models/bom.py
+++ b/backend/src/models/bom.py
@@ -1,0 +1,13 @@
+from sqlalchemy import Column, Integer, Numeric, ForeignKey, DateTime, func
+from src.db.base import Base
+
+
+class BillOfMaterial(Base):
+    __tablename__ = "bill_of_materials"
+
+    id = Column(Integer, primary_key=True, index=True)
+    company_id = Column(Integer, ForeignKey("company_profiles.id"), nullable=False, index=True)
+    product_id = Column(Integer, ForeignKey("products.id"), nullable=False, index=True)
+    component_product_id = Column(Integer, ForeignKey("products.id"), nullable=False, index=True)
+    quantity_required = Column(Numeric(12, 3), nullable=False)
+    created_at = Column(DateTime, server_default=func.now(), nullable=True)

--- a/backend/src/models/product.py
+++ b/backend/src/models/product.py
@@ -16,4 +16,6 @@ class Product(Base):
     unit = Column(String, nullable=False, default="Pieces")
     allow_decimal = Column(Boolean, nullable=False, default=False)
     maintain_inventory = Column(Boolean, nullable=False, default=True)
+    is_producable = Column(Boolean, nullable=False, default=False)
+    production_cost = Column(Numeric(12, 2), nullable=True)
     created_at = Column(DateTime, server_default=func.now(), nullable=True)

--- a/backend/src/models/production_transaction.py
+++ b/backend/src/models/production_transaction.py
@@ -1,0 +1,14 @@
+from sqlalchemy import Column, Integer, Numeric, String, ForeignKey, DateTime, func
+from src.db.base import Base
+
+
+class ProductionTransaction(Base):
+    __tablename__ = "production_transactions"
+
+    id = Column(Integer, primary_key=True, index=True)
+    company_id = Column(Integer, ForeignKey("company_profiles.id"), nullable=False, index=True)
+    product_id = Column(Integer, ForeignKey("products.id"), nullable=False, index=True)
+    quantity_produced = Column(Numeric(12, 3), nullable=False)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    notes = Column(String, nullable=True)
+    created_at = Column(DateTime, server_default=func.now(), nullable=True)

--- a/backend/src/schemas/bom.py
+++ b/backend/src/schemas/bom.py
@@ -1,0 +1,60 @@
+from pydantic import BaseModel
+from typing import Optional
+from datetime import datetime
+
+
+class BOMComponentOut(BaseModel):
+    """BOM component with product details"""
+    id: int
+    product_id: int
+    component_product_id: int
+    quantity_required: float
+    created_at: Optional[datetime] = None
+    
+    # Denormalized component product info
+    component_sku: str
+    component_name: str
+    component_price: float
+    component_unit: str
+    component_allow_decimal: bool
+
+
+class BOMCreate(BaseModel):
+    """Create a new BOM entry"""
+    product_id: int
+    component_product_id: int
+    quantity_required: float
+
+
+class BOMUpdate(BaseModel):
+    """Update a BOM entry"""
+    quantity_required: float
+
+
+class ProduceRequest(BaseModel):
+    """Request to produce an item"""
+    product_id: int
+    quantity: float
+
+
+class ProductionTransactionOut(BaseModel):
+    """Production transaction response"""
+    id: int
+    company_id: int
+    product_id: int
+    quantity_produced: float
+    user_id: int
+    notes: Optional[str] = None
+    created_at: Optional[datetime] = None
+
+    class Config:
+        from_attributes = True
+
+
+class PaginatedProductionTransactionOut(BaseModel):
+    """Paginated production transactions"""
+    items: list[ProductionTransactionOut]
+    total: int
+    page: int
+    page_size: int
+    total_pages: int

--- a/backend/src/schemas/product.py
+++ b/backend/src/schemas/product.py
@@ -15,6 +15,8 @@ class ProductCreate(BaseModel):
     unit: str = "Pieces"
     allow_decimal: bool = False
     maintain_inventory: bool = True
+    is_producable: bool = False
+    production_cost: Optional[float] = None
     initial_quantity: float = 0
 
     @field_validator("hsn_sac")
@@ -42,6 +44,8 @@ class ProductOut(BaseModel):
     unit: str
     allow_decimal: bool
     maintain_inventory: bool
+    is_producable: bool
+    production_cost: Optional[float]
     created_at: Optional[datetime] = None
 
     class Config:

--- a/backend/src/services/bom_service.py
+++ b/backend/src/services/bom_service.py
@@ -25,44 +25,37 @@ class InsufficientInventoryError(Exception):
     pass
 
 
-def _detect_circular_bom(
+def _can_reach(
     db: Session,
     company_id: int,
-    parent_product_id: int,
-    component_product_id: int,
-    visited: Set[int] | None = None,
+    start: int,
+    target: int,
+    seen: Set[int] | None = None,
 ) -> bool:
     """
-    Detect if adding component_product_id as a component of parent_product_id
-    would create a circular BOM reference.
-    
-    Returns True if circular reference detected, False otherwise.
+    Return True if `target` is reachable from `start` by following BOM edges.
+    Uses `seen` to avoid revisiting nodes (handles diamonds and cycles safely).
     """
-    if visited is None:
-        visited = set()
+    if seen is None:
+        seen = set()
 
-    if component_product_id in visited:
+    if start == target:
         return True
 
-    visited.add(component_product_id)
+    if start in seen:
+        return False
 
-    # Get all components of component_product_id
-    components = db.query(BillOfMaterial).filter(
+    seen.add(start)
+
+    bom_entries = db.query(BillOfMaterial).filter(
         and_(
             BillOfMaterial.company_id == company_id,
-            BillOfMaterial.product_id == component_product_id,
+            BillOfMaterial.product_id == start,
         )
     ).all()
 
-    for component_bom in components:
-        if component_bom.component_product_id == parent_product_id:
-            # Found parent in component's BOM - circular reference!
-            return True
-
-        # Recursively check deeper levels
-        if _detect_circular_bom(
-            db, company_id, parent_product_id, component_bom.component_product_id, visited
-        ):
+    for bom in bom_entries:
+        if _can_reach(db, company_id, bom.component_product_id, target, seen):
             return True
 
     return False
@@ -73,9 +66,11 @@ def validate_no_circular_bom(
 ) -> None:
     """
     Validate that adding component_product_id to product_id's BOM won't create cycles.
+    A cycle exists if product_id is reachable FROM component_product_id (i.e. component
+    already has product_id in its own BOM sub-tree).
     Raises CircularBOMError if validation fails.
     """
-    if _detect_circular_bom(db, company_id, product_id, component_product_id):
+    if _can_reach(db, company_id, component_product_id, product_id):
         raise CircularBOMError(
             f"Cannot add product {component_product_id} as component of {product_id}: "
             "would create a circular BOM reference."
@@ -175,14 +170,16 @@ def get_bom_requirements(
     company_id: int,
     product_id: int,
     quantity: Decimal,
-    requirements: dict[int, Decimal] | None = None,
 ) -> dict[int, Decimal]:
     """
-    Recursively expand BOM and calculate total material requirements.
+    Return direct BOM component requirements for producing `quantity` units of `product_id`.
     Returns dict: {component_product_id: total_quantity_needed}
+
+    Deliberately does NOT recurse into producable sub-components — if a component
+    is itself producable the user must produce it as a separate step first. This
+    prevents double-deduction (consuming both B and B's raw-materials in one hit).
     """
-    if requirements is None:
-        requirements = {}
+    requirements: dict[int, Decimal] = {}
 
     bom_entries = db.query(BillOfMaterial).filter(
         and_(
@@ -195,16 +192,7 @@ def get_bom_requirements(
         component_id = bom.component_product_id
         qty_per_unit = Decimal(str(bom.quantity_required))
         total_qty = qty_per_unit * quantity
-
-        if component_id not in requirements:
-            requirements[component_id] = Decimal("0")
-
-        requirements[component_id] += total_qty
-
-        # If component is also producable, recursively expand its BOM
-        component = db.query(Product).filter(Product.id == component_id).first()
-        if component and component.is_producable:
-            get_bom_requirements(db, company_id, component_id, total_qty, requirements)
+        requirements[component_id] = requirements.get(component_id, Decimal("0")) + total_qty
 
     return requirements
 
@@ -223,9 +211,8 @@ def validate_bom_availability(
 
     for component_id, required_qty in requirements.items():
         inventory = db.query(Inventory).filter(
-            and_(
-                Inventory.product_id == component_id,
-            )
+            Inventory.product_id == component_id,
+            Inventory.company_id == company_id,
         ).first()
 
         if not inventory:
@@ -296,7 +283,8 @@ def execute_production(
         # Deduct all components
         for component_id, required_qty in requirements.items():
             inventory = db.query(Inventory).filter(
-                Inventory.product_id == component_id
+                Inventory.product_id == component_id,
+                Inventory.company_id == company_id,
             ).first()
 
             component = db.query(Product).filter(Product.id == component_id).first()
@@ -315,11 +303,14 @@ def execute_production(
 
         # Increment producable item inventory
         product_inventory = db.query(Inventory).filter(
-            Inventory.product_id == product_id
+            Inventory.product_id == product_id,
+            Inventory.company_id == company_id,
         ).first()
 
         if not product_inventory:
-            product_inventory = Inventory(product_id=product_id, quantity=Decimal("0"))
+            product_inventory = Inventory(
+                company_id=company_id, product_id=product_id, quantity=Decimal("0")
+            )
             db.add(product_inventory)
 
         before_produced = float(product_inventory.quantity)
@@ -342,12 +333,14 @@ def execute_production(
         )
         db.add(transaction)
 
+        db.flush()  # populate transaction.id before commit
+        transaction_id = transaction.id
         db.commit()
 
         return {
             "success": True,
             "message": f"Successfully produced {quantity} units of {product.sku}",
-            "transaction_id": transaction.id,
+            "transaction_id": transaction_id,
             "inventory_changes": inventory_changes,
         }
 

--- a/backend/src/services/bom_service.py
+++ b/backend/src/services/bom_service.py
@@ -1,0 +1,359 @@
+"""
+BOM (Bill of Materials) business logic service.
+Handles BOM calculations, validation, and production execution.
+"""
+
+from decimal import Decimal
+from typing import Set
+from sqlalchemy.orm import Session
+from sqlalchemy import and_
+
+from src.models.bom import BillOfMaterial
+from src.models.product import Product
+from src.models.inventory import Inventory
+from src.models.production_transaction import ProductionTransaction
+from src.schemas.bom import BOMComponentOut
+
+
+class CircularBOMError(Exception):
+    """Raised when a circular BOM reference is detected."""
+    pass
+
+
+class InsufficientInventoryError(Exception):
+    """Raised when there's insufficient inventory for production."""
+    pass
+
+
+def _detect_circular_bom(
+    db: Session,
+    company_id: int,
+    parent_product_id: int,
+    component_product_id: int,
+    visited: Set[int] | None = None,
+) -> bool:
+    """
+    Detect if adding component_product_id as a component of parent_product_id
+    would create a circular BOM reference.
+    
+    Returns True if circular reference detected, False otherwise.
+    """
+    if visited is None:
+        visited = set()
+
+    if component_product_id in visited:
+        return True
+
+    visited.add(component_product_id)
+
+    # Get all components of component_product_id
+    components = db.query(BillOfMaterial).filter(
+        and_(
+            BillOfMaterial.company_id == company_id,
+            BillOfMaterial.product_id == component_product_id,
+        )
+    ).all()
+
+    for component_bom in components:
+        if component_bom.component_product_id == parent_product_id:
+            # Found parent in component's BOM - circular reference!
+            return True
+
+        # Recursively check deeper levels
+        if _detect_circular_bom(
+            db, company_id, parent_product_id, component_bom.component_product_id, visited
+        ):
+            return True
+
+    return False
+
+
+def validate_no_circular_bom(
+    db: Session, company_id: int, product_id: int, component_product_id: int
+) -> None:
+    """
+    Validate that adding component_product_id to product_id's BOM won't create cycles.
+    Raises CircularBOMError if validation fails.
+    """
+    if _detect_circular_bom(db, company_id, product_id, component_product_id):
+        raise CircularBOMError(
+            f"Cannot add product {component_product_id} as component of {product_id}: "
+            "would create a circular BOM reference."
+        )
+
+
+def get_bom_components(
+    db: Session,
+    company_id: int,
+    product_id: int,
+) -> list[BOMComponentOut]:
+    """
+    Get all direct BOM components for a product with denormalized component product info.
+    """
+    bom_entries = db.query(BillOfMaterial).filter(
+        and_(
+            BillOfMaterial.company_id == company_id,
+            BillOfMaterial.product_id == product_id,
+        )
+    ).all()
+
+    result = []
+    for bom in bom_entries:
+        component = db.query(Product).filter(Product.id == bom.component_product_id).first()
+        if component:
+            result.append(
+                BOMComponentOut(
+                    id=bom.id,
+                    product_id=bom.product_id,
+                    component_product_id=bom.component_product_id,
+                    quantity_required=float(bom.quantity_required),
+                    created_at=bom.created_at,
+                    component_sku=component.sku,
+                    component_name=component.name,
+                    component_price=float(component.price),
+                    component_unit=component.unit,
+                    component_allow_decimal=component.allow_decimal,
+                )
+            )
+
+    return result
+
+
+def calculate_bom_cost_recursive(
+    db: Session,
+    company_id: int,
+    product_id: int,
+    visited: Set[int] | None = None,
+) -> Decimal:
+    """
+    Recursively calculate total cost of a BOM by summing component costs.
+    Prevents infinite loops by tracking visited products.
+    
+    Returns cost as Decimal(12,2).
+    """
+    if visited is None:
+        visited = set()
+
+    if product_id in visited:
+        return Decimal("0")
+
+    visited.add(product_id)
+
+    cost = Decimal("0")
+    bom_entries = db.query(BillOfMaterial).filter(
+        and_(
+            BillOfMaterial.company_id == company_id,
+            BillOfMaterial.product_id == product_id,
+        )
+    ).all()
+
+    for bom in bom_entries:
+        component = db.query(Product).filter(Product.id == bom.component_product_id).first()
+        if component:
+            # Component cost = component.price * quantity_required
+            component_total = Decimal(str(component.price)) * Decimal(str(bom.quantity_required))
+            
+            # If component is also producable, use its production cost if available
+            if component.is_producable and component.production_cost is not None:
+                component_cost = Decimal(str(component.production_cost))
+                component_total = component_cost * Decimal(str(bom.quantity_required))
+            else:
+                # Recursively sum sub-components if producable but no production_cost
+                if component.is_producable:
+                    sub_cost = calculate_bom_cost_recursive(
+                        db, company_id, component.id, visited.copy()
+                    )
+                    component_total = sub_cost * Decimal(str(bom.quantity_required))
+
+            cost += component_total
+
+    return cost
+
+
+def get_bom_requirements(
+    db: Session,
+    company_id: int,
+    product_id: int,
+    quantity: Decimal,
+    requirements: dict[int, Decimal] | None = None,
+) -> dict[int, Decimal]:
+    """
+    Recursively expand BOM and calculate total material requirements.
+    Returns dict: {component_product_id: total_quantity_needed}
+    """
+    if requirements is None:
+        requirements = {}
+
+    bom_entries = db.query(BillOfMaterial).filter(
+        and_(
+            BillOfMaterial.company_id == company_id,
+            BillOfMaterial.product_id == product_id,
+        )
+    ).all()
+
+    for bom in bom_entries:
+        component_id = bom.component_product_id
+        qty_per_unit = Decimal(str(bom.quantity_required))
+        total_qty = qty_per_unit * quantity
+
+        if component_id not in requirements:
+            requirements[component_id] = Decimal("0")
+
+        requirements[component_id] += total_qty
+
+        # If component is also producable, recursively expand its BOM
+        component = db.query(Product).filter(Product.id == component_id).first()
+        if component and component.is_producable:
+            get_bom_requirements(db, company_id, component_id, total_qty, requirements)
+
+    return requirements
+
+
+def validate_bom_availability(
+    db: Session,
+    company_id: int,
+    product_id: int,
+    quantity: Decimal,
+) -> tuple[bool, str]:
+    """
+    Check if there's sufficient inventory for all BOM components.
+    Returns: (is_valid, error_message)
+    """
+    requirements = get_bom_requirements(db, company_id, product_id, quantity)
+
+    for component_id, required_qty in requirements.items():
+        inventory = db.query(Inventory).filter(
+            and_(
+                Inventory.product_id == component_id,
+            )
+        ).first()
+
+        if not inventory:
+            component = db.query(Product).filter(Product.id == component_id).first()
+            return (
+                False,
+                f"No inventory record for component: {component.sku if component else 'Unknown'}",
+            )
+
+        available_qty = Decimal(str(inventory.quantity))
+        if available_qty < required_qty:
+            component = db.query(Product).filter(Product.id == component_id).first()
+            return (
+                False,
+                f"Insufficient inventory for {component.sku if component else 'Unknown'}: "
+                f"need {required_qty}, have {available_qty}",
+            )
+
+    return (True, "")
+
+
+def execute_production(
+    db: Session,
+    company_id: int,
+    product_id: int,
+    quantity: Decimal,
+    user_id: int,
+    notes: str | None = None,
+) -> dict:
+    """
+    Execute production: deduct all BOM components, increment producable item inventory.
+    This is an atomic operation wrapped in a transaction.
+    
+    Returns: {
+        "success": bool,
+        "message": str,
+        "transaction_id": int (if successful),
+        "inventory_changes": {
+            "component_id": {"product_sku": str, "before": float, "after": float}
+        }
+    }
+    """
+    # Validate product is producable
+    product = db.query(Product).filter(
+        and_(Product.id == product_id, Product.company_id == company_id)
+    ).first()
+
+    if not product or not product.is_producable:
+        return {
+            "success": False,
+            "message": "Product is not marked as producable",
+        }
+
+    # Validate inventory availability
+    is_available, error_msg = validate_bom_availability(db, company_id, product_id, quantity)
+    if not is_available:
+        return {
+            "success": False,
+            "message": f"Production blocked: {error_msg}",
+        }
+
+    # Get material requirements
+    requirements = get_bom_requirements(db, company_id, product_id, quantity)
+
+    try:
+        inventory_changes = {}
+
+        # Deduct all components
+        for component_id, required_qty in requirements.items():
+            inventory = db.query(Inventory).filter(
+                Inventory.product_id == component_id
+            ).first()
+
+            component = db.query(Product).filter(Product.id == component_id).first()
+
+            before_qty = float(inventory.quantity)
+            inventory.quantity -= required_qty
+
+            after_qty = float(inventory.quantity)
+            inventory_changes[component_id] = {
+                "product_sku": component.sku,
+                "before": before_qty,
+                "after": after_qty,
+            }
+
+            db.add(inventory)
+
+        # Increment producable item inventory
+        product_inventory = db.query(Inventory).filter(
+            Inventory.product_id == product_id
+        ).first()
+
+        if not product_inventory:
+            product_inventory = Inventory(product_id=product_id, quantity=Decimal("0"))
+            db.add(product_inventory)
+
+        before_produced = float(product_inventory.quantity)
+        product_inventory.quantity += quantity
+        after_produced = float(product_inventory.quantity)
+
+        inventory_changes[product_id] = {
+            "product_sku": product.sku,
+            "before": before_produced,
+            "after": after_produced,
+        }
+
+        # Log transaction
+        transaction = ProductionTransaction(
+            company_id=company_id,
+            product_id=product_id,
+            quantity_produced=quantity,
+            user_id=user_id,
+            notes=notes,
+        )
+        db.add(transaction)
+
+        db.commit()
+
+        return {
+            "success": True,
+            "message": f"Successfully produced {quantity} units of {product.sku}",
+            "transaction_id": transaction.id,
+            "inventory_changes": inventory_changes,
+        }
+
+    except Exception as e:
+        db.rollback()
+        return {
+            "success": False,
+            "message": f"Production failed: {str(e)}",
+        }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import LoginPage from './pages/LoginPage';
 import DashboardPage from './pages/DashboardPage';
 import ProductsPage from './pages/ProductsPage';
 import InventoryPage from './pages/InventoryPage';
+import ProduceItemsPage from './pages/ProduceItemsPage';
 import InvoicesPage from './pages/InvoicesPage';
 import InvoiceDuesPage from './pages/InvoiceDuesPage';
 import InvoicesAdvancedView from './pages/InvoicesAdvancedView';
@@ -97,6 +98,7 @@ function AppRoutes() {
       <Route path="/" element={<Protected><CompanyRequired><Layout><DashboardPage /></Layout></CompanyRequired></Protected>} />
       <Route path="/products" element={<Protected><CompanyRequired><Layout><ProductsPage /></Layout></CompanyRequired></Protected>} />
       <Route path="/inventory" element={<Protected><CompanyRequired><Layout><InventoryPage /></Layout></CompanyRequired></Protected>} />
+      <Route path="/produce-items" element={<Protected><CompanyRequired><Layout><ProduceItemsPage /></Layout></CompanyRequired></Protected>} />
       <Route path="/ledgers" element={<Protected><CompanyRequired><Layout><LedgersPage /></Layout></CompanyRequired></Protected>} />
       <Route path="/ledgers/new" element={<Protected><CompanyRequired><Layout><LedgerCreatePage /></Layout></CompanyRequired></Protected>} />
       <Route path="/ledgers/:id" element={<Protected><CompanyRequired><Layout><LedgerViewPage /></Layout></CompanyRequired></Protected>} />

--- a/frontend/src/components/BOMConfigModal.tsx
+++ b/frontend/src/components/BOMConfigModal.tsx
@@ -1,0 +1,252 @@
+import { useEffect, useState } from 'react';
+import { Trash2 } from 'lucide-react';
+import { useEscapeClose } from '../hooks/useEscapeClose';
+import { getApiErrorMessage } from '../api/client';
+import type { BOMComponent, Product } from '../types/api';
+import { fetchBOM, createBOMEntry, updateBOMEntry, deleteBOMEntry } from '../services/bomApi';
+import ProductCombobox from './ProductCombobox';
+import api from '../api/client';
+import type { PaginatedProducts } from '../types/api';
+
+type BOMConfigModalProps = {
+  productId: number;
+  productName: string;
+  onClose: () => void;
+};
+
+export default function BOMConfigModal({ productId, productName, onClose }: BOMConfigModalProps) {
+  const [components, setComponents] = useState<BOMComponent[]>([]);
+  const [allProducts, setAllProducts] = useState<Product[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+
+  // Add row state
+  const [addComponentId, setAddComponentId] = useState('');
+  const [addQty, setAddQty] = useState('1');
+  const [adding, setAdding] = useState(false);
+
+  // Inline edit qty state: bomId -> draft string
+  const [editQty, setEditQty] = useState<Record<number, string>>({});
+  const [savingId, setSavingId] = useState<number | null>(null);
+  const [deletingId, setDeletingId] = useState<number | null>(null);
+
+  useEscapeClose(onClose);
+
+  useEffect(() => {
+    void loadData();
+  }, [productId]);
+
+  async function loadData() {
+    try {
+      setLoading(true);
+      setError('');
+      const [bomData, productsRes] = await Promise.all([
+        fetchBOM(productId),
+        api.get<PaginatedProducts>('/products/', { params: { page: 1, page_size: 500 } }),
+      ]);
+      setComponents(bomData);
+      // Exclude the product itself from component options
+      setAllProducts(productsRes.data.items.filter((p) => p.id !== productId));
+    } catch (err) {
+      setError(getApiErrorMessage(err, 'Unable to load BOM data'));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleAdd(e: React.FormEvent) {
+    e.preventDefault();
+    const componentId = Number(addComponentId);
+    const qty = Number(addQty);
+    if (!componentId || qty <= 0) return;
+
+    try {
+      setAdding(true);
+      setError('');
+      await createBOMEntry({ product_id: productId, component_product_id: componentId, quantity_required: qty });
+      setAddComponentId('');
+      setAddQty('1');
+      setSuccess('Component added.');
+      await loadData();
+    } catch (err) {
+      setError(getApiErrorMessage(err, 'Unable to add component'));
+    } finally {
+      setAdding(false);
+    }
+  }
+
+  async function handleSaveQty(bomId: number) {
+    const qty = Number(editQty[bomId]);
+    if (!qty || qty <= 0) return;
+
+    try {
+      setSavingId(bomId);
+      setError('');
+      await updateBOMEntry(bomId, { quantity_required: qty });
+      setEditQty((prev) => {
+        const next = { ...prev };
+        delete next[bomId];
+        return next;
+      });
+      setSuccess('Quantity updated.');
+      await loadData();
+    } catch (err) {
+      setError(getApiErrorMessage(err, 'Unable to update quantity'));
+    } finally {
+      setSavingId(null);
+    }
+  }
+
+  async function handleDelete(bomId: number) {
+    try {
+      setDeletingId(bomId);
+      setError('');
+      await deleteBOMEntry(bomId);
+      setSuccess('Component removed.');
+      await loadData();
+    } catch (err) {
+      setError(getApiErrorMessage(err, 'Unable to remove component'));
+    } finally {
+      setDeletingId(null);
+    }
+  }
+
+  const totalCost = components.reduce(
+    (sum, c) => sum + c.component_price * c.quantity_required,
+    0
+  );
+
+  return (
+    <div className="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="bom-modal-title">
+      <div className="modal-panel" onClick={(e) => e.stopPropagation()} style={{ maxWidth: '640px', width: '100%' }}>
+        <div className="panel__header">
+          <div>
+            <p className="eyebrow">Bill of Materials</p>
+            <h2 id="bom-modal-title" className="nav-panel__title">{productName}</h2>
+          </div>
+          <button
+            type="button"
+            className="button button--ghost"
+            onClick={onClose}
+            title="Close modal"
+            aria-label="Close BOM modal"
+          >
+            ✕
+          </button>
+        </div>
+
+        {error ? <p className="error-message" role="alert">{error}</p> : null}
+        {success ? <p className="success-message" role="status">{success}</p> : null}
+
+        {loading ? (
+          <p style={{ padding: '16px 0', color: 'var(--color-text-muted)' }}>Loading components…</p>
+        ) : (
+          <div className="stack">
+            {/* Add component form */}
+            <form onSubmit={handleAdd} className="stack" style={{ gap: '8px' }}>
+              <p style={{ fontWeight: 600, fontSize: '0.875rem' }}>Add component</p>
+              <div className="field-grid">
+                <div className="field field--full">
+                  <label htmlFor="bom-component-select">Component product</label>
+                  <ProductCombobox
+                    id="bom-component-select"
+                    products={allProducts}
+                    value={addComponentId}
+                    onChange={(id) => setAddComponentId(id)}
+                    required
+                  />
+                </div>
+                <div className="field">
+                  <label htmlFor="bom-component-qty">Quantity required</label>
+                  <input
+                    id="bom-component-qty"
+                    className="input"
+                    type="number"
+                    min="0.001"
+                    step="0.001"
+                    value={addQty}
+                    onChange={(e) => setAddQty(e.target.value)}
+                    required
+                  />
+                </div>
+              </div>
+              <div className="button-row">
+                <button
+                  className="button button--primary"
+                  disabled={adding || !addComponentId}
+                  title="Add component to BOM"
+                  aria-label="Add component to BOM"
+                >
+                  {adding ? 'Adding…' : 'Add component'}
+                </button>
+              </div>
+            </form>
+
+            {/* Components list */}
+            {components.length === 0 ? (
+              <p style={{ color: 'var(--color-text-muted)', fontSize: '0.875rem' }}>
+                No components defined yet. Add components above.
+              </p>
+            ) : (
+              <div className="table-list">
+                {components.map((c) => {
+                  const isDirty = editQty[c.id] !== undefined;
+                  return (
+                    <div key={c.id} className="table-row">
+                      <div className="table-row__meta">
+                        <strong>{c.component_name}</strong>
+                        <span className="table-subtext">{c.component_sku} · {c.component_unit}</span>
+                      </div>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                        <input
+                          className="input"
+                          type="number"
+                          min="0.001"
+                          step="0.001"
+                          style={{ width: '90px' }}
+                          value={isDirty ? editQty[c.id] : String(c.quantity_required)}
+                          onChange={(e) => setEditQty((prev) => ({ ...prev, [c.id]: e.target.value }))}
+                          aria-label={`Quantity for ${c.component_name}`}
+                        />
+                        {isDirty ? (
+                          <button
+                            type="button"
+                            className="button button--secondary"
+                            style={{ padding: '4px 10px', fontSize: '0.8rem' }}
+                            disabled={savingId === c.id}
+                            onClick={() => void handleSaveQty(c.id)}
+                            title="Save quantity"
+                            aria-label={`Save quantity for ${c.component_name}`}
+                          >
+                            {savingId === c.id ? 'Saving…' : 'Save'}
+                          </button>
+                        ) : null}
+                        <button
+                          type="button"
+                          className="button button--danger button--icon"
+                          disabled={deletingId === c.id}
+                          onClick={() => void handleDelete(c.id)}
+                          title={`Remove ${c.component_name}`}
+                          aria-label={`Remove ${c.component_name} from BOM`}
+                        >
+                          <Trash2 size={14} />
+                        </button>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+
+            {components.length > 0 ? (
+              <p style={{ fontSize: '0.85rem', color: 'var(--color-text-muted)', textAlign: 'right' }}>
+                Estimated material cost per unit: <strong>{totalCost.toFixed(2)}</strong>
+              </p>
+            ) : null}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -26,6 +26,7 @@ const mainGroup: NavItem[] = [
 const managementGroup: NavItem[] = [
   { to: '/products', label: 'Products' },
   { to: '/inventory', label: 'Inventory' },
+  { to: '/produce-items', label: 'Produce Items' },
   { to: '/ledgers', label: 'Ledgers' },
   { to: '/company', label: 'Company' },
 ];

--- a/frontend/src/pages/ProduceItemsPage.tsx
+++ b/frontend/src/pages/ProduceItemsPage.tsx
@@ -1,0 +1,330 @@
+import { useEffect, useState } from 'react';
+import api, { getApiErrorMessage } from '../api/client';
+import type { BOMComponent, PaginatedProducts, Product, ProductionTransaction } from '../types/api';
+import StatusToasts from '../components/StatusToasts';
+import EmptyState from '../components/EmptyState';
+import { fetchBOM, fetchProductionHistory, produceBatch } from '../services/bomApi';
+
+export default function ProduceItemsPage() {
+  // Producable products list
+  const [products, setProducts] = useState<Product[]>([]);
+  const [loadingProducts, setLoadingProducts] = useState(true);
+
+  // Selected product & BOM
+  const [selectedProduct, setSelectedProduct] = useState<Product | null>(null);
+  const [bom, setBom] = useState<BOMComponent[]>([]);
+  const [loadingBom, setLoadingBom] = useState(false);
+
+  // Produce form
+  const [quantity, setQuantity] = useState('1');
+  const [notes, setNotes] = useState('');
+  const [producing, setProducing] = useState(false);
+
+  // History
+  const [history, setHistory] = useState<ProductionTransaction[]>([]);
+  const [historyPage, setHistoryPage] = useState(1);
+  const [historyTotalPages, setHistoryTotalPages] = useState(1);
+  const [historyTotal, setHistoryTotal] = useState(0);
+  const [loadingHistory, setLoadingHistory] = useState(true);
+  const historyPageSize = 20;
+
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+
+  // Product name lookup for history
+  const [productNameMap, setProductNameMap] = useState<Record<number, string>>({});
+
+  useEffect(() => {
+    void loadProducableProducts();
+    void loadHistory(1);
+  }, []);
+
+  useEffect(() => {
+    void loadHistory(historyPage);
+  }, [historyPage]);
+
+  async function loadProducableProducts() {
+    try {
+      setLoadingProducts(true);
+      const res = await api.get<PaginatedProducts>('/products/', {
+        params: { page: 1, page_size: 500, is_producable: true },
+      });
+      const items = res.data.items;
+      setProducts(items);
+      const nameMap: Record<number, string> = {};
+      items.forEach((p) => { nameMap[p.id] = p.name; });
+      setProductNameMap(nameMap);
+    } catch (err) {
+      setError(getApiErrorMessage(err, 'Unable to load producable products'));
+    } finally {
+      setLoadingProducts(false);
+    }
+  }
+
+  async function handleSelectProduct(product: Product) {
+    setSelectedProduct(product);
+    setQuantity('1');
+    setNotes('');
+    setBom([]);
+    try {
+      setLoadingBom(true);
+      const components = await fetchBOM(product.id);
+      setBom(components);
+    } catch (err) {
+      setError(getApiErrorMessage(err, 'Unable to load BOM for this product'));
+    } finally {
+      setLoadingBom(false);
+    }
+  }
+
+  async function handleProduce(e: React.FormEvent) {
+    e.preventDefault();
+    if (!selectedProduct) return;
+    const qty = Number(quantity);
+    if (!qty || qty <= 0) return;
+
+    try {
+      setProducing(true);
+      setError('');
+      setSuccess('');
+      await produceBatch({ product_id: selectedProduct.id, quantity: qty });
+      setSuccess(`Produced ${qty} × ${selectedProduct.name} successfully.`);
+      // Refresh BOM requirements display (available qty may have changed)
+      const components = await fetchBOM(selectedProduct.id);
+      setBom(components);
+      await loadHistory(1);
+      setHistoryPage(1);
+    } catch (err) {
+      setError(getApiErrorMessage(err, 'Production failed'));
+    } finally {
+      setProducing(false);
+    }
+  }
+
+  async function loadHistory(page: number) {
+    try {
+      setLoadingHistory(true);
+      const res = await fetchProductionHistory(page, historyPageSize);
+      setHistory(res.items);
+      setHistoryTotal(res.total);
+      setHistoryTotalPages(res.total_pages);
+    } catch (err) {
+      setError(getApiErrorMessage(err, 'Unable to load production history'));
+    } finally {
+      setLoadingHistory(false);
+    }
+  }
+
+  function formatDate(iso: string | null) {
+    if (!iso) return '—';
+    return new Date(iso).toLocaleString(undefined, {
+      day: 'numeric',
+      month: 'short',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  }
+
+  const qty = Number(quantity) || 0;
+
+  return (
+    <div className="page-grid">
+      <section className="page-hero">
+        <div>
+          <p className="eyebrow">Production</p>
+          <h1 className="page-title">Produce items</h1>
+          <p className="section-copy">
+            Select a producable product, verify component availability, and run a production batch. Components are deducted from
+            inventory automatically.
+          </p>
+        </div>
+        <div className="status-chip">{historyTotal} runs logged</div>
+      </section>
+
+      <StatusToasts
+        error={error}
+        success={success}
+        onClearError={() => setError('')}
+        onClearSuccess={() => setSuccess('')}
+      />
+
+      <section className="content-grid">
+        {/* Left panel — product select + produce form */}
+        <article className="panel stack">
+          <div className="panel__header">
+            <div>
+              <p className="eyebrow">Run production</p>
+              <h2 className="nav-panel__title">Select product &amp; quantity</h2>
+            </div>
+          </div>
+
+          {loadingProducts ? (
+            <EmptyState message="Loading producable products…" />
+          ) : products.length === 0 ? (
+            <EmptyState
+              message="No producable products found. Mark a product as Producable on the Products page, then configure its Bill of Materials."
+            />
+          ) : (
+            <>
+              <div className="field">
+                <label htmlFor="produce-product-select">Product to produce</label>
+                <select
+                  id="produce-product-select"
+                  className="input"
+                  value={selectedProduct?.id ?? ''}
+                  onChange={(e) => {
+                    const product = products.find((p) => p.id === Number(e.target.value));
+                    if (product) void handleSelectProduct(product);
+                  }}
+                >
+                  <option value="">— select a product —</option>
+                  {products.map((p) => (
+                    <option key={p.id} value={p.id}>
+                      {p.name} ({p.sku})
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              {selectedProduct ? (
+                <>
+                  {/* BOM requirements table */}
+                  <div>
+                    <p style={{ fontWeight: 600, fontSize: '0.875rem', marginBottom: '8px' }}>
+                      Required components {qty > 0 ? `for ${qty} unit${qty !== 1 ? 's' : ''}` : ''}
+                    </p>
+                    {loadingBom ? (
+                      <p style={{ color: 'var(--color-text-muted)', fontSize: '0.875rem' }}>Loading BOM…</p>
+                    ) : bom.length === 0 ? (
+                      <p style={{ color: 'var(--color-text-muted)', fontSize: '0.875rem' }}>
+                        No BOM configured for this product. Add components via Products → Configure BOM.
+                      </p>
+                    ) : (
+                      <div className="table-list">
+                        {bom.map((c) => (
+                          <div key={c.id} className="table-row">
+                            <div className="table-row__meta">
+                              <strong>{c.component_name}</strong>
+                              <span className="table-subtext">{c.component_sku} · {c.component_unit}</span>
+                            </div>
+                            <span style={{ fontSize: '0.875rem', color: 'var(--color-text-muted)' }}>
+                              {qty > 0
+                                ? `${(c.quantity_required * qty).toFixed(3).replace(/\.?0+$/, '')} ${c.component_unit} needed`
+                                : `${c.quantity_required} ${c.component_unit} per unit`}
+                            </span>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+
+                  {bom.length > 0 ? (
+                    <form onSubmit={(e) => void handleProduce(e)} className="stack">
+                      <div className="field-grid">
+                        <div className="field">
+                          <label htmlFor="produce-qty">Quantity to produce</label>
+                          <input
+                            id="produce-qty"
+                            className="input"
+                            type="number"
+                            min={selectedProduct.allow_decimal ? '0.001' : '1'}
+                            step={selectedProduct.allow_decimal ? '0.001' : '1'}
+                            value={quantity}
+                            onChange={(e) => setQuantity(e.target.value)}
+                            required
+                          />
+                        </div>
+                        <div className="field field--full">
+                          <label htmlFor="produce-notes">Notes (optional)</label>
+                          <input
+                            id="produce-notes"
+                            className="input"
+                            value={notes}
+                            onChange={(e) => setNotes(e.target.value)}
+                            placeholder="e.g. Batch #42, assembly run"
+                          />
+                        </div>
+                      </div>
+                      <div className="button-row">
+                        <button
+                          className="button button--primary"
+                          disabled={producing || bom.length === 0}
+                          title="Start production run"
+                          aria-label="Start production run"
+                        >
+                          {producing ? 'Producing…' : `Produce ${quantity || '?'} × ${selectedProduct.name}`}
+                        </button>
+                      </div>
+                    </form>
+                  ) : null}
+                </>
+              ) : null}
+            </>
+          )}
+        </article>
+
+        {/* Right panel — production history */}
+        <article className="panel stack">
+          <div className="panel__header">
+            <div>
+              <p className="eyebrow">Audit log</p>
+              <h2 className="nav-panel__title">Production history</h2>
+            </div>
+          </div>
+
+          {loadingHistory ? (
+            <EmptyState message="Loading history…" />
+          ) : history.length === 0 ? (
+            <EmptyState message="No production runs recorded yet." />
+          ) : (
+            <div className="table-list">
+              {history.map((tx) => (
+                <div key={tx.id} className="table-row">
+                  <div className="table-row__meta">
+                    <strong>{productNameMap[tx.product_id] ?? `Product #${tx.product_id}`}</strong>
+                    <span className="table-subtext">
+                      {formatDate(tx.created_at)}
+                      {tx.notes ? ` · ${tx.notes}` : ''}
+                    </span>
+                  </div>
+                  <span style={{ fontSize: '0.875rem', color: 'var(--color-text)' }}>
+                    ×{tx.quantity_produced}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {historyTotalPages > 1 ? (
+            <div className="button-row" style={{ justifyContent: 'center', paddingTop: '8px' }}>
+              <button
+                type="button"
+                className="button button--ghost"
+                disabled={historyPage <= 1}
+                onClick={() => setHistoryPage((p) => p - 1)}
+                title="Previous page"
+                aria-label="Previous page"
+              >
+                Previous
+              </button>
+              <span className="muted-text" style={{ alignSelf: 'center' }}>
+                Page {historyPage} of {historyTotalPages}
+              </span>
+              <button
+                type="button"
+                className="button button--ghost"
+                disabled={historyPage >= historyTotalPages}
+                onClick={() => setHistoryPage((p) => p + 1)}
+                title="Next page"
+                aria-label="Next page"
+              >
+                Next
+              </button>
+            </div>
+          ) : null}
+        </article>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/pages/ProductsPage.tsx
+++ b/frontend/src/pages/ProductsPage.tsx
@@ -356,6 +356,30 @@ export default function ProductsPage() {
                   <span className="field-hint">Added on top of component material cost.</span>
                 </div>
               ) : null}
+              {form.is_producable ? (
+                <div className="field field--full">
+                  {editingProductId ? (
+                    <button
+                      type="button"
+                      className="button button--secondary"
+                      onClick={() => {
+                        const product = products.find((p) => p.id === editingProductId);
+                        setBomModalProductId(editingProductId);
+                        setBomModalProductName(product?.name ?? form.name);
+                      }}
+                      title="Configure Bill of Materials"
+                      aria-label="Configure Bill of Materials"
+                    >
+                      <Settings2 size={15} style={{ marginRight: 6 }} />
+                      Configure Bill of Materials
+                    </button>
+                  ) : (
+                    <span className="field-hint" style={{ fontStyle: 'italic' }}>
+                      Save the product first, then use the ⚙ button in the list to configure its components.
+                    </span>
+                  )}
+                </div>
+              ) : null}
               {!editingProductId && form.maintain_inventory ? (
                 <div className="field">
                   <label htmlFor="initial-quantity">Initial stock quantity</label>

--- a/frontend/src/pages/ProductsPage.tsx
+++ b/frontend/src/pages/ProductsPage.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from 'react';
-import { Pencil, Trash2 } from 'lucide-react';
+import { Pencil, Trash2, Settings2 } from 'lucide-react';
 import api, { getApiErrorMessage } from '../api/client';
 import type { CompanyProfile, PaginatedProducts, Product, ProductCreate } from '../types/api';
 import StatusToasts from '../components/StatusToasts';
 import ConfirmDialog from '../components/ConfirmDialog';
+import BOMConfigModal from '../components/BOMConfigModal';
 import formatCurrency from '../utils/formatting';
 import EmptyState from '../components/EmptyState';
 
@@ -37,7 +38,11 @@ export default function ProductsPage() {
     allow_decimal: false,
     maintain_inventory: true,
     initial_quantity: '0',
+    is_producable: false,
+    production_cost: '',
   });
+  const [bomModalProductId, setBomModalProductId] = useState<number | null>(null);
+  const [bomModalProductName, setBomModalProductName] = useState('');
 
   const activeCurrencyCode = company?.currency_code || 'USD';
 
@@ -67,7 +72,7 @@ export default function ProductsPage() {
   }, [page, search]);
 
   function resetForm() {
-    setForm({ sku: '', name: '', description: '', hsn_sac: '', price: '', gst_rate: '0', unit: 'Pieces', allow_decimal: false, maintain_inventory: true, initial_quantity: '0' });
+    setForm({ sku: '', name: '', description: '', hsn_sac: '', price: '', gst_rate: '0', unit: 'Pieces', allow_decimal: false, maintain_inventory: true, initial_quantity: '0', is_producable: false, production_cost: '' });
     setEditingProductId(null);
   }
 
@@ -86,6 +91,8 @@ export default function ProductsPage() {
       allow_decimal: product.allow_decimal,
       maintain_inventory: product.maintain_inventory,
       initial_quantity: '0',
+      is_producable: product.is_producable,
+      production_cost: product.production_cost != null ? String(product.production_cost) : '',
     });
   }
 
@@ -107,6 +114,8 @@ export default function ProductsPage() {
         unit: form.unit.trim() || 'Pieces',
         allow_decimal: form.allow_decimal,
         maintain_inventory: form.maintain_inventory,
+        is_producable: form.is_producable,
+        production_cost: form.production_cost !== '' ? Number(form.production_cost) : null,
         ...(editingProductId ? {} : { initial_quantity: Number(form.initial_quantity) }),
       };
 
@@ -317,6 +326,36 @@ export default function ProductsPage() {
                   Turn this on for units like Kg, l, m and other fractional stock.
                 </span>
               </div>
+              <div className="field field--full" style={{ marginBottom: 0 }}>
+                <label htmlFor="is-producable" style={{ display: 'flex', alignItems: 'center', gap: '10px', marginBottom: 0 }}>
+                  <input
+                    id="is-producable"
+                    type="checkbox"
+                    checked={form.is_producable}
+                    onChange={(event) => setForm((current) => ({ ...current, is_producable: event.target.checked }))}
+                  />
+                  Producable item (assembled from components)
+                </label>
+                <span className="field-hint">
+                  Enable to configure a Bill of Materials and allow production from raw components.
+                </span>
+              </div>
+              {form.is_producable ? (
+                <div className="field">
+                  <label htmlFor="production-cost">Additional production cost (optional)</label>
+                  <input
+                    id="production-cost"
+                    className="input"
+                    type="number"
+                    min="0"
+                    step="0.01"
+                    value={form.production_cost}
+                    onChange={(event) => setForm((current) => ({ ...current, production_cost: event.target.value }))}
+                    placeholder="e.g. 5.00 for labour/overhead"
+                  />
+                  <span className="field-hint">Added on top of component material cost.</span>
+                </div>
+              ) : null}
               {!editingProductId && form.maintain_inventory ? (
                 <div className="field">
                   <label htmlFor="initial-quantity">Initial stock quantity</label>
@@ -399,6 +438,18 @@ export default function ProductsPage() {
                     </div>
                     <span className="table-row__price">{formatCurrency(product.price, activeCurrencyCode)}</span>
                     <div className="table-row__actions">
+                      {product.is_producable ? (
+                        <button
+                          type="button"
+                          className="button button--ghost button--icon"
+                          onClick={() => { setBomModalProductId(product.id); setBomModalProductName(product.name); }}
+                          disabled={submitting}
+                          title={`Configure BOM for ${product.name}`}
+                          aria-label={`Configure BOM for ${product.name}`}
+                        >
+                          <Settings2 size={16} />
+                        </button>
+                      ) : null}
                       <button
                         type="button"
                         className="button button--ghost button--icon"
@@ -464,6 +515,13 @@ export default function ProductsPage() {
           danger={true}
           onConfirm={() => void confirmDeleteProduct()}
           onCancel={cancelDeleteProduct}
+        />
+      ) : null}
+      {bomModalProductId !== null ? (
+        <BOMConfigModal
+          productId={bomModalProductId}
+          productName={bomModalProductName}
+          onClose={() => { setBomModalProductId(null); setBomModalProductName(''); }}
         />
       ) : null}
     </div>

--- a/frontend/src/services/bomApi.ts
+++ b/frontend/src/services/bomApi.ts
@@ -1,4 +1,4 @@
-import api, { getApiErrorMessage } from '../api/client';
+import api from '../api/client';
 import type {
   BOMComponent,
   BOMCreate,

--- a/frontend/src/services/bomApi.ts
+++ b/frontend/src/services/bomApi.ts
@@ -1,0 +1,45 @@
+import api, { getApiErrorMessage } from '../api/client';
+import type {
+  BOMComponent,
+  BOMCreate,
+  BOMUpdate,
+  ProduceRequest,
+  ProduceResponse,
+  ProductionTransaction,
+  PaginatedProductionTransactions,
+} from '../types/api';
+
+export async function fetchBOM(productId: number): Promise<BOMComponent[]> {
+  const res = await api.get<BOMComponent[]>(`/bom/product/${productId}`);
+  return res.data;
+}
+
+export async function createBOMEntry(payload: BOMCreate): Promise<{ id: number; message: string }> {
+  const res = await api.post<{ id: number; message: string }>('/bom/', payload);
+  return res.data;
+}
+
+export async function updateBOMEntry(bomId: number, payload: BOMUpdate): Promise<{ id: number; message: string }> {
+  const res = await api.put<{ id: number; message: string }>(`/bom/${bomId}`, payload);
+  return res.data;
+}
+
+export async function deleteBOMEntry(bomId: number): Promise<{ message: string; product_id: number }> {
+  const res = await api.delete<{ message: string; product_id: number }>(`/bom/${bomId}`);
+  return res.data;
+}
+
+export async function produceBatch(payload: ProduceRequest): Promise<ProduceResponse> {
+  const res = await api.post<ProduceResponse>('/inventory/produce', payload);
+  return res.data;
+}
+
+export async function fetchProductionHistory(
+  page: number = 1,
+  pageSize: number = 20
+): Promise<PaginatedProductionTransactions> {
+  const res = await api.get<PaginatedProductionTransactions>('/inventory/production-history', {
+    params: { page, page_size: pageSize },
+  });
+  return res.data;
+}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -15,6 +15,8 @@ export type Product = {
   unit: string;
   allow_decimal: boolean;
   maintain_inventory: boolean;
+  is_producable: boolean;
+  production_cost: number | null;
   created_at: string | null;
 };
 
@@ -28,6 +30,8 @@ export type ProductCreate = {
   unit: string;
   allow_decimal: boolean;
   maintain_inventory: boolean;
+  is_producable: boolean;
+  production_cost?: number | null;
   initial_quantity?: number;
 };
 
@@ -641,4 +645,65 @@ export type BackupRestoreResponse = {
   detail: string;
   compatibility: string;
   applied_migrations: number;
+};
+
+// BOM (Bill of Materials) types
+export type BOMComponent = {
+  id: number;
+  product_id: number;
+  component_product_id: number;
+  quantity_required: number;
+  created_at: string | null;
+  component_sku: string;
+  component_name: string;
+  component_price: number;
+  component_unit: string;
+  component_allow_decimal: boolean;
+};
+
+export type BOMCreate = {
+  product_id: number;
+  component_product_id: number;
+  quantity_required: number;
+};
+
+export type BOMUpdate = {
+  quantity_required: number;
+};
+
+export type ProduceRequest = {
+  product_id: number;
+  quantity: number;
+};
+
+export type ProductionTransaction = {
+  id: number;
+  company_id: number;
+  product_id: number;
+  quantity_produced: number;
+  user_id: number;
+  notes: string | null;
+  created_at: string | null;
+};
+
+export type PaginatedProductionTransactions = {
+  items: ProductionTransaction[];
+  total: number;
+  page: number;
+  page_size: number;
+  total_pages: number;
+};
+
+export type ProduceResponse = {
+  success: boolean;
+  message: string;
+  transaction_id?: number;
+  inventory_changes?: Record<
+    number,
+    {
+      product_sku: string;
+      before: number;
+      after: number;
+    }
+  >;
 };


### PR DESCRIPTION
## Summary

Implement Bill of Materials support end-to-end for inventory production.

This branch adds:
- BOM and production transaction data model + migration
- BOM service logic (validation, availability checks, production execution)
- BOM API routes and inventory production/history endpoints
- Product `is_producable` and `production_cost` support
- Frontend BOM management modal and Produce Items page
- Products page UX fix so BOM configuration is visible from edit flow

## Type of change

- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs (documentation)
- [ ] test (tests)
- [ ] chore/refactor

## How to test

1. Run backend and frontend locally with your existing `.env`.
2. Create or edit a product and enable "Producable item".
3. Save product, open BOM configuration, and add components.
4. Go to "Produce Items", select product, enter quantity, and produce.
5. Verify component stock decreases and finished product stock increases.
6. Verify production history entries appear.

## Checklist

- [x] My code follows the project style and conventions
- [ ] I added/updated tests where appropriate
- [ ] I updated docs where needed
- [x] I ran relevant checks locally
- [x] I verified this does not break existing behavior

## Screenshots (if UI changes)

Add before/after screenshots or screen recording.

## Related issue

Closes #
