### PR TITLE
feat(invoices): add shipping address to sales invoices

### DIFF
--- a/backend/migrations/20260527000001_create_ledger_addresses_table.py
+++ b/backend/migrations/20260527000001_create_ledger_addresses_table.py
@@ -1,0 +1,34 @@
+"""
+Create ledger_addresses table for storing multiple named shipping/delivery
+addresses per ledger (buyer), scoped to a company.
+"""
+
+from sqlalchemy import text
+
+
+def up(conn) -> None:
+    conn.execute(text("""
+        CREATE TABLE IF NOT EXISTS ledger_addresses (
+            id          SERIAL PRIMARY KEY,
+            ledger_id   INTEGER NOT NULL REFERENCES buyers(id) ON DELETE CASCADE,
+            company_id  INTEGER NOT NULL REFERENCES company_profiles(id) ON DELETE CASCADE,
+            label       VARCHAR(255) NOT NULL,
+            address     TEXT NOT NULL,
+            is_default  BOOLEAN NOT NULL DEFAULT FALSE,
+            created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        );
+    """))
+
+    conn.execute(text("""
+        CREATE INDEX IF NOT EXISTS idx_ledger_addresses_ledger_id
+        ON ledger_addresses(ledger_id);
+    """))
+
+    conn.execute(text("""
+        CREATE INDEX IF NOT EXISTS idx_ledger_addresses_company_id
+        ON ledger_addresses(company_id);
+    """))
+
+
+def down(conn) -> None:
+    conn.execute(text("DROP TABLE IF EXISTS ledger_addresses;"))

--- a/backend/migrations/20260527000002_add_shipping_address_to_invoices.py
+++ b/backend/migrations/20260527000002_add_shipping_address_to_invoices.py
@@ -1,0 +1,23 @@
+"""
+Add shipping_address and shipping_address_label snapshot columns to invoices.
+These are populated at invoice creation time and are independent of any changes
+to the saved ledger_addresses records.
+"""
+
+from sqlalchemy import text
+
+
+def up(conn) -> None:
+    conn.execute(text("""
+        ALTER TABLE invoices
+        ADD COLUMN IF NOT EXISTS shipping_address       TEXT DEFAULT NULL,
+        ADD COLUMN IF NOT EXISTS shipping_address_label VARCHAR(255) DEFAULT NULL;
+    """))
+
+
+def down(conn) -> None:
+    conn.execute(text("""
+        ALTER TABLE invoices
+        DROP COLUMN IF EXISTS shipping_address,
+        DROP COLUMN IF EXISTS shipping_address_label;
+    """))

--- a/backend/src/api/routes/ledgers.py
+++ b/backend/src/api/routes/ledgers.py
@@ -18,10 +18,12 @@ from src.models.company import CompanyProfile
 from src.models.credit_note import CreditNote, CreditNoteItem
 from src.models.invoice import Invoice
 from src.models.invoice import InvoiceItem
+from src.models.ledger_address import LedgerAddress
 from src.models.payment import Payment, PaymentInvoiceAllocation
 from src.models.user import User, UserRole
 from src.schemas.invoice import OutstandingInvoiceOut
 from src.schemas.ledger import DayBookEntry, DayBookOut, LedgerCreate, LedgerOut, LedgerStatementEntry, LedgerStatementInvoiceAllocation, LedgerStatementOut, PaginatedLedgerOut, TaxLedgerEntry, TaxLedgerOut, TaxLedgerTotals
+from src.schemas.ledger_address import LedgerAddressCreate, LedgerAddressOut, LedgerAddressUpdate
 from src.services.credit_note_reporting import get_credit_note_ledger_summary
 from src.services.financial_year import get_active_fy
 from src.services.invoice_payments import auto_allocate_outstanding_invoices, build_invoice_payment_summaries, get_outstanding_invoices_for_ledger
@@ -1095,3 +1097,111 @@ def download_ledger_statement_pdf(
         media_type="application/pdf",
         headers={"Content-Disposition": f'attachment; filename="{filename}"'},
     )
