### PR TITLE
fix(db): server_default on company_profiles.show_sku_on_pdf (fixes fresh-DB install)

### DIFF
--- a/backend/src/models/company.py
+++ b/backend/src/models/company.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Boolean, Column, Integer, String, Text
+from sqlalchemy import Boolean, Column, Integer, String, Text, text
 from sqlalchemy.orm import relationship
 
 from src.db.base import Base
@@ -23,5 +23,7 @@ class CompanyProfile(Base):
     logo_data = Column(Text, nullable=True)
     logo_mime_type = Column(String(50), nullable=True)
     additional_company_info = Column(Text, nullable=True)
-    show_sku_on_pdf = Column(Boolean, nullable=False, default=False)
+    # server_default so create_all() emits a DB-level default — raw-SQL data
+    # migrations (e.g. the company-scope backfill) INSERT without this column.
+    show_sku_on_pdf = Column(Boolean, nullable=False, default=False, server_default=text("false"))
     terms = relationship("CompanyTerm", back_populates="company", order_by="CompanyTerm.serial_number", cascade="all, delete-orphan")


### PR DESCRIPTION
## Problem

A brand-new install fails to start. On first boot, `app_main` runs `Base.metadata.create_all()` (which builds the latest schema from the models) and then replays all migrations. The `20260424000002_backfill_company_scope_data` migration seeds a *Default Company* via a **raw-SQL `INSERT`** that omits `show_sku_on_pdf` and relies on a DB column default.

But `show_sku_on_pdf` was declared `NOT NULL` with only an **ORM-side** `default=False` and no `server_default`, so `create_all()` emitted no DB-level default. The raw INSERT therefore failed:

```
psycopg2.errors.NotNullViolation: null value in column "show_sku_on_pdf"
of relation "company_profiles" violates not-null constraint
```

This only bites fresh databases — existing/migrated DBs already have the default from the column's own `ALTER` migration, and the seed branch is skipped when a company already exists.

## Fix

Add `server_default=text("false")` to the model column so `create_all()` emits a DB-level default, matching what the migration already sets on existing databases.

## Verification

- A completely fresh database now runs the full migration chain end-to-end (previously died at `20260424000002`).
- Full backend test suite: **267 passed**. The only failures are 4 tests that fail identically on `main` without this change (pre-existing, unrelated — in `test_invoice_product_names` and `test_invoice_tax_split`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)