### PR TITLE
fix(gstr1): split doc_issue range for B2B and B2C invoices

### DIFF
--- a/backend/src/api/routes/ledgers.py
+++ b/backend/src/api/routes/ledgers.py
@@ -2082,12 +2082,12 @@ def gstr1_export_json(
         hsn_section["hsn_b2c"] = hsn_b2c_rows
 
     # Documents issued (Table 13): nature-of-document code + issued range.
-    def _doc_range(numbers: list[str]) -> dict | None:
+    def _doc_range(numbers: list[str], num: int = 1) -> dict | None:
         nums = sorted(n for n in numbers if n)
         if not nums:
             return None
         return {
-            "num": 1,
+            "num": num,
             "from": nums[0],
             "to": nums[-1],
             "totnum": len(nums),
@@ -2096,9 +2096,29 @@ def gstr1_export_json(
         }
 
     doc_det: list[dict] = []
-    inv_range = _doc_range([inv.invoice_number or f"INV-{inv.id}" for inv in invoices if inv.voucher_type == "sales"])
-    if inv_range:  # 1 = Invoices for outward supply
-        doc_det.append({"doc_num": 1, "docs": [inv_range]})
+    # B2B and B2C invoices must be declared as separate doc ranges (Table 13).
+    # A single merged range spanning both B2B and B2C invoice numbers causes a
+    # portal rejection because B2C invoices only appear aggregated in b2cs and
+    # cannot be individually resolved within a B2B range.
+    b2b_inv_numbers = [
+        inv.invoice_number or f"INV-{inv.id}"
+        for inv in invoices
+        if inv.voucher_type == "sales" and inv.ledger_gst and inv.ledger_gst.strip()
+    ]
+    b2c_inv_numbers = [
+        inv.invoice_number or f"INV-{inv.id}"
+        for inv in invoices
+        if inv.voucher_type == "sales" and not (inv.ledger_gst and inv.ledger_gst.strip())
+    ]
+    inv_docs: list[dict] = []
+    b2b_range = _doc_range(b2b_inv_numbers, num=len(inv_docs) + 1)
+    if b2b_range:
+        inv_docs.append(b2b_range)
+    b2c_range = _doc_range(b2c_inv_numbers, num=len(inv_docs) + 1)
+    if b2c_range:
+        inv_docs.append(b2c_range)
+    if inv_docs:  # 1 = Invoices for outward supply
+        doc_det.append({"doc_num": 1, "docs": inv_docs})
     dn_range = _doc_range([cn.credit_note_number or f"DN-{cn.id}" for cn in credit_notes if cn.credit_note_type != "return"])
     if dn_range:  # 4 = Debit Note
         doc_det.append({"doc_num": 4, "docs": [dn_range]})

--- a/backend/tests/api/test_tax_ledger.py
+++ b/backend/tests/api/test_tax_ledger.py
@@ -1006,6 +1006,84 @@ def test_gstr1_doc_issue_uses_nature_code_and_ranges(db_session):
     assert rng["net_issue"] == 2
 
 
+def test_gstr1_doc_issue_splits_b2b_and_b2c_ranges(db_session):
+    """doc_issue must produce separate docs entries for B2B and B2C invoices.
+
+    A single merged range covering both B2B and B2C invoice numbers causes a
+    portal rejection because B2C invoices only appear aggregated in b2cs and
+    the portal cannot resolve them individually within a B2B range.
+    """
+    user, ledger = _seed_basics(db_session)
+    company = _make_company(gst="29TESTT1234X1Z5")
+
+    # B2B invoice — ledger has GSTIN
+    _add_invoice_with_item(
+        db_session, ledger, user,
+        voucher_type="sales",
+        invoice_number="INV-2026-27-068",
+        when=datetime(2026, 6, 14),
+        gst_rate=18,
+        taxable_amount=10000,
+        cgst_amount=900,
+        sgst_amount=900,
+        igst_amount=0,
+    )
+
+    # B2C invoice — no GSTIN on ledger; use a fresh Buyer without gst
+    b2c_ledger = Buyer(
+        name="B2C Customer",
+        address="Some Street",
+        gst=None,
+        phone_number="8888888888",
+    )
+    db_session.add(b2c_ledger)
+    db_session.commit()
+    db_session.refresh(b2c_ledger)
+
+    _add_invoice_with_item(
+        db_session, b2c_ledger, user,
+        voucher_type="sales",
+        invoice_number="INV-2026-27-069",
+        when=datetime(2026, 6, 15),
+        gst_rate=18,
+        taxable_amount=216,
+        cgst_amount=19,
+        sgst_amount=19,
+        igst_amount=0,
+    )
+    db_session.commit()
+
+    data = _export_json_data(db_session, user, company, date(2026, 6, 1), date(2026, 6, 30))
+
+    doc_det = data["doc_issue"]["doc_det"]
+    inv_doc = next(d for d in doc_det if d["doc_num"] == 1)
+    docs = inv_doc["docs"]
+
+    # Must have TWO separate range entries: one for B2B, one for B2C
+    assert len(docs) == 2, (
+        f"Expected 2 separate doc ranges (B2B + B2C), got {len(docs)}: {docs}"
+    )
+
+    nums = [d["num"] for d in docs]
+    assert nums == [1, 2], f"docs 'num' fields should be 1 and 2, got {nums}"
+
+    b2b_doc = docs[0]
+    assert b2b_doc["from"] == "INV-2026-27-068"
+    assert b2b_doc["to"] == "INV-2026-27-068"
+    assert b2b_doc["totnum"] == 1
+    assert b2b_doc["net_issue"] == 1
+
+    b2c_doc = docs[1]
+    assert b2c_doc["from"] == "INV-2026-27-069"
+    assert b2c_doc["to"] == "INV-2026-27-069"
+    assert b2c_doc["totnum"] == 1
+    assert b2c_doc["net_issue"] == 1
+
+    # The single merged range INV-068 → INV-069 must NOT appear
+    merged = [d for d in docs if d["from"] == "INV-2026-27-068" and d["to"] == "INV-2026-27-069"]
+    assert not merged, "B2B and B2C ranges must not be merged into a single doc entry"
+
+
 def test_gstr1_hsn_section_splits_b2b_with_rate(db_session):
     """HSN summary must expose hsn_b2b rows with hsn_sc first and a rate."""
     user, ledger = _seed_basics(db_session)


### PR DESCRIPTION
## Problem

The GST portal was rejecting GSTR-1 JSON exports with a document count/range mismatch error.

Root cause: `_doc_range` was merging **all sales invoices** (B2B + B2C) into a single continuous range in `doc_issue` (Table 13). B2C invoices only appear aggregated in `b2cs` — they have no individual record in the payload. So when the portal saw a range like `INV-052 → INV-069`, it could not resolve `INV-069` individually and threw a mismatch rejection.

**Real-world example that triggered this:** INV-2026-27-052 to INV-2026-27-068 were B2B, INV-2026-27-069 was B2C. The exported JSON declared a single range 052→069 (totnum=18) but only 17 invoices were individually traceable.

## Fix

`doc_num=1` (Tax Invoices for outward supply) now produces **two separate `docs` entries** under the same `doc_det` node:

- Entry `num=1` — B2B invoices (ledger has GSTIN)
- Entry `num=2` — B2C invoices (no GSTIN)

Each entry carries its own `from` / `to` / `totnum` / `net_issue`. The `_doc_range` helper gains a `num` parameter to support this.

## Test

New test `test_gstr1_doc_issue_splits_b2b_and_b2c_ranges` in `test_tax_ledger.py`:
- Seeds one B2B invoice (`INV-2026-27-068`) and one B2C invoice (`INV-2026-27-069`)
- Asserts the export produces exactly **two separate `docs` entries** with correct ranges
- Asserts the merged single-range form does **not** appear

## Files changed

- `backend/src/api/routes/ledgers.py` — fix `_doc_range` + invoice range splitting
- `backend/tests/api/test_tax_ledger.py` — new regression test