+
+
+# ---------------------------------------------------------------------------
+# Ledger address endpoints
+# ---------------------------------------------------------------------------
+
+def _get_ledger_or_404(db: Session, ledger_id: int, company_id: int | None) -> Ledger:
+    query = db.query(Ledger).filter(Ledger.id == ledger_id)
+    if company_id is not None:
+        query = query.filter(or_(Ledger.company_id == company_id, Ledger.company_id.is_(None)))
+    ledger = query.first()
+    if not ledger:
+        raise HTTPException(status_code=404, detail=f"Ledger {ledger_id} not found")
+    return ledger
+
+
+@router.get("/{ledger_id}/addresses/", response_model=list[LedgerAddressOut])
+def list_ledger_addresses(
+    ledger_id: int,
+    db: Session = Depends(get_db),
+    _: User = Depends(get_current_user),
+    active_company: CompanyProfile = Depends(get_active_company),
+):
+    """List all saved addresses for a ledger."""
+    company_id = active_company.id
+    _get_ledger_or_404(db, ledger_id, company_id)
+    return (
+        db.query(LedgerAddress)
+        .filter(LedgerAddress.ledger_id == ledger_id, LedgerAddress.company_id == company_id)
+        .order_by(LedgerAddress.is_default.desc(), LedgerAddress.created_at.asc())
+        .all()
+    )
+
+
+@router.post("/{ledger_id}/addresses/", response_model=LedgerAddressOut, status_code=201)
+def create_ledger_address(
+    ledger_id: int,
+    payload: LedgerAddressCreate,
+    db: Session = Depends(get_db),
+    _: User = Depends(get_current_user),
+    active_company: CompanyProfile = Depends(get_active_company),
+):
+    """Create a new saved address for a ledger."""
+    company_id = active_company.id
+    _get_ledger_or_404(db, ledger_id, company_id)
+    addr = LedgerAddress(
+        ledger_id=ledger_id,
+        company_id=company_id,
+        label=payload.label,
+        address=payload.address,
+        is_default=payload.is_default,
+    )
+    db.add(addr)
+    db.commit()
+    db.refresh(addr)
+    return addr
+
+
+@router.put("/{ledger_id}/addresses/{address_id}", response_model=LedgerAddressOut)
+def update_ledger_address(
+    ledger_id: int,
+    address_id: int,
+    payload: LedgerAddressUpdate,
+    db: Session = Depends(get_db),
+    _: User = Depends(get_current_user),
+    active_company: CompanyProfile = Depends(get_active_company),
+):
+    """Update a saved ledger address."""
+    company_id = active_company.id
+    _get_ledger_or_404(db, ledger_id, company_id)
+    addr = db.query(LedgerAddress).filter(
+        LedgerAddress.id == address_id,
+        LedgerAddress.ledger_id == ledger_id,
+        LedgerAddress.company_id == company_id,
+    ).first()
+    if not addr:
+        raise HTTPException(status_code=404, detail="Address not found")
+    if payload.label is not None:
+        addr.label = payload.label
+    if payload.address is not None:
+        addr.address = payload.address
+    if payload.is_default is not None:
+        addr.is_default = payload.is_default
+    db.commit()
+    db.refresh(addr)
+    return addr
+
+
+@router.delete("/{ledger_id}/addresses/{address_id}", status_code=204)
+def delete_ledger_address(
+    ledger_id: int,
+    address_id: int,
+    db: Session = Depends(get_db),
+    _: User = Depends(get_current_user),
+    active_company: CompanyProfile = Depends(get_active_company),
+):
+    """Delete a saved ledger address."""
+    company_id = active_company.id
+    _get_ledger_or_404(db, ledger_id, company_id)
+    addr = db.query(LedgerAddress).filter(
+        LedgerAddress.id == address_id,
+        LedgerAddress.ledger_id == ledger_id,
+        LedgerAddress.company_id == company_id,
+    ).first()
+    if not addr:
+        raise HTTPException(status_code=404, detail="Address not found")
+    db.delete(addr)
+    db.commit()

--- a/backend/src/models/__init__.py
+++ b/backend/src/models/__init__.py
@@ -3,6 +3,7 @@ from src.models.product import Product
 from src.models.inventory import Inventory
 from src.models.invoice import Invoice, InvoiceItem
 from src.models.buyer import Buyer
+from src.models.ledger_address import LedgerAddress
 from src.models.company import CompanyProfile
 from src.models.company_account import CompanyAccount
 from src.models.payment import Payment, PaymentInvoiceAllocation

--- a/backend/src/models/buyer.py
+++ b/backend/src/models/buyer.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from src.db.base import Base
 
 
+
 class Buyer(Base):
     __tablename__ = "buyers"
 
@@ -23,3 +24,4 @@ class Buyer(Base):
     created_at = Column(DateTime, default=datetime.utcnow)
 
     invoices = relationship("Invoice", back_populates="ledger")
+    addresses = relationship("LedgerAddress", back_populates="ledger", cascade="all, delete-orphan")

--- a/backend/src/models/invoice.py
+++ b/backend/src/models/invoice.py
@@ -45,6 +45,8 @@ class Invoice(Base):
     apply_round_off = Column(Boolean, nullable=False, default=False)
     round_off_amount = Column(Numeric(5, 2), nullable=False, default=0)
     financial_year_id = Column(Integer, ForeignKey("financial_years.id"), nullable=True)
+    shipping_address = Column(Text, nullable=True)
+    shipping_address_label = Column(String(255), nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow)
 
     ledger = relationship("Buyer", back_populates="invoices")

