### PR TITLE
feat: add tax inclusive/exclusive pricing toggle for PDF generation

### DIFF
--- a/backend/src/services/pdf_templates/__init__.py
+++ b/backend/src/services/pdf_templates/__init__.py
@@ -12,6 +12,7 @@ from .builders import (
     _fmt_rate,
     _pdf_display_quantity,
     _pdf_display_unit,
+    _pdf_unit_price,
     _pdf_unit_price_including_tax,
 )
 from .invoice_template import (
@@ -40,5 +41,6 @@ __all__ = [
     "_fmt_rate",
     "_pdf_display_quantity",
     "_pdf_display_unit",
+    "_pdf_unit_price",
     "_pdf_unit_price_including_tax",
 ]

--- a/backend/src/services/pdf_templates/builders.py
+++ b/backend/src/services/pdf_templates/builders.py
@@ -102,6 +102,18 @@ def _pdf_unit_price_including_tax(item: InvoiceItem) -> float:
     return float(_money(line_total / quantity))
 
 
+def _pdf_unit_price(item: InvoiceItem, *, tax_inclusive: bool) -> float:
+    """Return the unit price for PDF display, respecting the tax-inclusive preference.
+
+    When *tax_inclusive* is True the unit price includes tax (line_total / quantity).
+    When *tax_inclusive* is False the unit price is displayed without tax
+    (the stored unit_price).
+    """
+    if tax_inclusive:
+        return _pdf_unit_price_including_tax(item)
+    return float(item.unit_price or 0)
+
+
 def _pdf_display_unit(unit: str | None) -> str:
     """Format unit display for PDF, abbreviating common units."""
     normalized_unit = (unit or "Pieces").strip()

--- a/backend/src/services/pdf_templates/invoice_template.py
+++ b/backend/src/services/pdf_templates/invoice_template.py
@@ -15,7 +15,7 @@ from .builders import (
     _fmt_currency,
     _pdf_display_quantity,
     _pdf_display_unit,
-    _pdf_unit_price_including_tax,
+    _pdf_unit_price,
 )
 from .purchase_template import _build_purchase_invoice_html, _is_interstate_supply, _extract_pan_from_gstin
 
@@ -46,6 +46,7 @@ def _build_invoice_html(invoice: Invoice, products: list[Product], invoice_bank_
     table_colgroup = _build_pdf_table_colgroup(interstate_supply)
 
     product_map = {p.id: p for p in products}
+    tax_inclusive = bool(invoice.tax_inclusive)
 
     # Build line item rows
     item_rows = ""
@@ -70,12 +71,13 @@ def _build_invoice_html(invoice: Invoice, products: list[Product], invoice_bank_
           <td>{hsn}</td>
           <td class="right">{quantity_display}</td>
           <td>{unit}</td>
-          <td class="right">{_fmt_currency(_pdf_unit_price_including_tax(item), currency)}</td>
+          <td class="right">{_fmt_currency(_pdf_unit_price(item, tax_inclusive=tax_inclusive), currency)}</td>
           {tax_row_cells}
           <td class="right">{_fmt_currency(float(item.line_total), currency)}</td>
         </tr>"""
 
-    # Company details
+    # Dynamic unit price column header based on tax_inclusive preference
+    unit_price_header_label = "(with tax)" if tax_inclusive else "(without tax)"
     company_detail_parts = []
     if invoice.company_gst:
         company_detail_parts.append(f"GST: {_e(invoice.company_gst)}")
@@ -409,7 +411,7 @@ def _build_invoice_html(invoice: Invoice, products: list[Product], invoice_bank_
           <th>HSN/SAC</th>
           <th class="right">Qty</th>
           <th>Unit</th>
-          <th class="right">Unit Price<br><span style="font-size: 6px; font-weight: 500; text-transform: none;">(with tax)</span></th>
+          <th class="right">Unit Price<br><span style="font-size: 6px; font-weight: 500; text-transform: none;">{unit_price_header_label}</span></th>
           {tax_header_cells}
           <th class="right">Amount</th>
         </tr>

--- a/backend/src/services/pdf_templates/purchase_template.py
+++ b/backend/src/services/pdf_templates/purchase_template.py
@@ -15,7 +15,7 @@ from .builders import (
     _fmt_currency,
     _pdf_display_quantity,
     _pdf_display_unit,
-    _pdf_unit_price_including_tax,
+    _pdf_unit_price,
 )
 
 
@@ -45,6 +45,7 @@ def _build_purchase_invoice_html(invoice: Invoice, products: list[Product]) -> s
     table_colgroup = _build_pdf_table_colgroup(interstate_supply)
 
     product_map = {p.id: p for p in products}
+    tax_inclusive = bool(invoice.tax_inclusive)
 
     item_rows = ""
     for idx, item in enumerate(invoice.items or [], start=1):
@@ -68,10 +69,13 @@ def _build_purchase_invoice_html(invoice: Invoice, products: list[Product]) -> s
           <td>{hsn}</td>
           <td class="right">{quantity_display}</td>
           <td>{unit}</td>
-          <td class="right">{_fmt_currency(_pdf_unit_price_including_tax(item), currency)}</td>
+          <td class="right">{_fmt_currency(_pdf_unit_price(item, tax_inclusive=tax_inclusive), currency)}</td>
           {tax_row_cells}
           <td class="right">{_fmt_currency(float(item.line_total), currency)}</td>
         </tr>"""
+
+    # Dynamic unit price column header based on tax_inclusive preference
+    unit_price_header_label = "(with tax)" if tax_inclusive else "(without tax)"
 
     # Supplier details are stored as ledger_* (buyer_* in DB) on purchase invoices
     supplier_detail_parts = []
@@ -303,7 +307,7 @@ def _build_purchase_invoice_html(invoice: Invoice, products: list[Product]) -> s
           <th>HSN/SAC</th>
           <th class="right">Qty</th>
           <th>Unit</th>
-          <th class="right">Unit Price<br><span style="font-size: 6px; font-weight: 500; text-transform: none;">(with tax)</span></th>
+          <th class="right">Unit Price<br><span style="font-size: 6px; font-weight: 500; text-transform: none;">{unit_price_header_label}</span></th>
           {tax_header_cells}
           <th class="right">Amount</th>
         </tr>

--- a/backend/tests/api/test_invoice_pan_display.py
+++ b/backend/tests/api/test_invoice_pan_display.py
@@ -159,3 +159,128 @@ def test_pdf_quantity_keeps_decimal_for_decimal_enabled_product():
     html = _build_invoice_html(invoice, [product])
 
     assert '<td class="right">1.5</td>' in html
+
+
+def test_sales_pdf_shows_unit_price_without_tax_when_tax_inclusive_false():
+    """When tax_inclusive=False, the unit price column should show stored unit_price and label says (without tax)."""
+    invoice = _invoice_base("sales")
+    invoice.tax_inclusive = False
+    item = InvoiceItem(
+        product_id=1,
+        hsn_sac="1234",
+        quantity=2.0,
+        unit_price=100.0,
+        tax_amount=36.0,
+        cgst_amount=18.0,
+        sgst_amount=18.0,
+        igst_amount=0.0,
+        line_total=236.0,
+        description=None,
+    )
+    invoice.items = [item]
+    product = SimpleNamespace(id=1, name="Widget", sku="W-1", hsn_sac="1234", unit="Pieces", allow_decimal=False)
+
+    html = _build_invoice_html(invoice, [product])
+
+    assert "(without tax)" in html
+    assert "₹100.00" in html  # unit price = stored unit_price (not with tax)
+
+
+def test_sales_pdf_shows_unit_price_with_tax_when_tax_inclusive_true():
+    """When tax_inclusive=True, the unit price column should show line_total/quantity and label says (with tax)."""
+    invoice = _invoice_base("sales")
+    invoice.tax_inclusive = True
+    item = InvoiceItem(
+        product_id=1,
+        hsn_sac="1234",
+        quantity=2.0,
+        unit_price=100.0,
+        tax_amount=36.0,
+        cgst_amount=18.0,
+        sgst_amount=18.0,
+        igst_amount=0.0,
+        line_total=236.0,
+        description=None,
+    )
+    invoice.items = [item]
+    product = SimpleNamespace(id=1, name="Widget", sku="W-1", hsn_sac="1234", unit="Pieces", allow_decimal=False)
+
+    html = _build_invoice_html(invoice, [product])
+
+    assert "(with tax)" in html
+    assert "₹118.00" in html  # unit price = line_total / quantity = 236/2 = 118
+
+
+def test_purchase_pdf_shows_unit_price_without_tax_when_tax_inclusive_false():
+    """When tax_inclusive=False on a purchase invoice, unit price shows stored unit_price."""
+    invoice = _invoice_base("purchase")
+    invoice.tax_inclusive = False
+    item = InvoiceItem(
+        product_id=1,
+        hsn_sac="1234",
+        quantity=1.0,
+        unit_price=500.0,
+        tax_amount=90.0,
+        cgst_amount=45.0,
+        sgst_amount=45.0,
+        igst_amount=0.0,
+        line_total=590.0,
+        description=None,
+    )
+    invoice.items = [item]
+    product = SimpleNamespace(id=1, name="Widget", sku="W-1", hsn_sac="1234", unit="Pieces", allow_decimal=False)
+
+    html = _build_purchase_invoice_html(invoice, [product])
+
+    assert "(without tax)" in html
+    assert "₹500.00" in html  # stored unit_price, not inclusive
+
+
+def test_purchase_pdf_shows_unit_price_with_tax_when_tax_inclusive_true():
+    """When tax_inclusive=True on a purchase invoice, unit price shows line_total/quantity."""
+    invoice = _invoice_base("purchase")
+    invoice.tax_inclusive = True
+    item = InvoiceItem(
+        product_id=1,
+        hsn_sac="1234",
+        quantity=1.0,
+        unit_price=500.0,
+        tax_amount=90.0,
+        cgst_amount=45.0,
+        sgst_amount=45.0,
+        igst_amount=0.0,
+        line_total=590.0,
+        description=None,
+    )
+    invoice.items = [item]
+    product = SimpleNamespace(id=1, name="Widget", sku="W-1", hsn_sac="1234", unit="Pieces", allow_decimal=False)
+
+    html = _build_purchase_invoice_html(invoice, [product])
+
+    assert "(with tax)" in html
+    assert "₹590.00" in html  # line_total / quantity = 590/1 = 590
+
+
+def test_sales_pdf_defaults_to_without_tax_when_tax_inclusive_not_set():
+    """When tax_inclusive is not explicitly set (defaults to False/None), show without tax."""
+    invoice = _invoice_base("sales")
+    # tax_inclusive defaults to False on the model
+    item = InvoiceItem(
+        product_id=1,
+        hsn_sac="1234",
+        quantity=1.0,
+        unit_price=100.0,
+        tax_amount=18.0,
+        cgst_amount=9.0,
+        sgst_amount=9.0,
+        igst_amount=0.0,
+        line_total=118.0,
+        description=None,
+    )
+    invoice.items = [item]
+    product = SimpleNamespace(id=1, name="Widget", sku="W-1", hsn_sac="1234", unit="Pieces", allow_decimal=False)
+
+    html = _build_invoice_html(invoice, [product])
+
+    assert "(without tax)" in html
+    assert "₹100.00" in html

--- a/backend/tests/services/test_pdf_price_display.py
+++ b/backend/tests/services/test_pdf_price_display.py
@@ -1,0 +1,116 @@
+"""
+Unit tests for PDF unit price display based on tax_inclusive preference.
+
+Covers:
+- _pdf_unit_price function in builders.py
+- Invoice HTML template unit price rendering with/without tax
+- Column header labels
+"""
+
+from decimal import Decimal
+
+import pytest
+
+from src.models.invoice import InvoiceItem
+from src.services.pdf_templates.builders import _pdf_unit_price, _pdf_unit_price_including_tax
+
+
+def make_invoice_item(unit_price=100.0, quantity=2.0, taxable_amount=200.0, tax_amount=36.0, line_total=236.0, gst_rate=18.0):
+    """Create an InvoiceItem with the given values."""
+    item = InvoiceItem()
+    item.product_id = 1
+    item.unit_price = unit_price
+    item.quantity = quantity
+    item.taxable_amount = taxable_amount
+    item.tax_amount = tax_amount
+    item.line_total = line_total
+    item.gst_rate = gst_rate
+    return item
+
+
+class TestPdfUnitPrice:
+    def test_tax_inclusive_returns_line_total_divided_by_quantity(self):
+        """When tax_inclusive=True, unit price = line_total / quantity."""
+        item = make_invoice_item(
+            unit_price=100.0, quantity=2.0, line_total=236.0
+        )
+        result = _pdf_unit_price(item, tax_inclusive=True)
+        # 236 / 2 = 118
+        assert result == 118.0
+
+    def test_tax_inclusive_falls_back_to_unit_price_when_quantity_zero(self):
+        """When quantity is 0, fall back to stored unit_price."""
+        item = make_invoice_item(
+            unit_price=100.0, quantity=0.0, line_total=0.0
+        )
+        result = _pdf_unit_price(item, tax_inclusive=True)
+        assert result == 100.0
+
+    def test_tax_exclusive_returns_stored_unit_price(self):
+        """When tax_inclusive=False, unit price = the stored unit_price."""
+        item = make_invoice_item(
+            unit_price=100.0, quantity=2.0, line_total=236.0
+        )
+        result = _pdf_unit_price(item, tax_inclusive=False)
+        assert result == 100.0
+
+    def test_tax_exclusive_returns_stored_unit_price_regardless_of_quantity(self):
+        """Even with fractional quantities, tax-exclusive uses stored unit_price."""
+        item = make_invoice_item(
+            unit_price=150.0, quantity=0.5, line_total=88.50
+        )
+        result = _pdf_unit_price(item, tax_inclusive=False)
+        assert result == 150.0
+
+    def test_tax_exclusive_unit_price_zero(self):
+        """Zero unit_price is returned as-is."""
+        item = make_invoice_item(
+            unit_price=0.0, quantity=1.0, line_total=18.0
+        )
+        result = _pdf_unit_price(item, tax_inclusive=False)
+        assert result == 0.0
+
+    def test_tax_inclusive_with_fractional_quantity(self):
+        """Tax inclusive with fractional quantity."""
+        item = make_invoice_item(
+            unit_price=100.0, quantity=0.5, taxable_amount=50.0,
+            tax_amount=9.0, line_total=59.0,
+        )
+        result = _pdf_unit_price(item, tax_inclusive=True)
+        # 59 / 0.5 = 118
+        assert result == 118.0
+
+    def test_zero_gst_tax_inclusive_equals_unit_price(self):
+        """With 0% GST, tax-inclusive unit price equals stored unit_price."""
+        item = make_invoice_item(
+            unit_price=100.0, quantity=1.0, taxable_amount=100.0,
+            tax_amount=0.0, line_total=100.0, gst_rate=0.0,
+        )
+        result = _pdf_unit_price(item, tax_inclusive=True)
+        assert result == 100.0
+
+    def test_tax_exclusive_and_tax_inclusive_differ_with_gst(self):
+        """With GST > 0, tax-inclusive and tax-exclusive values differ."""
+        item = make_invoice_item(
+            unit_price=100.0, quantity=1.0, taxable_amount=100.0,
+            tax_amount=18.0, line_total=118.0,
+        )
+        inclusive = _pdf_unit_price(item, tax_inclusive=True)
+        exclusive = _pdf_unit_price(item, tax_inclusive=False)
+        assert inclusive == 118.0
+        assert exclusive == 100.0
+        assert inclusive != exclusive
+
+
+class TestPdfUnitPriceIncludingTax:
+    """Test the existing _pdf_unit_price_including_tax function still works."""
+
+    def test_returns_line_total_divided_by_quantity(self):
+        item = make_invoice_item(line_total=236.0, quantity=2.0)
+        result = _pdf_unit_price_including_tax(item)
+        assert result == 118.0
+
+    def test_falls_back_to_unit_price_when_quantity_zero(self):
+        item = make_invoice_item(unit_price=100.0, quantity=0.0, line_total=0.0)
+        result = _pdf_unit_price_including_tax(item)
+        assert result == 100.0

--- a/frontend/src/utils/invoiceTax.test.ts
+++ b/frontend/src/utils/invoiceTax.test.ts
@@ -1,0 +1,92 @@
+import { expect, test } from 'vitest';
+
+/**
+ * Tests for tax-inclusive/exclusive pricing toggle logic.
+ *
+ * These tests verify the calculation logic used in CreateInvoiceModal and
+ * InvoicesPageView components.
+ */
+
+// Replicating the calculation logic from the components:
+function calculateLineTotal(
+  unitPrice: number,
+  quantity: number,
+  gstRate: number,
+  taxInclusive: boolean,
+): number {
+  if (taxInclusive) {
+    return unitPrice * quantity;
+  }
+  const taxableAmount = unitPrice * quantity;
+  return taxableAmount + taxableAmount * gstRate / 100;
+}
+
+function calculateTaxAmount(
+  unitPrice: number,
+  quantity: number,
+  gstRate: number,
+  taxInclusive: boolean,
+): number {
+  if (taxInclusive) {
+    const lineTotal = unitPrice * quantity;
+    return lineTotal - lineTotal / (1 + gstRate / 100);
+  }
+  const taxableAmount = unitPrice * quantity;
+  return taxableAmount * gstRate / 100;
+}
+
+test('tax_exclusive: taxable + tax = line total', () => {
+  // unit_price=100, qty=2, GST=18%
+  // taxable = 200, tax = 36, line total = 236
+  const lineTotal = calculateLineTotal(100, 2, 18, false);
+  expect(lineTotal).toBe(236);
+});
+
+test('tax_exclusive: tax amount calculation', () => {
+  const taxAmount = calculateTaxAmount(100, 2, 18, false);
+  expect(taxAmount).toBe(36);
+});
+
+test('tax_inclusive: line total = unit_price * quantity (no extra tax)', () => {
+  // unit_price=118 (inclusive of 18% GST), qty=1
+  // line total = 118
+  const lineTotal = calculateLineTotal(118, 1, 18, true);
+  expect(lineTotal).toBe(118);
+});
+
+test('tax_inclusive: tax is backed out from inclusive price', () => {
+  // unit_price=118 (inclusive of 18% GST), qty=1
+  // line total = 118, tax = 118 - 118/1.18 = 18
+  const taxAmount = calculateTaxAmount(118, 1, 18, true);
+  expect(taxAmount).toBeCloseTo(18, 1);
+});
+
+test('tax_inclusive: zero GST rate', () => {
+  const lineTotal = calculateLineTotal(100, 1, 0, true);
+  expect(lineTotal).toBe(100);
+
+  const taxAmount = calculateTaxAmount(100, 1, 0, true);
+  expect(taxAmount).toBe(0);
+});
+
+test('tax_exclusive: zero GST rate', () => {
+  const lineTotal = calculateLineTotal(100, 1, 0, false);
+  expect(lineTotal).toBe(100);
+
+  const taxAmount = calculateTaxAmount(100, 1, 0, false);
+  expect(taxAmount).toBe(0);
+});
+
+test('tax_inclusive with tax_exclusive give same result when GST=0', () => {
+  const inc = calculateLineTotal(100, 1, 0, true);
+  const exc = calculateLineTotal(100, 1, 0, false);
+  expect(inc).toBe(exc);
+});
+
+test('tax_inclusive with tax_exclusive differ when GST>0', () => {
+  const inc = calculateLineTotal(100, 1, 18, true);
+  const exc = calculateLineTotal(100, 1, 18, false);
+  expect(inc).toBe(100);
+  expect(exc).toBe(118);
+  expect(inc).not.toBe(exc);
+});


### PR DESCRIPTION
## Summary

Implements #363 — adds a checkbox/toggle on the invoicing page so users can choose whether PDF pricing includes taxes.

## Changes

**Backend — PDF templates:**
- Added `_pdf_unit_price()` helper in `builders.py` that returns unit price with or without tax based on `tax_inclusive` flag
- Updated `invoice_template.py` and `purchase_template.py` to use dynamic column headers ("(with tax)" / "(without tax)") and call the new helper

**Backend — other layers** (already wired up):
- Database migration already had `tax_inclusive` column
- Invoice model, Pydantic schemas, and API endpoint already accepted the field
- Invoice processor/service layer already passed it through

**Frontend** (already wired up):
- `CreateInvoiceModal` and `InvoicesPageView` already had the checkbox
- `useInvoiceComposerStore` already stored the flag

**Tests added:**
- `tests/services/test_pdf_price_display.py` — unit tests for `_pdf_unit_price`
- `tests/api/test_invoice_pan_display.py` — integration tests verifying correct unit prices and column headers in generated PDF HTML for both `tax_inclusive=True/False`

Closes #363