### PR TITLE
feat(dashboard): server-side metrics endpoint and charts

### DIFF
--- a/backend/app_main.py
+++ b/backend/app_main.py
@@ -7,7 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy import text
 
 from src.api.routes import auth, users, products, inventory, invoices, ledgers, company, payments, smtp, email as email_routes, shortcuts, invoice_series as invoice_series_routes, financial_years as financial_years_routes
-from src.api.routes import auth, users, products, inventory, invoices, ledgers, company, payments, smtp, email as email_routes, shortcuts, invoice_series as invoice_series_routes, financial_years as financial_years_routes, credit_notes as credit_notes_routes, backups as backups_routes, company_accounts as company_accounts_routes, bom as bom_routes, email_logs as email_logs_routes, api_keys as api_keys_routes
+from src.api.routes import auth, users, products, inventory, invoices, ledgers, company, payments, smtp, email as email_routes, shortcuts, invoice_series as invoice_series_routes, financial_years as financial_years_routes, credit_notes as credit_notes_routes, backups as backups_routes, company_accounts as company_accounts_routes, bom as bom_routes, email_logs as email_logs_routes, api_keys as api_keys_routes, dashboard as dashboard_routes
 from src.db.base import Base
 from src.db.session import engine
 # Import all models to register them with declarative_base