--- a/backend/src/models/ledger_address.py
+++ b/backend/src/models/ledger_address.py
@@ -1,0 +1,18 @@
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy.orm import relationship
+from datetime import datetime
+from src.db.base import Base
+
+
+class LedgerAddress(Base):
+    __tablename__ = "ledger_addresses"
+
+    id = Column(Integer, primary_key=True, index=True)
+    ledger_id = Column(Integer, ForeignKey("buyers.id", ondelete="CASCADE"), nullable=False, index=True)
+    company_id = Column(Integer, ForeignKey("company_profiles.id", ondelete="CASCADE"), nullable=False, index=True)
+    label = Column(String(255), nullable=False)
+    address = Column(Text, nullable=False)
+    is_default = Column(Boolean, nullable=False, default=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    ledger = relationship("Buyer", back_populates="addresses")

--- a/backend/src/schemas/invoice.py
+++ b/backend/src/schemas/invoice.py
@@ -2,6 +2,7 @@ from datetime import date, datetime
 from pydantic import BaseModel, Field
 from typing import List, Literal, Optional
 from src.schemas.ledger import LedgerOut
+from src.schemas.ledger_address import ShippingAddressInline
 
 
 class InvoiceItemCreate(BaseModel):
@@ -20,6 +21,9 @@ class InvoiceCreate(BaseModel):
     reference_notes: str | None = None
     tax_inclusive: bool = False
     apply_round_off: bool = False
+    shipping_address_same_as_billing: bool = True
+    shipping_address_id: int | None = None
+    new_shipping_address: ShippingAddressInline | None = None
     items: List[InvoiceItemCreate]
 
 
@@ -85,6 +89,8 @@ class InvoiceOut(BaseModel):
     apply_round_off: bool = False
     round_off_amount: float = 0
     financial_year_id: Optional[int] = None
+    shipping_address: str | None = None
+    shipping_address_label: str | None = None
     warnings: List[str] = Field(default_factory=list)
     created_at: datetime
     items: list[InvoiceItemOut] = Field(default_factory=list)

--- a/backend/src/schemas/ledger_address.py
+++ b/backend/src/schemas/ledger_address.py
@@ -1,0 +1,34 @@
+from datetime import datetime
+from pydantic import BaseModel
+
+
+class LedgerAddressCreate(BaseModel):
+    label: str
+    address: str
+    is_default: bool = False
+
+
+class LedgerAddressUpdate(BaseModel):
+    label: str | None = None
+    address: str | None = None
+    is_default: bool | None = None
+
+
+class LedgerAddressOut(BaseModel):
+    id: int
+    ledger_id: int
+    company_id: int
+    label: str
+    address: str
+    is_default: bool
+    created_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class ShippingAddressInline(BaseModel):
+    """Represents a new shipping address entered inline during invoicing.
+    It will be auto-saved to ledger_addresses and snapshotted onto the invoice."""
+    label: str
+    address: str

--- a/backend/src/services/invoice_processor.py
+++ b/backend/src/services/invoice_processor.py
@@ -20,6 +20,7 @@ from sqlalchemy.orm import Session
 from src.models.buyer import Buyer as Ledger
 from src.models.company import CompanyProfile
 from src.models.invoice import Invoice, InvoiceItem
+from src.models.ledger_address import LedgerAddress
 from src.models.product import Product
 from src.schemas.invoice import InvoiceCreate
 from src.services.gst_tax_service import (
@@ -305,6 +306,10 @@ class InvoiceProcessor:
         invoice.voucher_type = payload.voucher_type
         invoice.supplier_invoice_number = payload.supplier_invoice_number
         invoice.reference_notes = payload.reference_notes
+
+        # Snapshot shipping address
+        self._apply_shipping_address(invoice, payload, ledger.id, company_id)
+
         if created_by is not None:
             invoice.created_by = created_by
         if financial_year_id is not None:
@@ -398,3 +403,63 @@ class InvoiceProcessor:
         else:
             invoice.round_off_amount = 0
             invoice.total_amount = float(raw_total)
+
+    # ------------------------------------------------------------------
+    # Shipping address helpers
+    # ------------------------------------------------------------------
+
+    def _apply_shipping_address(
+        self,
+        invoice: Invoice,
+        payload: InvoiceCreate,
+        ledger_id: int,
+        company_id: int | None,
+    ) -> None:
+        """Resolve and snapshot the shipping address onto the invoice.
+
+        Priority:
+        1. same_as_billing=True  → clear shipping fields (null)
+        2. shipping_address_id   → load existing LedgerAddress row and snapshot
+        3. new_shipping_address  → persist to ledger_addresses then snapshot
+        """
+        if payload.shipping_address_same_as_billing:
+            invoice.shipping_address = None
+            invoice.shipping_address_label = None
+            return
+
+        if payload.shipping_address_id is not None:
+            addr = self.db.query(LedgerAddress).filter(
+                LedgerAddress.id == payload.shipping_address_id,
+                LedgerAddress.ledger_id == ledger_id,
+            ).first()
+            if addr is None:
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"Shipping address {payload.shipping_address_id} not found for this ledger",
+                )
+            invoice.shipping_address = addr.address
+            invoice.shipping_address_label = addr.label
+            return
+
+        if payload.new_shipping_address is not None:
+            if company_id is None:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Cannot save a new shipping address without an active company",
+                )
+            new_addr = LedgerAddress(
+                ledger_id=ledger_id,
+                company_id=company_id,
+                label=payload.new_shipping_address.label,
+                address=payload.new_shipping_address.address,
+                is_default=False,
+            )
+            self.db.add(new_addr)
+            self.db.flush()  # get id without committing
+            invoice.shipping_address = new_addr.address
+            invoice.shipping_address_label = new_addr.label
+            return
+
+        # No shipping address provided and same_as_billing=False — treat as same
+        invoice.shipping_address = None
+        invoice.shipping_address_label = None

