### PR TITLE
fix(company): return show_sku_on_pdf in API response; refresh two stale tests

### DIFF
--- a/backend/src/api/routes/company.py
+++ b/backend/src/api/routes/company.py
@@ -122,6 +122,7 @@ def _company_to_out(company: CompanyProfile) -> CompanyProfileOut:
         logo_data=company.logo_data,
         logo_mime_type=company.logo_mime_type,
         additional_company_info=company.additional_company_info,
+        show_sku_on_pdf=company.show_sku_on_pdf,
         terms=[
             CompanyTermOut(
                 id=t.id,

--- a/backend/tests/api/test_invoice_product_names.py
+++ b/backend/tests/api/test_invoice_product_names.py
@@ -428,10 +428,30 @@ class TestInvoiceApiProductName:
             assert len(data["items"]) == 1
             assert data["items"][0]["product_name"] == "Mechanical Keyboard"
 
-    def test_product_name_none_when_product_deleted(self, client):
-        """product_name is None if the product no longer exists."""
+    def test_product_delete_blocked_when_linked_to_invoice(self, client):
+        """A product linked to an invoice cannot be deleted via the API."""
         with patch("src.services.invoice_processor.generate_next_number", return_value="INV-0005"):
             ledger_id = _create_ledger(client, name="Del Buyer", gst="27ABCDE9999F1Z9")
+            product_id = _create_product(client, sku="TEMP", name="Temporary Item")
+            _add_inventory(client, product_id=product_id, quantity=10)
+
+            client.post("/api/invoices/", json={
+                "ledger_id": ledger_id,
+                "voucher_type": "sales",
+                "items": [{"product_id": product_id, "quantity": 1}],
+            })
+
+            resp = client.delete(f"/api/products/{product_id}")
+            assert resp.status_code == 400
+
+    def test_product_name_none_when_product_orphaned(self, client, db_session):
+        """product_name is None when the underlying product no longer exists.
+
+        The API blocks deleting a product that is linked to an invoice, so we
+        simulate orphaned/legacy data by removing the product row directly.
+        """
+        with patch("src.services.invoice_processor.generate_next_number", return_value="INV-0006"):
+            ledger_id = _create_ledger(client, name="Orphan Buyer", gst="27ABCDE9999F1Z9")
             product_id = _create_product(client, sku="TEMP", name="Temporary Item")
             _add_inventory(client, product_id=product_id, quantity=10)
 
@@ -442,10 +462,11 @@ class TestInvoiceApiProductName:
             })
             invoice_id = create_resp.json()["id"]
 
-            # Delete the product
-            client.delete(f"/api/products/{product_id}")
+            # Orphan the invoice item by removing the product row directly.
+            db_session.query(Product).filter(Product.id == product_id).delete()
+            db_session.commit()
 
-            # Fetch invoice — should still return but product_name is None
+            # Fetch invoice — should still return but product_name is None.
             resp = client.get(f"/api/invoices/{invoice_id}")
             assert resp.status_code == 200
             data = resp.json()

--- a/backend/tests/api/test_invoice_tax_split.py
+++ b/backend/tests/api/test_invoice_tax_split.py
@@ -142,16 +142,16 @@ def test_intrastate_odd_paise_total_tax_is_not_inflated(db_session):
     assert "GST Split" not in html
 
 
-def test_pdf_unit_price_always_displays_tax_inclusive_value(db_session):
+def _unit_price_html(db_session, *, tax_inclusive: bool, unit_price: float) -> str:
     user, ledger = _seed_common(db_session)
-    product = _create_product_with_inventory(db_session, "UNIT01", 100.00, 18)
+    product = _create_product_with_inventory(db_session, "UNIT01", unit_price, 18)
     invoice = _new_invoice(db_session)
 
     payload = InvoiceCreate(
         ledger_id=ledger.id,
         voucher_type="sales",
-        tax_inclusive=False,
-        items=[InvoiceItemCreate(product_id=product.id, quantity=2, unit_price=100.00)],
+        tax_inclusive=tax_inclusive,
+        items=[InvoiceItemCreate(product_id=product.id, quantity=2, unit_price=unit_price)],
     )
 
     InvoiceProcessor(db_session).apply_payload(
@@ -163,11 +163,27 @@ def test_pdf_unit_price_always_displays_tax_inclusive_value(db_session):
     db_session.flush()
     db_session.refresh(invoice)
 
-    html = _build_invoice_html(invoice, [product])
+    return _build_invoice_html(invoice, [product])
 
-    # Unit price column should always show tax-inclusive per-unit amount.
+
+def test_pdf_unit_price_excludes_tax_when_tax_exclusive(db_session):
+    """tax_inclusive=False → unit price column shows the entered pre-tax amount (#363 toggle).
+
+    The price is shown as entered (100.00) — it is NOT grossed up to the
+    tax-inclusive figure (118.00).
+    """
+    html = _unit_price_html(db_session, tax_inclusive=False, unit_price=100.00)
+    assert "100.00</td>" in html
+    assert "118.00</td>" not in html
+
+
+def test_pdf_unit_price_includes_tax_when_tax_inclusive(db_session):
+    """tax_inclusive=True → unit price column shows the tax-inclusive amount (#363 toggle).
+
+    A price entered as tax-inclusive (118.00) flows through to the column as-is.
+    """
+    html = _unit_price_html(db_session, tax_inclusive=True, unit_price=118.00)
     assert "118.00</td>" in html
-    assert "100.00</td>" not in html
 
 
 def test_intrastate_three_line_case_keeps_tax_exact_with_balanced_split(db_session):


### PR DESCRIPTION
Investigating the pre-existing failures in the backend test suite on `main` turned up **one real bug** and **two stale tests** left behind by later feature changes.

## Real bug — `show_sku_on_pdf` never returned by the API

`_company_to_out()` builds `CompanyProfileOut(...)` but never passed `show_sku_on_pdf`, so it always fell back to the schema default `False`. The value was *persisted* correctly (the PUT handler sets it on the model), but `GET`/`PUT /company` never reflected it — so the "Show SKU on PDF" company setting silently failed to round-trip in the UI.

**Fix:** pass `show_sku_on_pdf=company.show_sku_on_pdf` into the serializer.

Fixes `test_get_company_returns_show_sku_on_pdf` and `test_update_company_show_sku_to_true`.

## Stale test — product deletion

`test_product_name_none_when_product_deleted` assumed a product linked to an invoice could be deleted and that the invoice item's `product_name` would then become `None`. The API now (correctly) blocks deleting a product linked to invoices with a `400`, so the product was never deleted.

**Fix:** split into:
- `test_product_delete_blocked_when_linked_to_invoice` — asserts the `400` guard.
- `test_product_name_none_when_product_orphaned` — orphans the product row directly (simulating legacy/orphaned data) to exercise the `product_name=None` path.

## Stale test — PDF unit price

`test_pdf_unit_price_always_displays_tax_inclusive_value` (added 2026-04-27) predated the **#363 tax inclusive/exclusive PDF toggle** (2026-06-10), which deliberately made the unit-price column respect `invoice.tax_inclusive`. The test still asserted the price is *always* grossed up to tax-inclusive.

**Fix:** replaced with two tests covering both toggle states (`test_pdf_unit_price_excludes_tax_when_tax_exclusive`, `test_pdf_unit_price_includes_tax_when_tax_inclusive`).

## Verification

Full backend test suite is green (**273 passed**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)