### PR TITLE
refactor: Extract GST/tax calculation logic to service module (#350)

### DIFF
--- a/backend/src/api/routes/invoices.py
+++ b/backend/src/api/routes/invoices.py
@@ -31,7 +31,7 @@ from src.services.pdf_templates import (
     _build_multi_copy_invoice_html,
     _copy_label,
 )
-from src.services.gst_tax_service import _money, is_interstate_supply, assign_item_tax_split, TaxCalculator
+from src.services.gst_tax_service import money as _money, is_interstate_supply, assign_item_tax_split, assign_invoice_tax_totals
 
 router = APIRouter()
 
@@ -221,7 +221,6 @@ def _apply_payload_to_invoice(
     interstate_supply = is_interstate_supply(invoice.company_gst, invoice.ledger_gst)
 
     taxable_total = Decimal("0")
-    tax_total = Decimal("0")
     created_items: list[InvoiceItem] = []
     for item in payload.items:
         quantity_value = Decimal(str(item.quantity))
@@ -274,7 +273,6 @@ def _apply_payload_to_invoice(
             line_total = _money(taxable_amount + tax_amount)
 
         taxable_total += taxable_amount
-        tax_total += tax_amount
 
         invoice_item = InvoiceItem(
             invoice_id=invoice.id,
@@ -299,12 +297,12 @@ def _apply_payload_to_invoice(
         interstate_supply=interstate_supply,
     )
 
-    TaxCalculator.assign_invoice_tax_totals(
+    tax_total = assign_invoice_tax_totals(
         invoice,
         created_items,
         interstate_supply=interstate_supply,
     )
-    raw_total = _money(taxable_total + Decimal(str(invoice.total_tax_amount)))
+    raw_total = _money(taxable_total + tax_total)
     if invoice.apply_round_off:
         rounded_total = raw_total.quantize(Decimal("1"), rounding=ROUND_HALF_UP)
         round_off_amount = _money(rounded_total - raw_total)

--- a/backend/src/services/credit_note.py
+++ b/backend/src/services/credit_note.py
@@ -1,6 +1,5 @@
 from datetime import datetime
-from decimal import Decimal, ROUND_HALF_UP
-from typing import Optional
+from decimal import Decimal
 
 from fastapi import HTTPException
 from sqlalchemy import or_
@@ -14,18 +13,7 @@ from src.models.product import Product
 from src.schemas.credit_note import CreditNoteCreate, CreditNoteOut
 from src.services.financial_year import get_active_fy, get_fy_for_date
 from src.services.series import generate_next_number
-
-
-def _money(value: Decimal) -> Decimal:
-    return value.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
-
-
-def _is_interstate(company_gst: Optional[str], ledger_gst: Optional[str]) -> bool:
-    if not company_gst or not ledger_gst:
-        return False
-    if len(company_gst) < 2 or len(ledger_gst) < 2:
-        return False
-    return company_gst[:2] != ledger_gst[:2]
+from src.services.gst_tax_service import money as _money, is_interstate_supply as _is_interstate
 
 
 def _change_inventory_quantity(

--- a/backend/src/services/gst_tax_service.py
+++ b/backend/src/services/gst_tax_service.py
@@ -10,16 +10,8 @@ from decimal import Decimal, ROUND_HALF_UP
 from src.models.invoice import Invoice, InvoiceItem
 
 
-def _money(value: Decimal) -> Decimal:
-    """
-    Round a Decimal value to 2 decimal places using ROUND_HALF_UP.
-    
-    Args:
-        value: The Decimal value to round for currency calculations.
-        
-    Returns:
-        The value rounded to 2 decimal places.
-    """
+def money(value: Decimal) -> Decimal:
+    """Round a Decimal value to 2 decimal places using ROUND_HALF_UP."""
     return value.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
 
 
@@ -66,88 +58,71 @@ def assign_item_tax_split(
 
     if interstate_supply:
         for item in items:
-            item_tax_amount = _money(Decimal(str(item.tax_amount or 0)))
+            item_tax_amount = money(Decimal(str(item.tax_amount or 0)))
             item_igst_amount = item_tax_amount
-            taxable_amount = _money(Decimal(str(item.taxable_amount or 0)))
+            taxable_amount = money(Decimal(str(item.taxable_amount or 0)))
 
             item.tax_amount = float(item_igst_amount)
-            item.line_total = float(_money(taxable_amount + item_igst_amount))
+            item.line_total = float(money(taxable_amount + item_igst_amount))
             item.cgst_amount = 0.0
             item.sgst_amount = 0.0
             item.igst_amount = float(item_igst_amount)
         return
 
     for item in items:
-        item_tax_amount = _money(Decimal(str(item.tax_amount or 0)))
-        item_half_tax_amount = _money(item_tax_amount / Decimal("2"))
+        item_tax_amount = money(Decimal(str(item.tax_amount or 0)))
+        item_half_tax_amount = money(item_tax_amount / Decimal("2"))
         item_cgst_amount = item_half_tax_amount
         item_sgst_amount = item_half_tax_amount
-        item_total_tax_amount = _money(item_cgst_amount + item_sgst_amount)
-        taxable_amount = _money(Decimal(str(item.taxable_amount or 0)))
+        item_total_tax_amount = money(item_cgst_amount + item_sgst_amount)
+        taxable_amount = money(Decimal(str(item.taxable_amount or 0)))
 
         item.tax_amount = float(item_total_tax_amount)
-        item.line_total = float(_money(taxable_amount + item_total_tax_amount))
+        item.line_total = float(money(taxable_amount + item_total_tax_amount))
         item.cgst_amount = float(item_cgst_amount)
         item.sgst_amount = float(item_sgst_amount)
         item.igst_amount = 0.0
 
 
-class TaxCalculator:
+def calculate_tax_totals(items: list[InvoiceItem]) -> tuple[Decimal, Decimal, Decimal]:
     """
-    Encapsulates tax calculation operations for invoices.
-    
-    Provides methods to calculate and assign tax totals at the invoice level based on
-    aggregated item-level taxes.
+    Calculate total CGST, SGST, and IGST from invoice items.
+
+    Returns:
+        A tuple of (cgst_total, sgst_total, igst_total) as Decimals rounded to 2 places.
     """
+    cgst_total = money(sum((money(Decimal(str(item.cgst_amount or 0))) for item in items), Decimal("0")))
+    sgst_total = money(sum((money(Decimal(str(item.sgst_amount or 0))) for item in items), Decimal("0")))
+    igst_total = money(sum((money(Decimal(str(item.igst_amount or 0))) for item in items), Decimal("0")))
+    return cgst_total, sgst_total, igst_total
 
-    @staticmethod
-    def calculate_tax_totals(items: list[InvoiceItem]) -> tuple[Decimal, Decimal, Decimal]:
-        """
-        Calculate total CGST, SGST, and IGST from invoice items.
-        
-        Args:
-            items: List of InvoiceItem objects with tax amounts assigned.
-            
-        Returns:
-            A tuple of (cgst_total, sgst_total, igst_total) as Decimal values rounded to 2 places.
-        """
-        cgst_total = _money(sum((_money(Decimal(str(item.cgst_amount or 0))) for item in items), Decimal("0")))
-        sgst_total = _money(sum((_money(Decimal(str(item.sgst_amount or 0))) for item in items), Decimal("0")))
-        igst_total = _money(sum((_money(Decimal(str(item.igst_amount or 0))) for item in items), Decimal("0")))
-        return cgst_total, sgst_total, igst_total
 
-    @staticmethod
-    def assign_invoice_tax_totals(
-        invoice: Invoice,
-        items: list[InvoiceItem],
-        *,
-        interstate_supply: bool,
-    ) -> None:
-        """
-        Assign tax totals to invoice based on item taxes and supply type.
-        
-        For interstate supplies, sets cgst_amount and sgst_amount to 0, igst_amount to total.
-        For intrastate supplies, aggregates cgst and sgst totals, sets igst_amount to 0.
-        
-        Modifies the invoice in-place, updating:
-        - cgst_amount, sgst_amount, igst_amount
-        - total_tax_amount
-        
-        Args:
-            invoice: The Invoice object to assign tax totals to.
-            items: List of InvoiceItem objects with item-level taxes already calculated.
-            interstate_supply: True if this is an interstate supply, False for intrastate.
-        """
-        cgst_total, sgst_total, igst_total = TaxCalculator.calculate_tax_totals(items)
+def assign_invoice_tax_totals(
+    invoice: Invoice,
+    items: list[InvoiceItem],
+    *,
+    interstate_supply: bool,
+) -> Decimal:
+    """
+    Assign tax totals to the invoice based on aggregated item taxes and supply type.
 
-        if interstate_supply:
-            invoice.cgst_amount = 0.0
-            invoice.sgst_amount = 0.0
-            invoice.igst_amount = float(igst_total)
-        else:
-            invoice.cgst_amount = float(cgst_total)
-            invoice.sgst_amount = float(sgst_total)
-            invoice.igst_amount = 0.0
+    For interstate supplies, sets cgst_amount and sgst_amount to 0, igst_amount to total.
+    For intrastate supplies, aggregates cgst and sgst totals, sets igst_amount to 0.
 
-        tax_total = _money(cgst_total + sgst_total + igst_total)
-        invoice.total_tax_amount = float(tax_total)
+    Modifies the invoice in-place (cgst_amount, sgst_amount, igst_amount, total_tax_amount)
+    and returns the total tax as a Decimal for use in downstream calculations.
+    """
+    cgst_total, sgst_total, igst_total = calculate_tax_totals(items)
+
+    if interstate_supply:
+        invoice.cgst_amount = 0.0
+        invoice.sgst_amount = 0.0
+        invoice.igst_amount = float(igst_total)
+    else:
+        invoice.cgst_amount = float(cgst_total)
+        invoice.sgst_amount = float(sgst_total)
+        invoice.igst_amount = 0.0
+
+    tax_total = money(cgst_total + sgst_total + igst_total)
+    invoice.total_tax_amount = float(tax_total)
+    return tax_total


### PR DESCRIPTION
## Summary
Extracts GST and tax calculation logic from `backend/src/api/routes/invoices.py` and `backend/src/services/credit_note.py` into a shared `gst_tax_service` module.

## Changes

### `backend/src/services/gst_tax_service.py` (new)
- `money()` — public Decimal rounding utility (2dp, ROUND_HALF_UP)
- `is_interstate_supply()` — detects interstate vs intrastate supply from GST state codes
- `assign_item_tax_split()` — assigns CGST/SGST/IGST split to invoice items in-place
- `calculate_tax_totals()` — aggregates item-level CGST, SGST, IGST into Decimal totals
- `assign_invoice_tax_totals()` — sets invoice-level tax amounts and returns the tax total Decimal (avoids float round-trip at call site)

### `backend/src/api/routes/invoices.py`
- Imports tax functions from `gst_tax_service` (aliased `_money` for local convention)
- Removes duplicate `_money`, `_is_interstate_supply`, `_assign_item_tax_split`
- Replaces inline tax aggregation with `assign_invoice_tax_totals`
- Removes dead `tax_total` accumulation in the item loop

### `backend/src/services/credit_note.py`
- Replaces duplicate local `_money` and `_is_interstate` with imports from `gst_tax_service`
- Removes now-unused `ROUND_HALF_UP` and `Optional` imports

## Testing
✅ 138 passed, 0 failed across full test suite (run against real Postgres)

Closes #350