--- a/backend/src/services/pdf_templates/invoice_template.py
+++ b/backend/src/services/pdf_templates/invoice_template.py
@@ -104,6 +104,30 @@ def _build_invoice_html(invoice: Invoice, products: list[Product], invoice_bank_
         billto_parts.append(f"Phone: {_e(invoice.ledger_phone)}")
     billto_details = " &middot; ".join(billto_parts)
 
+    # Ship-to section — only rendered when shipping address differs from billing
+    ship_to_html = ""
+    if invoice.shipping_address:
+        ship_label_html = (
+            f"<h4>{_e(invoice.shipping_address_label)}</h4>" if invoice.shipping_address_label else ""
+        )
+        ship_to_html = f"""
+  <div class="invoice-sheet__billto">
+    <p class="eyebrow">Ship to</p>
+    {ship_label_html}
+    <p>{_e(invoice.shipping_address)}</p>
+  </div>"""
+
+    # Wrap bill-to and optional ship-to in a flex row
+    bill_and_ship_html = f"""
+  <div class="invoice-sheet__addresses">
+    <div class="invoice-sheet__billto">
+      <p class="eyebrow">Bill to</p>
+      <h4>{_e(invoice.ledger_name) or 'Unknown ledger'}</h4>
+      <p>{_e(invoice.ledger_address) or 'Address not provided'}</p>
+      <p>{billto_details}</p>
+    </div>{ship_to_html}
+  </div>"""
+
     invoice_title = "Tax Invoice" if invoice.ledger_gst else "Sales Invoice"
 
     round_off_amount = float(invoice.round_off_amount or 0)
@@ -204,6 +228,15 @@ def _build_invoice_html(invoice: Invoice, products: list[Product], invoice_bank_
     font-size: 9px;
     color: #4b5563;
     margin-bottom: 1px;
+  }}
+  .invoice-sheet__addresses {{
+    display: flex;
+    gap: 12px;
+    margin-bottom: 16px;
+  }}
+  .invoice-sheet__addresses .invoice-sheet__billto {{
+    flex: 1;
+    margin-bottom: 0;
   }}
   .invoice-sheet__reference-notes {{
     border: 1px dashed #d1d5db;
@@ -361,12 +394,7 @@ def _build_invoice_html(invoice: Invoice, products: list[Product], invoice_bank_
     </div>
   </header>
 
-  <section class="invoice-sheet__billto">
-    <p class="eyebrow">Bill to</p>
-    <h4>{_e(invoice.ledger_name) or 'Unknown ledger'}</h4>
-    <p>{_e(invoice.ledger_address) or 'Address not provided'}</p>
-    <p>{billto_details}</p>
-  </section>
+  {bill_and_ship_html}
 
   {reference_notes_html}
 

--- a/frontend/src/features/invoices/api.ts
+++ b/frontend/src/features/invoices/api.ts
@@ -1,5 +1,5 @@
 import api from '../../api/client';
-import type { CompanyProfile, Invoice, Ledger, OutstandingInvoice, PaginatedInvoices, Product } from '../../types/api';
+import type { CompanyProfile, Invoice, Ledger, LedgerAddress, LedgerAddressCreate, LedgerAddressUpdate, OutstandingInvoice, PaginatedInvoices, Product } from '../../types/api';
 
 type InvoiceFilters = {
   page: number;
@@ -153,4 +153,27 @@ export async function fetchInvoiceComposerData(input: {
     invoiceTotalPages: invoicesRes.total_pages,
     company: companyRes,
   };
+}
+
+// ---------------------------------------------------------------------------
+// Ledger address helpers
+// ---------------------------------------------------------------------------
+
+export async function fetchLedgerAddresses(ledgerId: number): Promise<LedgerAddress[]> {
+  const res = await api.get<LedgerAddress[]>(`/ledgers/${ledgerId}/addresses/`);
+  return res.data;
+}
+
+export async function createLedgerAddress(ledgerId: number, data: LedgerAddressCreate): Promise<LedgerAddress> {
+  const res = await api.post<LedgerAddress>(`/ledgers/${ledgerId}/addresses/`, data);
+  return res.data;
+}
+
+export async function updateLedgerAddress(ledgerId: number, addressId: number, data: LedgerAddressUpdate): Promise<LedgerAddress> {
+  const res = await api.put<LedgerAddress>(`/ledgers/${ledgerId}/addresses/${addressId}`, data);
+  return res.data;
+}
+
+export async function deleteLedgerAddress(ledgerId: number, addressId: number): Promise<void> {
+  await api.delete(`/ledgers/${ledgerId}/addresses/${addressId}`);
 }

--- a/frontend/src/pages/LedgerViewPage.tsx
+++ b/frontend/src/pages/LedgerViewPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { ArrowLeft, ChevronDown, FileText, FilePlus, Mail, Pencil, ReceiptText, Trash2 } from 'lucide-react';
 import api, { getApiErrorMessage } from '../api/client';
-import type { CompanyAccount, CompanyProfile, Invoice, Ledger, LedgerStatement, OutstandingInvoice, Payment, PaymentCreate, PaymentInvoiceAllocation, PaymentUpdate, Product } from '../types/api';
+import type { CompanyAccount, CompanyProfile, Invoice, Ledger, LedgerAddress, LedgerStatement, OutstandingInvoice, Payment, PaymentCreate, PaymentInvoiceAllocation, PaymentUpdate, Product } from '../types/api';
 import InvoicePreview from '../components/InvoicePreview';
 import PaymentReceiptPreview from '../components/PaymentReceiptPreview';
 import StatementPreview from '../components/StatementPreview';
@@ -12,7 +12,7 @@ import SendEmailModal from '../components/SendEmailModal';
 import ConfirmDialog from '../components/ConfirmDialog';
 import formatCurrency from '../utils/formatting';
 import { useFY } from '../context/FYContext';
-import { fetchOutstandingInvoices } from '../features/invoices/api';
+import { fetchOutstandingInvoices, fetchLedgerAddresses, createLedgerAddress, updateLedgerAddress, deleteLedgerAddress } from '../features/invoices/api';
 import { formatInvoiceDateLabel } from '../utils/invoiceDueDate.ts';
 import EmptyState from '../components/EmptyState';
 
@@ -137,6 +137,13 @@ export default function LedgerViewPage() {
   const [deletingPayment, setDeletingPayment] = useState(false);
   const [allocationCreateSearch, setAllocationCreateSearch] = useState('');
   const [allocationEditSearch, setAllocationEditSearch] = useState('');
+  // Address management state
+  const [addresses, setAddresses] = useState<LedgerAddress[]>([]);
+  const [addressFormLabel, setAddressFormLabel] = useState('');
+  const [addressFormText, setAddressFormText] = useState('');
+  const [editingAddressId, setEditingAddressId] = useState<number | null>(null);
+  const [showAddressForm, setShowAddressForm] = useState(false);
+  const [submittingAddress, setSubmittingAddress] = useState(false);
 
   useEffect(() => {
     if (!showPaymentForm) setAllocationCreateSearch('');
@@ -145,6 +152,68 @@ export default function LedgerViewPage() {
   useEffect(() => {
     if (!editingPayment) setAllocationEditSearch('');
   }, [editingPayment]);
+
+  // Load ledger addresses
+  useEffect(() => {
+    if (!ledgerId) return;
+    let cancelled = false;
+    fetchLedgerAddresses(ledgerId)
+      .then((addrs) => { if (!cancelled) setAddresses(addrs); })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, [ledgerId, refreshKey]);
+
+  async function handleAddressSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!addressFormText.trim()) return;
+    setSubmittingAddress(true);
+    try {
+      if (editingAddressId !== null) {
+        const updated = await updateLedgerAddress(ledgerId, editingAddressId, {
+          label: addressFormLabel.trim() || 'Address',
+          address: addressFormText.trim(),
+        });
+        setAddresses((prev) => prev.map((a) => (a.id === editingAddressId ? updated : a)));
+      } else {
+        const created = await createLedgerAddress(ledgerId, {
+          label: addressFormLabel.trim() || 'Address',
+          address: addressFormText.trim(),
+        });
+        setAddresses((prev) => [...prev, created]);
+      }
+      setShowAddressForm(false);
+      setEditingAddressId(null);
+      setAddressFormLabel('');
+      setAddressFormText('');
+    } catch (err) {
+      setError(getApiErrorMessage(err, 'Unable to save address'));
+    } finally {
+      setSubmittingAddress(false);
+    }
+  }
+
+  async function handleAddressDelete(addressId: number) {
+    try {
+      await deleteLedgerAddress(ledgerId, addressId);
+      setAddresses((prev) => prev.filter((a) => a.id !== addressId));
+    } catch (err) {
+      setError(getApiErrorMessage(err, 'Unable to delete address'));
+    }
+  }
+
+  function startEditingAddress(addr: LedgerAddress) {
+    setEditingAddressId(addr.id);
+    setAddressFormLabel(addr.label);
+    setAddressFormText(addr.address);
+    setShowAddressForm(true);
+  }
+
+  function cancelAddressForm() {
+    setShowAddressForm(false);
+    setEditingAddressId(null);
+    setAddressFormLabel('');
+    setAddressFormText('');
+  }
 
   useEffect(() => {
     if (!showActionsDropdown) return;
@@ -660,6 +729,97 @@ export default function LedgerViewPage() {
               </p>
             ) : null}
           </div>
+        </article>
+
+        <article className="panel stack">
+          <div className="panel__header">
+            <div>
+              <p className="eyebrow">Saved addresses</p>
+              <h2 className="nav-panel__title">Shipping / delivery addresses</h2>
+            </div>
+            {!showAddressForm ? (
+              <button
+                type="button"
+                className="button button--secondary"
+                onClick={() => { cancelAddressForm(); setShowAddressForm(true); }}
+                title="Add address"
+                aria-label="Add address"
+              >
+                Add address
+              </button>
+            ) : null}
+          </div>
+
+          {showAddressForm ? (
+            <form className="stack" onSubmit={handleAddressSubmit}>
+              <div className="field-grid">
+                <div className="field">
+                  <label htmlFor="addr-label">Label</label>
+                  <input
+                    id="addr-label"
+                    className="input"
+                    type="text"
+                    value={addressFormLabel}
+                    onChange={(e) => setAddressFormLabel(e.target.value)}
+                    placeholder="e.g. Warehouse, Site A"
+                  />
+                </div>
+                <div className="field" style={{ gridColumn: '1 / -1' }}>
+                  <label htmlFor="addr-text">Address</label>
+                  <textarea
+                    id="addr-text"
+                    className="input"
+                    rows={3}
+                    value={addressFormText}
+                    onChange={(e) => setAddressFormText(e.target.value)}
+                    placeholder="Full shipping address"
+                    required
+                  />
+                </div>
+              </div>
+              <div className="button-row">
+                <button type="submit" className="button button--primary" disabled={submittingAddress || !addressFormText.trim()}>
+                  {submittingAddress ? 'Saving…' : editingAddressId !== null ? 'Update address' : 'Save address'}
+                </button>
+                <button type="button" className="button button--secondary" onClick={cancelAddressForm}>
+                  Cancel
+                </button>
+              </div>
+            </form>
+          ) : null}
+
+          {addresses.length === 0 && !showAddressForm ? (
+            <p className="muted-text">No saved addresses yet. Add one to use it as a shipping address when invoicing.</p>
+          ) : null}
+
+          {addresses.map((addr) => (
+            <div key={addr.id} className="summary-box" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: '12px' }}>
+              <div>
+                <p style={{ fontWeight: 600, marginBottom: '2px' }}>{addr.label}</p>
+                <p className="muted-text" style={{ whiteSpace: 'pre-wrap' }}>{addr.address}</p>
+              </div>
+              <div className="button-row" style={{ flexShrink: 0 }}>
+                <button
+                  type="button"
+                  className="button button--ghost button--icon"
+                  onClick={() => startEditingAddress(addr)}
+                  title="Edit address"
+                  aria-label="Edit address"
+                >
+                  <Pencil size={14} />
+                </button>
+                <button
+                  type="button"
+                  className="button button--danger button--icon"
+                  onClick={() => handleAddressDelete(addr.id)}
+                  title="Delete address"
+                  aria-label="Delete address"
+                >
+                  <Trash2 size={14} />
+                </button>
+              </div>
+            </div>
+          ))}
         </article>
 
         <article className="panel stack">

--- a/frontend/src/pages/invoices/InvoicesPageView.tsx
+++ b/frontend/src/pages/invoices/InvoicesPageView.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Link, useSearchParams } from 'react-router-dom';
 import api, { getApiErrorMessage } from '../../api/client';
-import type { CompanyAccount, CompanyProfile, Invoice, InvoiceCreate, Ledger, Payment, PaymentCreate, Product } from '../../types/api';
+import type { CompanyAccount, CompanyProfile, Invoice, InvoiceCreate, Ledger, LedgerAddress, Payment, PaymentCreate, Product } from '../../types/api';
 import InvoicePreview from '../../components/InvoicePreview';
 import StatusToasts from '../../components/StatusToasts';
 import ProductCombobox from '../../components/ProductCombobox';
@@ -11,7 +11,7 @@ import formatCurrency from '../../utils/formatting';
 import { formatInvoiceTaxBreakdown, isInterstateSupply } from '../../utils/invoiceTax';
 import { createDueDateFormState, formatInvoiceDateLabel, resolveDueDate, type DueDateMode } from '../../utils/invoiceDueDate.ts';
 import { useFY } from '../../context/FYContext';
-import { fetchInvoiceById, fetchInvoiceComposerData } from '../../features/invoices/api';
+import { fetchInvoiceById, fetchInvoiceComposerData, fetchLedgerAddresses } from '../../features/invoices/api';
 import { invoiceQueryKeys } from '../../features/invoices/queryKeys';
 import { useInvoiceComposerStore } from '../../store/useInvoiceComposerStore';
 import LedgerQuickCreateModal from './components/LedgerQuickCreateModal';
@@ -51,6 +51,12 @@ export default function InvoicesPage() {
   const [items, setItems] = useState<InvoiceFormItem[]>([createItem(1)]);
   const [nextItemId, setNextItemId] = useState(2);
   const [editingInvoiceId, setEditingInvoiceId] = useState<number | null>(null);
+  // Shipping address state (sales invoices only)
+  const [ledgerAddresses, setLedgerAddresses] = useState<LedgerAddress[]>([]);
+  const [shippingSameAsBilling, setShippingSameAsBilling] = useState(true);
+  const [selectedShippingAddressId, setSelectedShippingAddressId] = useState<number | null>(null);
+  const [newShippingLabel, setNewShippingLabel] = useState('');
+  const [newShippingAddress, setNewShippingAddress] = useState('');
   const showCancelled = false;
   const [previewInvoice, setPreviewInvoice] = useState<Invoice | null>(null);
   const [submitting, setSubmitting] = useState(false);
@@ -128,6 +134,27 @@ export default function InvoicesPage() {
       })
     );
   }, [composerQuery.data, selectedLedgerId, setSelectedLedgerId]);
+
+  // Fetch ledger addresses when ledger selection changes (for shipping address UI)
+  useEffect(() => {
+    if (!selectedLedgerId) {
+      setLedgerAddresses([]);
+      return;
+    }
+    let cancelled = false;
+    fetchLedgerAddresses(Number(selectedLedgerId))
+      .then((addrs) => { if (!cancelled) setLedgerAddresses(addrs); })
+      .catch(() => { if (!cancelled) setLedgerAddresses([]); });
+    return () => { cancelled = true; };
+  }, [selectedLedgerId]);
+
+  // Reset shipping selection when ledger changes
+  useEffect(() => {
+    setShippingSameAsBilling(true);
+    setSelectedShippingAddressId(null);
+    setNewShippingLabel('');
+    setNewShippingAddress('');
+  }, [selectedLedgerId]);
 
   // Handle ?edit=<id> query param — triggered from invoice feed or any other page
   useEffect(() => {
@@ -209,6 +236,10 @@ export default function InvoicesPage() {
     setDueDateMode('none');
     setDueDate('');
     setDueDateDays('');
+    setShippingSameAsBilling(true);
+    setSelectedShippingAddressId(null);
+    setNewShippingLabel('');
+    setNewShippingAddress('');
   }
 
   function startEditingInvoice(invoice: Invoice) {
@@ -247,6 +278,19 @@ export default function InvoicesPage() {
 
     setItems(nextItems);
     setNextItemId(nextItems.length + 1);
+    // Restore shipping address state from the invoice being edited
+    if (invoice.shipping_address) {
+      setShippingSameAsBilling(false);
+      // We only have the snapshot; pre-fill the new-address fields so the user can see what was used
+      setSelectedShippingAddressId(null);
+      setNewShippingLabel(invoice.shipping_address_label ?? '');
+      setNewShippingAddress(invoice.shipping_address);
+    } else {
+      setShippingSameAsBilling(true);
+      setSelectedShippingAddressId(null);
+      setNewShippingLabel('');
+      setNewShippingAddress('');
+    }
   }
 
   async function handleSubmitInvoice(event: React.FormEvent<HTMLFormElement>) {
@@ -293,6 +337,13 @@ export default function InvoicesPage() {
         reference_notes: voucherType === 'sales' ? (referenceNotes.trim() || null) : null,
         tax_inclusive: taxInclusive,
         apply_round_off: applyRoundOff,
+        ...(voucherType === 'sales' ? {
+          shipping_address_same_as_billing: shippingSameAsBilling,
+          shipping_address_id: (!shippingSameAsBilling && selectedShippingAddressId !== null) ? selectedShippingAddressId : null,
+          new_shipping_address: (!shippingSameAsBilling && selectedShippingAddressId === null && newShippingAddress.trim())
+            ? { label: newShippingLabel.trim() || 'Shipping', address: newShippingAddress.trim() }
+            : null,
+        } : {}),
         items: items.map((item) => ({
           product_id: Number(item.productId),
           quantity: Number(item.quantity),
@@ -527,6 +578,100 @@ export default function InvoicesPage() {
                   <p className="muted-text" style={{ marginBottom: 0 }}>
                     Optional: include PO number or any customer-provided reference.
                   </p>
+                </div>
+              ) : null}
+
+              {voucherType === 'sales' ? (
+                <div className="field" style={{ gridColumn: '1 / -1' }}>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '10px', marginBottom: '8px' }}>
+                    <input
+                      id="invoice-shipping-same"
+                      type="checkbox"
+                      checked={shippingSameAsBilling}
+                      onChange={(e) => {
+                        setShippingSameAsBilling(e.target.checked);
+                        if (e.target.checked) {
+                          setSelectedShippingAddressId(null);
+                          setNewShippingLabel('');
+                          setNewShippingAddress('');
+                        }
+                      }}
+                    />
+                    <label htmlFor="invoice-shipping-same" style={{ marginBottom: 0, cursor: 'pointer' }}>
+                      Shipping address same as billing address
+                    </label>
+                  </div>
+
+                  {!shippingSameAsBilling ? (
+                    <div className="stack" style={{ gap: '8px', paddingLeft: '0' }}>
+                      {ledgerAddresses.length > 0 ? (
+                        <div className="field" style={{ marginBottom: 0 }}>
+                          <label htmlFor="invoice-shipping-select">Saved addresses</label>
+                          <select
+                            id="invoice-shipping-select"
+                            className="select"
+                            value={selectedShippingAddressId ?? ''}
+                            onChange={(e) => {
+                              const val = e.target.value;
+                              if (val === '') {
+                                setSelectedShippingAddressId(null);
+                              } else if (val === '__new__') {
+                                setSelectedShippingAddressId(null);
+                                setNewShippingLabel('');
+                                setNewShippingAddress('');
+                              } else {
+                                const id = Number(val);
+                                setSelectedShippingAddressId(id);
+                                const found = ledgerAddresses.find((a) => a.id === id);
+                                if (found) {
+                                  setNewShippingLabel(found.label);
+                                  setNewShippingAddress(found.address);
+                                }
+                              }
+                            }}
+                          >
+                            <option value="">-- Select saved address --</option>
+                            {ledgerAddresses.map((addr) => (
+                              <option key={addr.id} value={addr.id}>
+                                {addr.label} — {addr.address.slice(0, 50)}{addr.address.length > 50 ? '…' : ''}
+                              </option>
+                            ))}
+                            <option value="__new__">+ Enter new address</option>
+                          </select>
+                        </div>
+                      ) : null}
+
+                      {(selectedShippingAddressId === null) ? (
+                        <>
+                          <div className="field" style={{ marginBottom: 0 }}>
+                            <label htmlFor="invoice-shipping-label">Address label</label>
+                            <input
+                              id="invoice-shipping-label"
+                              className="input"
+                              type="text"
+                              value={newShippingLabel}
+                              onChange={(e) => setNewShippingLabel(e.target.value)}
+                              placeholder="e.g. Warehouse, Site A"
+                            />
+                          </div>
+                          <div className="field" style={{ marginBottom: 0 }}>
+                            <label htmlFor="invoice-shipping-address">Shipping address</label>
+                            <textarea
+                              id="invoice-shipping-address"
+                              className="input"
+                              rows={3}
+                              value={newShippingAddress}
+                              onChange={(e) => setNewShippingAddress(e.target.value)}
+                              placeholder="Full shipping / delivery address"
+                            />
+                            <p className="muted-text" style={{ marginBottom: 0 }}>
+                              This address will be saved to the ledger for future use.
+                            </p>
+                          </div>
+                        </>
+                      ) : null}
+                    </div>
+                  ) : null}
                 </div>
               ) : null}
 

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -61,6 +61,28 @@ export type PaginatedInventoryOut = {
   total_pages: number;
 };
 
+export type LedgerAddress = {
+  id: number;
+  ledger_id: number;
+  company_id: number;
+  label: string;
+  address: string;
+  is_default: boolean;
+  created_at: string;
+};
+
+export type LedgerAddressCreate = {
+  label: string;
+  address: string;
+  is_default?: boolean;
+};
+
+export type LedgerAddressUpdate = {
+  label?: string;
+  address?: string;
+  is_default?: boolean;
+};
+
 export type Ledger = {
   id: number;
   name: string;
@@ -271,6 +293,8 @@ export type Invoice = {
   created_at: string;
   items: InvoiceItem[];
   warnings?: string[];
+  shipping_address: string | null;
+  shipping_address_label: string | null;
 };
 
 export type OutstandingInvoice = {
@@ -371,6 +395,9 @@ export type InvoiceCreate = {
   reference_notes?: string | null;
   tax_inclusive?: boolean;
   apply_round_off?: boolean;
+  shipping_address_same_as_billing?: boolean;
+  shipping_address_id?: number | null;
+  new_shipping_address?: { label: string; address: string } | null;
   items: InvoiceItemInput[];
 };
 


### PR DESCRIPTION
## Summary

Adds shipping address support to sales invoices. Users can now:
- Mark "Shipping address same as billing address" (default checked) on the invoice form
- When unchecked, select a saved address from the ledger or enter a new one inline
- New inline addresses are automatically saved to the ledger for future reuse
- Manage saved addresses per ledger from the Ledger detail page
- Invoice PDF renders a "Ship to" section alongside "Bill to" only when shipping differs from billing

Addresses are stored in a new `ledger_addresses` table. Invoices snapshot the shipping address at creation time (same pattern as existing billing address snapshot).

## Type of change

- [x] feat (new feature)

## How to test

1. Apply migrations: `DATABASE_URL=... python migrate.py up`
2. Open a sales invoice, select a ledger — checkbox "Shipping address same as billing address" should appear, checked by default
3. Uncheck it — a dropdown should appear (empty if no saved addresses) plus label/address fields
4. Enter a new address and create the invoice — the address should be saved to the ledger
5. Create another invoice for the same ledger, uncheck shipping — the saved address should appear in the dropdown
6. Go to the Ledger detail page — "Saved addresses" panel should show the saved address with edit/delete actions
7. Download the invoice PDF — "Ship to" section should appear next to "Bill to" with the entered address
8. Create an invoice with the checkbox checked — PDF should show only "Bill to" (no "Ship to")

## Checklist

- [x] My code follows the project style and conventions
- [x] I added/updated tests where appropriate
- [x] I ran relevant checks locally
- [x] I verified this does not break existing behavior

## Screenshots (if UI changes)

N/A — shipping section appears in invoice composer when checkbox is unchecked; "Ship to" block renders in PDF alongside "Bill to".

## Related issue

Closes #