@@ -106,6 +106,7 @@ app.include_router(credit_notes_routes.router, prefix="/api/credit-notes", tags=
 app.include_router(backups_routes.router, prefix="/api/backups", tags=["backups"])
 app.include_router(email_logs_routes.router, prefix="/api/email-logs", tags=["email-logs"])
 app.include_router(api_keys_routes.router, prefix="/api/api-keys", tags=["api-keys"])
+app.include_router(dashboard_routes.router, prefix="/api/dashboard", tags=["dashboard"])
 
 @app.get("/api/health")
 def health():

--- a/backend/src/api/routes/dashboard.py
+++ b/backend/src/api/routes/dashboard.py
@@ -1,0 +1,293 @@
+from datetime import date
+from decimal import Decimal
+
+from fastapi import APIRouter, Depends
+from sqlalchemy import and_, case, func
+from sqlalchemy.orm import Session
+
+from src.api.deps import get_active_company, get_current_user
+from src.db.session import get_db
+from src.models.company import CompanyProfile
+from src.models.inventory import Inventory
+from src.models.invoice import Invoice, InvoiceItem
+from src.models.payment import Payment
+from src.models.product import Product
+from src.models.user import User
+from src.schemas.dashboard import (
+    CatalogMetrics,
+    DashboardCharts,
+    DashboardMetrics,
+    InventoryMetrics,
+    MonthlyPoint,
+    PaymentsMetrics,
+    ReceivablesMetrics,
+    SalesMetrics,
+    TopProduct,
+)
+from src.services.invoice_payments import build_invoice_payment_summaries
+
+router = APIRouter()
+
+MONTHS_IN_TREND = 12
+_MONTH_LABELS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
+
+
+def _month_window(today: date) -> list[tuple[int, int]]:
+    """Return (year, month) tuples for the trailing MONTHS_IN_TREND months, oldest first."""
+    months: list[tuple[int, int]] = []
+    year, month = today.year, today.month
+    for _ in range(MONTHS_IN_TREND):
+        months.append((year, month))
+        month -= 1
+        if month == 0:
+            month = 12
+            year -= 1
+    return list(reversed(months))
+
+
+@router.get("/metrics", response_model=DashboardMetrics)
+def get_dashboard_metrics(
+    db: Session = Depends(get_db),
+    _: User = Depends(get_current_user),
+    active_company: CompanyProfile = Depends(get_active_company),
+):
+    company_id = active_company.id
+    today = date.today()
+    month_start = today.replace(day=1)
+
+    # --- Catalog ---------------------------------------------------------
+    catalog_row = (
+        db.query(
+            func.count(Product.id),
+            func.coalesce(func.sum(case((Product.is_producable.is_(True), 1), else_=0)), 0),
+        )
+        .filter(Product.company_id == company_id)
+        .one()
+    )
+    catalog = CatalogMetrics(
+        total_products=int(catalog_row[0] or 0),
+        producible_products=int(catalog_row[1] or 0),
+    )
+
+    # --- Inventory -------------------------------------------------------
+    # Iterate maintained products with their (possibly missing) stock rows so the
+    # low/out-of-stock rules can compare each quantity against its own reorder level.
+    inv_rows = (
+        db.query(
+            func.coalesce(Inventory.quantity, 0),
+            Product.reorder_level,
+            Product.purchase_price,
+        )
+        .outerjoin(
+            Inventory,
+            and_(Inventory.product_id == Product.id, Inventory.company_id == company_id),
+        )
+        .filter(Product.company_id == company_id, Product.maintain_inventory.is_(True))
+        .all()
+    )
+    total_units = Decimal("0")
+    stock_value = Decimal("0")
+    low_stock_count = 0
+    out_of_stock_count = 0
+    for quantity, reorder_level, purchase_price in inv_rows:
+        qty = Decimal(str(quantity or 0))
+        reorder = Decimal(str(reorder_level or 0))
+        cost = Decimal(str(purchase_price or 0))
+        total_units += qty
+        stock_value += qty * cost
+        if qty <= 0:
+            out_of_stock_count += 1
+        elif reorder > 0 and qty <= reorder:
+            low_stock_count += 1
+    inventory = InventoryMetrics(
+        tracked_products=len(inv_rows),
+        total_units=float(total_units),
+        low_stock_count=low_stock_count,
+        out_of_stock_count=out_of_stock_count,
+        stock_value=float(stock_value),
+    )
+
+    # --- Sales / Purchases (active invoices only) ------------------------
+    sales_case = (Invoice.voucher_type == "sales", Invoice.total_amount)
+    purchase_case = (Invoice.voucher_type == "purchase", Invoice.total_amount)
+    sales_row = (
+        db.query(
+            func.coalesce(func.sum(case((Invoice.voucher_type == "sales", 1), else_=0)), 0),
+            func.coalesce(func.sum(case((Invoice.voucher_type == "purchase", 1), else_=0)), 0),
+            func.coalesce(func.sum(case(sales_case, else_=0)), 0),
+            func.coalesce(func.sum(case(purchase_case, else_=0)), 0),
+            func.coalesce(
+                func.sum(
+                    case(
+                        ((Invoice.voucher_type == "sales") & (Invoice.invoice_date >= month_start), Invoice.total_amount),
+                        else_=0,
+                    )
+                ),
+                0,
+            ),
+        )
+        .filter(Invoice.company_id == company_id, Invoice.status == "active")
+        .one()
+    )
+    sales_count = int(sales_row[0] or 0)
+    total_sales = Decimal(str(sales_row[2] or 0))
+    sales = SalesMetrics(
+        sales_invoice_count=sales_count,
+        purchase_invoice_count=int(sales_row[1] or 0),
+        total_sales=float(total_sales),
+        total_purchases=float(Decimal(str(sales_row[3] or 0))),
+        this_month_sales=float(Decimal(str(sales_row[4] or 0))),
+        average_invoice_value=float(total_sales / sales_count) if sales_count else 0.0,
+    )
+
+    # --- Receivables (reuses the canonical outstanding calculation) ------
+    active_sales = (
+        db.query(Invoice)
+        .filter(
+            Invoice.company_id == company_id,
+            Invoice.voucher_type == "sales",
+            Invoice.status == "active",
+        )
+        .all()
+    )
+    summaries = build_invoice_payment_summaries(db, active_sales)
+    outstanding_amount = Decimal("0")
+    overdue_amount = Decimal("0")
+    overdue_count = 0
+    paid_count = partial_count = unpaid_count = 0
+    for invoice in active_sales:
+        summary = summaries[invoice.id]
+        remaining = Decimal(str(summary.remaining_amount or 0))
+        outstanding_amount += remaining
+        if summary.payment_status == "paid":
+            paid_count += 1
+        elif summary.payment_status == "partial":
+            partial_count += 1
+        else:
+            unpaid_count += 1
+        if remaining > 0 and invoice.due_date is not None and invoice.due_date.date() < today:
+            overdue_amount += remaining
+            overdue_count += 1
+    receivables = ReceivablesMetrics(
+        outstanding_amount=float(outstanding_amount),
+        overdue_amount=float(overdue_amount),
+        overdue_count=overdue_count,
+        paid_count=paid_count,
+        partial_count=partial_count,
+        unpaid_count=unpaid_count,
+    )
+
+    # --- Payments --------------------------------------------------------
+    payment_row = (
+        db.query(
+            func.coalesce(func.sum(case((Payment.voucher_type == "receipt", Payment.amount), else_=0)), 0),
+            func.coalesce(func.sum(case((Payment.voucher_type == "payment", Payment.amount), else_=0)), 0),
+            func.coalesce(
+                func.sum(
+                    case(
+                        ((Payment.voucher_type == "receipt") & (Payment.date >= month_start), Payment.amount),
+                        else_=0,
+                    )
+                ),
+                0,
+            ),
+        )
+        .filter(Payment.company_id == company_id, Payment.status == "active")
+        .one()
+    )
+    payments = PaymentsMetrics(
+        received_total=float(Decimal(str(payment_row[0] or 0))),
+        paid_total=float(Decimal(str(payment_row[1] or 0))),
+        this_month_received=float(Decimal(str(payment_row[2] or 0))),
+    )
+
+    # --- Monthly trend (DB-agnostic bucketing in Python) -----------------
+    months = _month_window(today)
+    window_start = date(months[0][0], months[0][1], 1)
+    buckets: dict[tuple[int, int], dict[str, Decimal]] = {
+        m: {"sales": Decimal("0"), "purchases": Decimal("0"), "receipts": Decimal("0")} for m in months
+    }
+
+    invoice_rows = (
+        db.query(Invoice.invoice_date, Invoice.voucher_type, Invoice.total_amount)
+        .filter(
+            Invoice.company_id == company_id,
+            Invoice.status == "active",
+            Invoice.invoice_date >= window_start,
+        )
+        .all()
+    )
+    for inv_date, voucher_type, amount in invoice_rows:
+        key = (inv_date.year, inv_date.month)
+        if key not in buckets:
+            continue
+        if voucher_type == "sales":
+            buckets[key]["sales"] += Decimal(str(amount or 0))
+        elif voucher_type == "purchase":
+            buckets[key]["purchases"] += Decimal(str(amount or 0))
+
+    receipt_rows = (
+        db.query(Payment.date, Payment.amount)
+        .filter(
+            Payment.company_id == company_id,
+            Payment.status == "active",
+            Payment.voucher_type == "receipt",
+            Payment.date >= window_start,
+        )
+        .all()
+    )
+    for pay_date, amount in receipt_rows:
+        key = (pay_date.year, pay_date.month)
+        if key in buckets:
+            buckets[key]["receipts"] += Decimal(str(amount or 0))
+
+    monthly = [
+        MonthlyPoint(
+            month=f"{year:04d}-{month:02d}",
+            label=f"{_MONTH_LABELS[month - 1]} {year % 100:02d}",
+            sales=float(buckets[(year, month)]["sales"]),
+            purchases=float(buckets[(year, month)]["purchases"]),
+            receipts=float(buckets[(year, month)]["receipts"]),
+        )
+        for year, month in months
+    ]
+
+    # --- Top products by revenue (active sales) --------------------------
+    top_rows = (
+        db.query(
+            Product.id,
+            Product.name,
+            func.coalesce(func.sum(InvoiceItem.quantity), 0),
+            func.coalesce(func.sum(InvoiceItem.line_total), 0),
+        )
+        .join(Invoice, InvoiceItem.invoice_id == Invoice.id)
+        .join(Product, Product.id == InvoiceItem.product_id)
+        .filter(
+            Invoice.company_id == company_id,
+            Invoice.status == "active",
+            Invoice.voucher_type == "sales",
+        )
+        .group_by(Product.id, Product.name)
+        .order_by(func.coalesce(func.sum(InvoiceItem.line_total), 0).desc())
+        .limit(5)
+        .all()
+    )
+    top_products = [
+        TopProduct(
+            product_id=product_id,
+            name=name,
+            quantity=float(Decimal(str(quantity or 0))),
+            revenue=float(Decimal(str(revenue or 0))),
+        )
+        for product_id, name, quantity, revenue in top_rows
+    ]
+
+    return DashboardMetrics(
+        currency_code=active_company.currency_code or "USD",
+        catalog=catalog,
+        inventory=inventory,
+        sales=sales,
+        receivables=receivables,
+        payments=payments,
+        charts=DashboardCharts(monthly=monthly, top_products=top_products),
+    )

--- a/backend/src/schemas/dashboard.py
+++ b/backend/src/schemas/dashboard.py
@@ -1,0 +1,68 @@
+from pydantic import BaseModel
+
+
+class CatalogMetrics(BaseModel):
+    total_products: int
+    producible_products: int
+
+
+class InventoryMetrics(BaseModel):
+    tracked_products: int
+    total_units: float
+    low_stock_count: int
+    out_of_stock_count: int
+    stock_value: float
+
+
+class SalesMetrics(BaseModel):
+    sales_invoice_count: int
+    purchase_invoice_count: int
+    total_sales: float
+    total_purchases: float
+    this_month_sales: float
+    average_invoice_value: float
+
+
+class ReceivablesMetrics(BaseModel):
+    outstanding_amount: float
+    overdue_amount: float
+    overdue_count: int
+    paid_count: int
+    partial_count: int
+    unpaid_count: int
+
+
+class PaymentsMetrics(BaseModel):
+    received_total: float
+    paid_total: float
+    this_month_received: float
+
+
+class MonthlyPoint(BaseModel):
+    month: str  # ISO year-month, e.g. "2026-01"
+    label: str  # short display label, e.g. "Jan 26"
+    sales: float
+    purchases: float
+    receipts: float
+
+
+class TopProduct(BaseModel):
+    product_id: int
+    name: str
+    quantity: float
+    revenue: float
+
+
+class DashboardCharts(BaseModel):
+    monthly: list[MonthlyPoint]
+    top_products: list[TopProduct]
+
+
+class DashboardMetrics(BaseModel):
+    currency_code: str
+    catalog: CatalogMetrics
+    inventory: InventoryMetrics
+    sales: SalesMetrics
+    receivables: ReceivablesMetrics
+    payments: PaymentsMetrics
+    charts: DashboardCharts

--- a/backend/tests/api/test_dashboard_metrics.py
+++ b/backend/tests/api/test_dashboard_metrics.py
@@ -1,0 +1,70 @@
+from datetime import datetime, timedelta
+
+
+def _create_product(client, sku, name, price, **extra):
+    payload = {"sku": sku, "name": name, "price": price, "gst_rate": 18}
+    payload.update(extra)
+    response = client.post("/api/products/", json=payload)
+    assert response.status_code == 200, response.text
+    return response.json()["id"]
+
+
+def _create_ledger(client, name):
+    response = client.post(
+        "/api/ledgers/",
+        json={"name": name, "address": "1 Market St", "phone_number": "1234567890"},
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["id"]
+
+
+def test_dashboard_metrics_aggregates_across_all_invoices(client):
+    # Two products, one with a reorder level so we can exercise low-stock logic.
+    low_product = _create_product(client, "DASH-LOW", "Low Stock Widget", 100, reorder_level=10)
+    ok_product = _create_product(client, "DASH-OK", "Healthy Widget", 50, reorder_level=0)
+
+    # Drive stock below the reorder level on the first product.
+    assert client.post("/api/inventory/adjust", json={"product_id": low_product, "quantity": 5}).status_code == 200
+    assert client.post("/api/inventory/adjust", json={"product_id": ok_product, "quantity": 80}).status_code == 200
+
+    # Create a sales invoice with two line items.
+    ledger_id = _create_ledger(client, "Acme Buyer")
+    invoice_payload = {
+        "voucher_type": "sales",
+        "ledger_id": ledger_id,
+        "items": [
+            {"product_id": low_product, "quantity": 2, "unit_price": 100, "gst_rate": 18},
+            {"product_id": ok_product, "quantity": 4, "unit_price": 50, "gst_rate": 18},
+        ],
+    }
+    inv_res = client.post("/api/invoices/", json=invoice_payload)
+    assert inv_res.status_code == 200, inv_res.text
+
+    res = client.get("/api/dashboard/metrics")
+    assert res.status_code == 200, res.text
+    data = res.json()
+
+    assert data["catalog"]["total_products"] == 2
+    assert data["inventory"]["tracked_products"] == 2
+    assert data["inventory"]["low_stock_count"] == 1  # only the reorder-level product
+    assert data["sales"]["sales_invoice_count"] == 1
+    assert data["sales"]["total_sales"] > 0
+    assert data["receivables"]["unpaid_count"] == 1
+    assert data["receivables"]["outstanding_amount"] > 0
+
+    # Charts always span the trailing 12 months and surface the sold products.
+    assert len(data["charts"]["monthly"]) == 12
+    assert any(point["sales"] > 0 for point in data["charts"]["monthly"])
+    top_names = {p["name"] for p in data["charts"]["top_products"]}
+    assert "Low Stock Widget" in top_names
+
+
+def test_dashboard_metrics_empty_company(client):
+    res = client.get("/api/dashboard/metrics")
+    assert res.status_code == 200, res.text
+    data = res.json()
+    assert data["catalog"]["total_products"] == 0
+    assert data["sales"]["total_sales"] == 0
+    assert data["receivables"]["outstanding_amount"] == 0
+    assert len(data["charts"]["monthly"]) == 12
+    assert data["charts"]["top_products"] == []

--- a/frontend/e2e/dashboard.spec.ts
+++ b/frontend/e2e/dashboard.spec.ts
@@ -4,11 +4,11 @@ test.describe('Dashboard', () => {
   test('displays stats cards after login', async ({ authedPage: page }) => {
     await expect(page.locator('h1')).toContainText('Operations dashboard');
 
-    // Four stat cards should be visible
+    // Key metric cards should be visible
+    await expect(page.locator('.eyebrow', { hasText: 'Net sales' })).toBeVisible();
+    await expect(page.locator('.eyebrow', { hasText: 'Outstanding' })).toBeVisible();
     await expect(page.locator('.eyebrow', { hasText: 'Catalog' })).toBeVisible();
-    await expect(page.locator('.eyebrow', { hasText: 'Stock units' })).toBeVisible();
     await expect(page.locator('.eyebrow', { hasText: 'Low stock' })).toBeVisible();
-    await expect(page.locator('.eyebrow', { hasText: 'Invoice value' })).toBeVisible();
   });
 
   test('shows "Backend synced" chip', async ({ authedPage: page }) => {

--- a/frontend/src/components/DashboardCharts.tsx
+++ b/frontend/src/components/DashboardCharts.tsx
@@ -1,0 +1,206 @@
+import type { DashboardMonthlyPoint, DashboardTopProduct } from '../types/api';
+import formatCurrency, { formatCompactCurrency } from '../utils/formatting';
+
+type MonthlyTrendChartProps = {
+  data: DashboardMonthlyPoint[];
+  currencyCode: string;
+};
+
+/**
+ * Grouped bar chart of sales vs. purchases per month with a receipts overlay line.
+ * Hand-rolled SVG so the dashboard stays dependency-free.
+ */
+export function MonthlyTrendChart({ data, currencyCode }: MonthlyTrendChartProps) {
+  const width = 720;
+  const height = 240;
+  const padding = { top: 16, right: 16, bottom: 28, left: 16 };
+  const plotWidth = width - padding.left - padding.right;
+  const plotHeight = height - padding.top - padding.bottom;
+
+  const maxValue = Math.max(
+    1,
+    ...data.map((point) => Math.max(point.sales, point.purchases, point.receipts)),
+  );
+
+  const groupWidth = plotWidth / data.length;
+  const barGap = 4;
+  const barWidth = Math.max(4, (groupWidth - barGap * 3) / 2);
+  const yFor = (value: number) => padding.top + plotHeight - (value / maxValue) * plotHeight;
+
+  const linePoints = data
+    .map((point, index) => {
+      const x = padding.left + groupWidth * index + groupWidth / 2;
+      return `${x},${yFor(point.receipts)}`;
+    })
+    .join(' ');
+
+  const hasData = data.some((point) => point.sales || point.purchases || point.receipts);
+
+  return (
+    <div className="chart">
+      <div className="chart__legend">
+        <span className="chart__legend-item"><i className="chart__swatch chart__swatch--sales" /> Sales</span>
+        <span className="chart__legend-item"><i className="chart__swatch chart__swatch--purchases" /> Purchases</span>
+        <span className="chart__legend-item"><i className="chart__swatch chart__swatch--receipts" /> Receipts</span>
+      </div>
+      {!hasData ? (
+        <p className="muted-text chart__empty">No invoice or payment activity in the last 12 months.</p>
+      ) : (
+        <svg viewBox={`0 0 ${width} ${height}`} className="chart__svg" role="img" aria-label="Monthly sales, purchases and receipts">
+          {[0.25, 0.5, 0.75, 1].map((fraction) => (
+            <line
+              key={fraction}
+              x1={padding.left}
+              x2={width - padding.right}
+              y1={padding.top + plotHeight * (1 - fraction)}
+              y2={padding.top + plotHeight * (1 - fraction)}
+              className="chart__gridline"
+            />
+          ))}
+          {data.map((point, index) => {
+            const groupX = padding.left + groupWidth * index;
+            const salesX = groupX + barGap;
+            const purchasesX = salesX + barWidth + barGap;
+            return (
+              <g key={point.month}>
+                <rect
+                  x={salesX}
+                  y={yFor(point.sales)}
+                  width={barWidth}
+                  height={padding.top + plotHeight - yFor(point.sales)}
+                  rx={3}
+                  className="chart__bar chart__bar--sales"
+                >
+                  <title>{`${point.label} · Sales ${formatCurrency(point.sales, currencyCode)}`}</title>
+                </rect>
+                <rect
+                  x={purchasesX}
+                  y={yFor(point.purchases)}
+                  width={barWidth}
+                  height={padding.top + plotHeight - yFor(point.purchases)}
+                  rx={3}
+                  className="chart__bar chart__bar--purchases"
+                >
+                  <title>{`${point.label} · Purchases ${formatCurrency(point.purchases, currencyCode)}`}</title>
+                </rect>
+                <text x={groupX + groupWidth / 2} y={height - 8} textAnchor="middle" className="chart__xlabel">
+                  {point.label}
+                </text>
+              </g>
+            );
+          })}
+          <polyline points={linePoints} className="chart__line" fill="none" />
+          {data.map((point, index) => {
+            const x = padding.left + groupWidth * index + groupWidth / 2;
+            return (
+              <circle key={`dot-${point.month}`} cx={x} cy={yFor(point.receipts)} r={3} className="chart__dot">
+                <title>{`${point.label} · Receipts ${formatCurrency(point.receipts, currencyCode)}`}</title>
+              </circle>
+            );
+          })}
+        </svg>
+      )}
+    </div>
+  );
+}
+
+type PaymentStatusDonutProps = {
+  paid: number;
+  partial: number;
+  unpaid: number;
+};
+
+const DONUT_SEGMENTS = [
+  { key: 'paid', label: 'Paid', className: 'donut__legend-swatch--paid' },
+  { key: 'partial', label: 'Partial', className: 'donut__legend-swatch--partial' },
+  { key: 'unpaid', label: 'Unpaid', className: 'donut__legend-swatch--unpaid' },
+] as const;
+
+export function PaymentStatusDonut({ paid, partial, unpaid }: PaymentStatusDonutProps) {
+  const counts = { paid, partial, unpaid };
+  const total = paid + partial + unpaid;
+  const radius = 52;
+  const stroke = 18;
+  const circumference = 2 * Math.PI * radius;
+
+  let offset = 0;
+  const arcs = DONUT_SEGMENTS.map((segment) => {
+    const value = counts[segment.key];
+    const fraction = total > 0 ? value / total : 0;
+    const dash = fraction * circumference;
+    const arc = {
+      key: segment.key,
+      dashArray: `${dash} ${circumference - dash}`,
+      dashOffset: -offset,
+      className: `donut__arc donut__arc--${segment.key}`,
+    };
+    offset += dash;
+    return arc;
+  });
+
+  return (
+    <div className="donut">
+      <svg viewBox="0 0 140 140" className="donut__svg" role="img" aria-label="Invoice payment status breakdown">
+        <circle cx="70" cy="70" r={radius} className="donut__track" strokeWidth={stroke} fill="none" />
+        {total > 0
+          ? arcs.map((arc) => (
+              <circle
+                key={arc.key}
+                cx="70"
+                cy="70"
+                r={radius}
+                className={arc.className}
+                strokeWidth={stroke}
+                fill="none"
+                strokeDasharray={arc.dashArray}
+                strokeDashoffset={arc.dashOffset}
+                transform="rotate(-90 70 70)"
+                strokeLinecap="butt"
+              />
+            ))
+          : null}
+        <text x="70" y="66" textAnchor="middle" className="donut__total">{total}</text>
+        <text x="70" y="84" textAnchor="middle" className="donut__caption">invoices</text>
+      </svg>
+      <ul className="donut__legend">
+        {DONUT_SEGMENTS.map((segment) => (
+          <li key={segment.key} className="donut__legend-item">
+            <span className={`donut__legend-swatch ${segment.className}`} />
+            <span>{segment.label}</span>
+            <strong>{counts[segment.key]}</strong>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+type TopProductsBarsProps = {
+  data: DashboardTopProduct[];
+  currencyCode: string;
+};
+
+export function TopProductsBars({ data, currencyCode }: TopProductsBarsProps) {
+  if (data.length === 0) {
+    return <p className="muted-text">No sales recorded yet.</p>;
+  }
+  const maxRevenue = Math.max(1, ...data.map((product) => product.revenue));
+  return (
+    <ul className="top-products">
+      {data.map((product) => (
+        <li key={product.product_id} className="top-products__row">
+          <div className="top-products__meta">
+            <span className="top-products__name">{product.name}</span>
+            <span className="top-products__value">{formatCompactCurrency(product.revenue, currencyCode)}</span>
+          </div>
+          <div className="top-products__track">
+            <div
+              className="top-products__fill"
+              style={{ width: `${Math.max(4, (product.revenue / maxRevenue) * 100)}%` }}
+            />
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -3,14 +3,9 @@ import { Link } from 'react-router-dom';
 import api, { getApiErrorMessage } from '../api/client';
 import StatusToasts from '../components/StatusToasts';
 import EmptyState from '../components/EmptyState';
-import type { CompanyProfile, InventoryRow, Invoice, PaginatedInventoryOut, Product } from '../types/api';
-import formatCurrency from '../utils/formatting';
-
-type DashboardState = {
-  products: Product[];
-  inventory: InventoryRow[];
-  invoices: Invoice[];
-};
+import { MonthlyTrendChart, PaymentStatusDonut, TopProductsBars } from '../components/DashboardCharts';
+import type { DashboardMetrics, InventoryRow, Invoice, PaginatedInventoryOut } from '../types/api';
+import formatCurrency, { formatCompactCurrency } from '../utils/formatting';
 
 function normalizeInventoryRows(payload: PaginatedInventoryOut | InventoryRow[] | unknown): InventoryRow[] {
   if (Array.isArray(payload)) {
@@ -23,13 +18,15 @@ function normalizeInventoryRows(payload: PaginatedInventoryOut | InventoryRow[] 
   return [];
 }
 
+const LOW_STOCK_THRESHOLD = 5;
+
 export default function DashboardPage() {
-  const [state, setState] = useState<DashboardState>({ products: [], inventory: [], invoices: [] });
-  const [company, setCompany] = useState<CompanyProfile | null>(null);
+  const [metrics, setMetrics] = useState<DashboardMetrics | null>(null);
+  const [lowStock, setLowStock] = useState<InventoryRow[]>([]);
+  const [recentInvoices, setRecentInvoices] = useState<Invoice[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
-  const activeCurrencyCode = company?.currency_code || 'USD';
-  const LOW_STOCK_THRESHOLD = 5;
+  const currencyCode = metrics?.currency_code || 'USD';
 
   useEffect(() => {
     let active = true;
@@ -38,23 +35,21 @@ export default function DashboardPage() {
       try {
         setLoading(true);
         setError('');
-        const [productsRes, inventoryRes, invoicesRes, companyRes] = await Promise.all([
-          api.get<{ items: Product[] }>('/products/', { params: { page_size: 100 } }),
-          api.get<PaginatedInventoryOut>('/inventory/', { params: { page_size: 100 } }),
-          api.get<{ items: Invoice[] }>('/invoices/', { params: { page_size: 100 } }),
-          api.get<CompanyProfile>('/company/'),
+        const [metricsRes, inventoryRes, invoicesRes] = await Promise.all([
+          api.get<DashboardMetrics>('/dashboard/metrics'),
+          api.get<PaginatedInventoryOut>('/inventory/', {
+            params: { sort_by: 'quantity', sort_order: 'asc', page_size: 5 },
+          }),
+          api.get<{ items: Invoice[] }>('/invoices/', { params: { page_size: 6 } }),
         ]);
 
         if (!active) {
           return;
         }
 
-        setState({
-          products: productsRes.data.items,
-          inventory: normalizeInventoryRows(inventoryRes.data),
-          invoices: invoicesRes.data.items,
-        });
-        setCompany(companyRes.data);
+        setMetrics(metricsRes.data);
+        setLowStock(normalizeInventoryRows(inventoryRes.data));
+        setRecentInvoices(invoicesRes.data.items);
       } catch (err) {
         if (active) {
           setError(getApiErrorMessage(err, 'Unable to load dashboard data'));
@@ -73,9 +68,74 @@ export default function DashboardPage() {
     };
   }, []);
 
-  const totalInventoryUnits = state.inventory.reduce((sum, row) => sum + row.quantity, 0);
-  const lowStockCount = state.inventory.filter((row) => row.quantity <= LOW_STOCK_THRESHOLD).length;
-  const invoiceRevenue = state.invoices.reduce((sum, invoice) => sum + invoice.total_amount, 0);
+  const skeleton = (width: string) => (
+    <span className="skeleton" style={{ width, height: '38px', display: 'inline-block' }} />
+  );
+
+  const money = (value: number) => ({
+    value: formatCompactCurrency(value, currencyCode),
+    title: formatCurrency(value, currencyCode),
+  });
+
+  const statCards: Array<{
+    eyebrow: string;
+    value: string | null;
+    title?: string;
+    width: string;
+    copy: string;
+    tone?: 'danger' | 'warning';
+  }> = [
+    {
+      eyebrow: 'Net sales',
+      ...(metrics ? money(metrics.sales.total_sales) : { value: null }),
+      width: '120px',
+      copy: `${metrics?.sales.sales_invoice_count ?? 0} active sales invoices.`,
+    },
+    {
+      eyebrow: 'Outstanding',
+      ...(metrics ? money(metrics.receivables.outstanding_amount) : { value: null }),
+      width: '120px',
+      copy: `${(metrics?.receivables.unpaid_count ?? 0) + (metrics?.receivables.partial_count ?? 0)} invoices awaiting payment.`,
+    },
+    {
+      eyebrow: 'Overdue',
+      ...(metrics ? money(metrics.receivables.overdue_amount) : { value: null }),
+      width: '110px',
+      copy: `${metrics?.receivables.overdue_count ?? 0} invoices past their due date.`,
+      tone: (metrics?.receivables.overdue_amount ?? 0) > 0 ? 'danger' : undefined,
+    },
+    {
+      eyebrow: 'This month',
+      ...(metrics ? money(metrics.sales.this_month_sales) : { value: null }),
+      width: '120px',
+      copy: `${formatCompactCurrency(metrics?.payments.this_month_received ?? 0, currencyCode)} received this month.`,
+    },
+    {
+      eyebrow: 'Catalog',
+      value: metrics ? String(metrics.catalog.total_products) : null,
+      width: '60px',
+      copy: 'Products available for quoting and invoicing.',
+    },
+    {
+      eyebrow: 'Stock value',
+      ...(metrics ? money(metrics.inventory.stock_value) : { value: null }),
+      width: '120px',
+      copy: `${metrics?.inventory.total_units ?? 0} units across ${metrics?.inventory.tracked_products ?? 0} tracked products.`,
+    },
+    {
+      eyebrow: 'Low stock',
+      value: metrics ? String(metrics.inventory.low_stock_count) : null,
+      width: '50px',
+      copy: `${metrics?.inventory.out_of_stock_count ?? 0} products are out of stock.`,
+      tone: (metrics?.inventory.low_stock_count ?? 0) > 0 ? 'warning' : undefined,
+    },
+    {
+      eyebrow: 'Avg invoice',
+      ...(metrics ? money(metrics.sales.average_invoice_value) : { value: null }),
+      width: '110px',
+      copy: `${formatCompactCurrency(metrics?.payments.received_total ?? 0, currencyCode)} received all-time.`,
+    },
+  ];
 
   return (
     <div className="page-grid">
@@ -83,33 +143,60 @@ export default function DashboardPage() {
         <div>
           <p className="eyebrow">Overview</p>
           <h1 className="page-title">Operations dashboard</h1>
-          <p className="section-copy">A live snapshot of catalog size, stock position, and invoice throughput.</p>
+          <p className="section-copy">A live snapshot of revenue, receivables, and stock position.</p>
         </div>
         <div className="status-chip">Backend synced</div>
       </section>
 
       <StatusToasts error={error} onClearError={() => setError('')} onClearSuccess={() => {}} />
 
-      <section className="stats-grid">
-        <article className="stat-card">
-          <p className="eyebrow">Catalog</p>
-          <p className="stat-card__value">{loading ? <span className="skeleton" style={{ width: '60px', height: '38px', display: 'inline-block' }} /> : state.products.length}</p>
-          <p className="muted-text">Products available for quoting and invoicing.</p>
+      <section className="stats-grid stats-grid--dense">
+        {statCards.map((card) => (
+          <article key={card.eyebrow} className="stat-card">
+            <p className="eyebrow">{card.eyebrow}</p>
+            <p
+              className={`stat-card__value${card.tone ? ` stat-card__value--${card.tone}` : ''}`}
+              title={!loading && metrics ? card.title : undefined}
+            >
+              {loading || !metrics ? skeleton(card.width) : card.value}
+            </p>
+            <p className="muted-text">{card.copy}</p>
+          </article>
+        ))}
+      </section>
+
+      <section className="content-grid">
+        <article className="panel stack">
+          <div className="panel__header">
+            <div>
+              <p className="eyebrow">Trend</p>
+              <h2 className="nav-panel__title">Sales, purchases & receipts</h2>
+            </div>
+            <div className="status-chip">Last 12 months</div>
+          </div>
+          {loading || !metrics ? (
+            <div className="skeleton" role="status" aria-label="Loading chart" style={{ height: '240px', borderRadius: '18px' }} />
+          ) : (
+            <MonthlyTrendChart data={metrics.charts.monthly} currencyCode={currencyCode} />
+          )}
         </article>
-        <article className="stat-card">
-          <p className="eyebrow">Stock units</p>
-          <p className="stat-card__value">{loading ? <span className="skeleton" style={{ width: '80px', height: '38px', display: 'inline-block' }} /> : totalInventoryUnits}</p>
-          <p className="muted-text">Total quantity currently registered across inventory rows.</p>
-        </article>
-        <article className="stat-card">
-          <p className="eyebrow">Low stock</p>
-          <p className="stat-card__value">{loading ? <span className="skeleton" style={{ width: '40px', height: '38px', display: 'inline-block' }} /> : lowStockCount}</p>
-          <p className="muted-text">Rows at 5 units or less that likely need replenishment.</p>
-        </article>
-        <article className="stat-card">
-          <p className="eyebrow">Invoice value</p>
-          <p className="stat-card__value">{loading ? <span className="skeleton" style={{ width: '120px', height: '38px', display: 'inline-block' }} /> : formatCurrency(invoiceRevenue, activeCurrencyCode)}</p>
-          <p className="muted-text">Combined gross amount from currently listed invoices.</p>
+
+        <article className="panel stack">
+          <div className="panel__header">
+            <div>
+              <p className="eyebrow">Receivables</p>
+              <h2 className="nav-panel__title">Payment status</h2>
+            </div>
+          </div>
+          {loading || !metrics ? (
+            <div className="skeleton" role="status" aria-label="Loading chart" style={{ height: '200px', borderRadius: '18px' }} />
+          ) : (
+            <PaymentStatusDonut
+              paid={metrics.receivables.paid_count}
+              partial={metrics.receivables.partial_count}
+              unpaid={metrics.receivables.unpaid_count}
+            />
+          )}
         </article>
       </section>
 
@@ -120,7 +207,7 @@ export default function DashboardPage() {
               <p className="eyebrow">Stock watch</p>
               <h2 className="nav-panel__title">Inventory pressure points</h2>
             </div>
-            <div className="status-chip">{state.inventory.length} tracked rows</div>
+            {metrics ? <div className="status-chip">{metrics.inventory.tracked_products} tracked</div> : null}
           </div>
 
           <div className="table-list">
@@ -131,27 +218,23 @@ export default function DashboardPage() {
                 <div className="table-row skeleton" role="status" aria-label="Loading" style={{ height: '76px', borderColor: 'transparent' }}></div>
               </>
             ) : null}
-            {!loading && state.inventory.length === 0 ? (
-              <EmptyState 
-                message="No inventory rows yet. Add products to track their stock." 
+            {!loading && lowStock.length === 0 ? (
+              <EmptyState
+                message="No inventory rows yet. Add products to track their stock."
                 action={<Link to="/products" className="button button--secondary button--small">Go to Products</Link>}
               />
             ) : null}
             {!loading
-              ? state.inventory
-                  .slice()
-                  .sort((a, b) => a.quantity - b.quantity)
-                  .slice(0, 5)
-                  .map((row) => (
-                    <div key={row.product_id} className="table-row">
-                      <div className="table-row__meta">
-                        <strong>{row.product_name}</strong>
-                        <span className="table-subtext">Product ID #{row.product_id}</span>
-                      </div>
-                      <span className={`pill ${row.quantity <= LOW_STOCK_THRESHOLD ? 'pill--low' : 'pill--ok'}`}>{row.quantity} units</span>
-                      <span className="table-subtext text-right">{row.quantity <= LOW_STOCK_THRESHOLD ? 'Needs attention' : 'Stable'}</span>
+              ? lowStock.map((row) => (
+                  <div key={row.product_id} className="table-row">
+                    <div className="table-row__meta">
+                      <strong>{row.product_name}</strong>
+                      <span className="table-subtext">Product ID #{row.product_id}</span>
                     </div>
-                  ))
+                    <span className={`pill ${row.quantity <= LOW_STOCK_THRESHOLD ? 'pill--low' : 'pill--ok'}`}>{row.quantity} units</span>
+                    <span className="table-subtext text-right">{row.quantity <= LOW_STOCK_THRESHOLD ? 'Needs attention' : 'Stable'}</span>
+                  </div>
+                ))
               : null}
           </div>
         </article>
@@ -159,9 +242,26 @@ export default function DashboardPage() {
         <article className="panel stack">
           <div className="panel__header">
             <div>
+              <p className="eyebrow">Best sellers</p>
+              <h2 className="nav-panel__title">Top products by revenue</h2>
+            </div>
+          </div>
+          {loading || !metrics ? (
+            <div className="skeleton" role="status" aria-label="Loading" style={{ height: '160px', borderRadius: '18px' }} />
+          ) : (
+            <TopProductsBars data={metrics.charts.top_products} currencyCode={currencyCode} />
+          )}
+        </article>
+      </section>
+
+      <section className="content-grid content-grid--single">
+        <article className="panel stack">
+          <div className="panel__header">
+            <div>
               <p className="eyebrow">Recent invoices</p>
               <h2 className="nav-panel__title">Latest activity</h2>
             </div>
+            <Link to="/invoices" className="button button--secondary button--small">View all</Link>
           </div>
 
           <div className="invoice-list">
@@ -172,20 +272,20 @@ export default function DashboardPage() {
                 <div className="invoice-row skeleton" role="status" aria-label="Loading" style={{ height: '88px', borderColor: 'transparent' }}></div>
               </>
             ) : null}
-            {!loading && state.invoices.length === 0 ? (
-              <EmptyState 
-                message="No invoices yet. Create your first invoice to get started." 
+            {!loading && recentInvoices.length === 0 ? (
+              <EmptyState
+                message="No invoices yet. Create your first invoice to get started."
                 action={<Link to="/invoices" className="button button--primary button--small">Create Invoice</Link>}
               />
             ) : null}
             {!loading
-              ? state.invoices.slice(0, 6).map((invoice) => (
+              ? recentInvoices.map((invoice) => (
                   <div key={invoice.id} className="invoice-row">
                     <div className="invoice-row__meta">
                       <strong>{invoice.ledger?.name || invoice.ledger_name || 'Unknown ledger'}</strong>
                       <span className="table-subtext">Invoice #{invoice.id}</span>
                     </div>
-                    <span className="invoice-row__price">{formatCurrency(invoice.total_amount, activeCurrencyCode)}</span>
+                    <span className="invoice-row__price">{formatCurrency(invoice.total_amount, currencyCode)}</span>
                   </div>
                 ))
               : null}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -2258,3 +2258,226 @@ textarea {
     justify-content: flex-start;
   }
 }
+
+/* ============================================================
+   Dashboard metrics, charts & visualizations
+   ============================================================ */
+
+.stats-grid--dense {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.stat-card__value--danger {
+  color: var(--danger);
+}
+
+.stat-card__value--warning {
+  color: var(--warning);
+}
+
+/* Monthly trend chart -------------------------------------- */
+.chart {
+  display: grid;
+  gap: 14px;
+}
+
+.chart__legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  font-size: 0.82rem;
+  color: var(--muted);
+}
+
+.chart__legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.chart__swatch {
+  width: 12px;
+  height: 12px;
+  border-radius: 4px;
+  display: inline-block;
+}
+
+.chart__swatch--sales {
+  background: var(--accent);
+}
+
+.chart__swatch--purchases {
+  background: #6f8bd8;
+}
+
+.chart__swatch--receipts {
+  background: var(--warning);
+}
+
+.chart__svg {
+  width: 100%;
+  height: auto;
+  overflow: visible;
+}
+
+.chart__empty {
+  padding: 40px 0;
+  text-align: center;
+}
+
+.chart__gridline {
+  stroke: var(--line);
+  stroke-width: 1;
+}
+
+.chart__bar--sales {
+  fill: var(--accent);
+}
+
+.chart__bar--purchases {
+  fill: #6f8bd8;
+}
+
+.chart__line {
+  stroke: var(--warning);
+  stroke-width: 2;
+}
+
+.chart__dot {
+  fill: var(--warning);
+}
+
+.chart__xlabel {
+  fill: var(--muted);
+  font-size: 10px;
+}
+
+/* Payment status donut ------------------------------------- */
+.donut {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+
+.donut__svg {
+  width: 150px;
+  height: 150px;
+  flex-shrink: 0;
+}
+
+.donut__track {
+  stroke: var(--line);
+}
+
+.donut__arc--paid {
+  stroke: var(--accent);
+}
+
+.donut__arc--partial {
+  stroke: var(--warning);
+}
+
+.donut__arc--unpaid {
+  stroke: var(--danger);
+}
+
+.donut__total {
+  fill: var(--text);
+  font-size: 26px;
+  font-weight: 800;
+  letter-spacing: -0.04em;
+}
+
+.donut__caption {
+  fill: var(--muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.donut__legend {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 12px;
+  min-width: 140px;
+}
+
+.donut__legend-item {
+  display: grid;
+  grid-template-columns: 14px 1fr auto;
+  align-items: center;
+  gap: 10px;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.donut__legend-item strong {
+  color: var(--text);
+}
+
+.donut__legend-swatch {
+  width: 12px;
+  height: 12px;
+  border-radius: 4px;
+}
+
+.donut__legend-swatch--paid {
+  background: var(--accent);
+}
+
+.donut__legend-swatch--partial {
+  background: var(--warning);
+}
+
+.donut__legend-swatch--unpaid {
+  background: var(--danger);
+}
+
+/* Top products ---------------------------------------------- */
+.top-products {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 16px;
+}
+
+.top-products__meta {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 7px;
+  font-size: 0.92rem;
+}
+
+.top-products__name {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.top-products__value {
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+.top-products__track {
+  height: 8px;
+  border-radius: 999px;
+  background: var(--line);
+  overflow: hidden;
+}
+
+.top-products__fill {
+  height: 100%;
+  border-radius: 999px;
+  background: linear-gradient(90deg, var(--accent-deep), var(--accent));
+}
+
+@media (max-width: 1100px) {
+  .stats-grid--dense {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -845,3 +845,58 @@ export type ApiKeyCreate = {
   name: string;
   expires_at: string;
 };
+
+export type DashboardMonthlyPoint = {
+  month: string;
+  label: string;
+  sales: number;
+  purchases: number;
+  receipts: number;
+};
+
+export type DashboardTopProduct = {
+  product_id: number;
+  name: string;
+  quantity: number;
+  revenue: number;
+};
+
+export type DashboardMetrics = {
+  currency_code: string;
+  catalog: {
+    total_products: number;
+    producible_products: number;
+  };
+  inventory: {
+    tracked_products: number;
+    total_units: number;
+    low_stock_count: number;
+    out_of_stock_count: number;
+    stock_value: number;
+  };
+  sales: {
+    sales_invoice_count: number;
+    purchase_invoice_count: number;
+    total_sales: number;
+    total_purchases: number;
+    this_month_sales: number;
+    average_invoice_value: number;
+  };
+  receivables: {
+    outstanding_amount: number;
+    overdue_amount: number;
+    overdue_count: number;
+    paid_count: number;
+    partial_count: number;
+    unpaid_count: number;
+  };
+  payments: {
+    received_total: number;
+    paid_total: number;
+    this_month_received: number;
+  };
+  charts: {
+    monthly: DashboardMonthlyPoint[];
+    top_products: DashboardTopProduct[];
+  };
+};

--- a/frontend/src/utils/formatting.ts
+++ b/frontend/src/utils/formatting.ts
@@ -1,7 +1,10 @@
+function localeFor(currencyCode: string) {
+    return currencyCode === 'INR' ? 'en-IN' : 'en-US';
+}
+
 export default function formatCurrency(value: number, currencyCode = 'USD') {
-    const locale = currencyCode === 'INR' ? 'en-IN' : 'en-US';
     try {
-        return new Intl.NumberFormat(locale, {
+        return new Intl.NumberFormat(localeFor(currencyCode), {
             style: 'currency',
             currency: currencyCode,
             maximumFractionDigits: 2,
@@ -12,5 +15,26 @@ export default function formatCurrency(value: number, currencyCode = 'USD') {
             currency: 'USD',
             maximumFractionDigits: 2,
         }).format(value);
+    }
+}
+
+/**
+ * Compact currency for tight spaces (e.g. dashboard KPI cards) so large
+ * figures don't overflow. INR renders lakh/crore (₹1.2Cr), others use M/K.
+ * Values under 1,000 fall back to the full format to stay precise.
+ */
+export function formatCompactCurrency(value: number, currencyCode = 'USD') {
+    if (Math.abs(value) < 1000) {
+        return formatCurrency(value, currencyCode);
+    }
+    try {
+        return new Intl.NumberFormat(localeFor(currencyCode), {
+            style: 'currency',
+            currency: currencyCode,
+            notation: 'compact',
+            maximumFractionDigits: 1,
+        }).format(value);
+    } catch {
+        return formatCurrency(value, currencyCode);
     }
 }


### PR DESCRIPTION
## Summary
Replaces the dashboard's client-side aggregation — which fetched only the first 100 products/inventory/invoices and computed totals from that slice (so totals were silently wrong for any real dataset) — with a dedicated `GET /api/dashboard/metrics` endpoint that aggregates across the **full** dataset.

## Backend
- New dashboard route + schema returning catalog, inventory (incl. stock valuation and per-product `reorder_level` low-stock), sales/purchases, receivables (outstanding/overdue, reusing `build_invoice_payment_summaries`), payments, a 12-month sales/purchases/receipts trend, and top products by revenue.
- Month bucketing done in Python so it works on both Postgres and the SQLite test DB.
- Tests covering aggregation across all invoices and the empty-company case.

## Frontend
- Dashboard now consumes `/dashboard/metrics`; the low-stock and recent-invoice panels fetch small, server-sorted pages instead of slicing 100.
- Dependency-free SVG charts (monthly trend, payment-status donut, top products) plus expanded KPI cards.
- Compact currency formatting on KPI cards so large INR figures (lakh/crore) don't overflow, with the exact value in a hover tooltip.

## Testing
- New backend tests pass (`test_dashboard_metrics.py`).
- `tsc --noEmit` and eslint clean; e2e card-label assertions updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)