### PR TITLE
feat: analytics section with month-wise & product-wise sales (#391)

### DIFF
--- a/backend/app_main.py
+++ b/backend/app_main.py
@@ -7,7 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy import text
 
 from src.api.routes import auth, users, products, inventory, invoices, ledgers, company, payments, smtp, email as email_routes, shortcuts, invoice_series as invoice_series_routes, financial_years as financial_years_routes
-from src.api.routes import auth, users, products, inventory, invoices, ledgers, company, payments, smtp, email as email_routes, shortcuts, invoice_series as invoice_series_routes, financial_years as financial_years_routes, credit_notes as credit_notes_routes, backups as backups_routes, company_accounts as company_accounts_routes, bom as bom_routes, email_logs as email_logs_routes, api_keys as api_keys_routes, dashboard as dashboard_routes
+from src.api.routes import auth, users, products, inventory, invoices, ledgers, company, payments, smtp, email as email_routes, shortcuts, invoice_series as invoice_series_routes, financial_years as financial_years_routes, credit_notes as credit_notes_routes, backups as backups_routes, company_accounts as company_accounts_routes, bom as bom_routes, email_logs as email_logs_routes, api_keys as api_keys_routes, dashboard as dashboard_routes, analytics as analytics_routes
 from src.db.base import Base
 from src.db.session import engine
 # Import all models to register them with declarative_base
@@ -107,6 +107,7 @@ app.include_router(backups_routes.router, prefix="/api/backups", tags=["backups"
 app.include_router(email_logs_routes.router, prefix="/api/email-logs", tags=["email-logs"])
 app.include_router(api_keys_routes.router, prefix="/api/api-keys", tags=["api-keys"])
 app.include_router(dashboard_routes.router, prefix="/api/dashboard", tags=["dashboard"])
+app.include_router(analytics_routes.router, prefix="/api/analytics", tags=["analytics"])
 
 @app.get("/api/health")
 def health():

--- a/backend/src/api/routes/analytics.py
+++ b/backend/src/api/routes/analytics.py
@@ -1,0 +1,400 @@
+import csv
+from datetime import date, timedelta
+from io import BytesIO, StringIO
+from typing import Literal
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import StreamingResponse
+from sqlalchemy.orm import Session
+
+from src.api.deps import get_active_company, get_current_user
+from src.db.session import get_db
+from src.models.company import CompanyProfile
+from src.models.financial_year import FinancialYear
+from src.models.user import User
+from src.schemas.analytics import (
+    MonthlySalesReport,
+    MonthlySalesRow,
+    MonthlySalesTotals,
+    ProductSalesReport,
+    ProductSalesRow,
+    ProductSalesTotals,
+    ReportPeriod,
+)
+from src.services.analytics_reports import (
+    average_of,
+    build_monthly_sales_report,
+    build_product_sales_report,
+    month_label,
+    month_window,
+)
+from src.services.financial_year import get_active_fy
+
+router = APIRouter()
+
+VoucherType = Literal["sales", "purchase"]
+SortBy = Literal["quantity", "revenue", "name", "stock"]
+SortDir = Literal["asc", "desc"]
+
+
+def _resolve_period(
+    db: Session,
+    *,
+    company_id: int,
+    financial_year_id: int | None,
+    from_date: date | None,
+    to_date: date | None,
+) -> ReportPeriod:
+    """Work out which window the report covers.
+
+    Precedence: explicit dates, then the requested financial year, then the
+    active financial year, then a trailing 12 months. The last fallback is
+    deliberate — unlike the day book (which 400s without an FY), an analytics
+    page must still render for a company that hasn't set one up yet.
+    """
+    if from_date is not None and to_date is not None:
+        if from_date > to_date:
+            raise HTTPException(status_code=400, detail="from_date must be before or equal to to_date")
+        return ReportPeriod(from_date=from_date, to_date=to_date)
+
+    fy: FinancialYear | None = None
+    if financial_year_id is not None:
+        fy = (
+            db.query(FinancialYear)
+            .filter(FinancialYear.id == financial_year_id, FinancialYear.company_id == company_id)
+            .first()
+        )
+        if fy is None:
+            raise HTTPException(status_code=404, detail="Financial year not found")
+    else:
+        fy = get_active_fy(db, company_id=company_id)
+
+    if fy is not None:
+        resolved_from = from_date or fy.start_date
+        resolved_to = to_date or fy.end_date
+        if resolved_from > resolved_to:
+            raise HTTPException(status_code=400, detail="from_date must be before or equal to to_date")
+        return ReportPeriod(
+            from_date=resolved_from,
+            to_date=resolved_to,
+            financial_year_id=fy.id,
+            fy_label=fy.label,
+        )
+
+    # No dates and no financial year — fall back to a trailing 12 months.
+    window = month_window(date.today())
+    fallback_from = date(window[0][0], window[0][1], 1)
+    fallback_to = date.today()
+    resolved_from = from_date or fallback_from
+    resolved_to = to_date or fallback_to
+    if resolved_from > resolved_to:
+        raise HTTPException(status_code=400, detail="from_date must be before or equal to to_date")
+    return ReportPeriod(from_date=resolved_from, to_date=resolved_to)
+
+
+def _monthly_report(
+    db: Session,
+    *,
+    active_company: CompanyProfile,
+    voucher_type: str,
+    period: ReportPeriod,
+    ledger_id: int | None,
+) -> MonthlySalesReport:
+    data = build_monthly_sales_report(
+        db,
+        company_id=active_company.id,
+        voucher_type=voucher_type,
+        from_date=period.from_date,
+        to_date=period.to_date,
+        ledger_id=ledger_id,
+    )
+
+    rows = [
+        MonthlySalesRow(
+            month=f"{year:04d}-{month:02d}",
+            label=month_label(year, month),
+            invoice_count=bucket.invoice_count,
+            total_sales=float(bucket.total_sales),
+            taxable_value=float(bucket.taxable_value),
+            gst_collected=float(bucket.gst_collected),
+            discount_given=float(bucket.discount_given),
+            average_invoice_value=float(average_of(bucket.total_sales, bucket.invoice_count)),
+        )
+        for year, month, bucket in data.rows
+    ]
+
+    totals = MonthlySalesTotals(
+        invoice_count=data.totals.invoice_count,
+        total_sales=float(data.totals.total_sales),
+        taxable_value=float(data.totals.taxable_value),
+        gst_collected=float(data.totals.gst_collected),
+        discount_given=float(data.totals.discount_given),
+        average_invoice_value=float(average_of(data.totals.total_sales, data.totals.invoice_count)),
+    )
+
+    return MonthlySalesReport(
+        currency_code=active_company.currency_code or "USD",
+        voucher_type=voucher_type,
+        period=period,
+        rows=rows,
+        totals=totals,
+    )
+
+
+def _product_report(
+    db: Session,
+    *,
+    active_company: CompanyProfile,
+    voucher_type: str,
+    period: ReportPeriod,
+    ledger_id: int | None,
+    product_id: int | None,
+    sort_by: str,
+    sort_dir: str,
+    limit: int | None,
+) -> ProductSalesReport:
+    data = build_product_sales_report(
+        db,
+        company_id=active_company.id,
+        voucher_type=voucher_type,
+        from_date=period.from_date,
+        to_date=period.to_date,
+        ledger_id=ledger_id,
+        product_id=product_id,
+        sort_by=sort_by,
+        sort_dir=sort_dir,
+        limit=limit,
+    )
+
+    rows = [
+        ProductSalesRow(
+            product_id=row["product_id"],
+            name=row["name"],
+            sku=row["sku"],
+            quantity_sold=float(row["quantity_sold"]),
+            sales_amount=float(row["sales_amount"]),
+            average_selling_price=float(row["average_selling_price"]),
+            total_revenue=float(row["total_revenue"]),
+            total_gst=float(row["total_gst"]),
+            invoice_count=row["invoice_count"],
+            current_stock=float(row["current_stock"]) if row["current_stock"] is not None else None,
+        )
+        for row in data.rows
+    ]
+
+    totals = ProductSalesTotals(
+        product_count=data.totals["product_count"],
+        quantity_sold=float(data.totals["quantity_sold"]),
+        sales_amount=float(data.totals["sales_amount"]),
+        total_revenue=float(data.totals["total_revenue"]),
+        total_gst=float(data.totals["total_gst"]),
+        invoice_count=data.totals["invoice_count"],
+    )
+
+    return ProductSalesReport(
+        currency_code=active_company.currency_code or "USD",
+        voucher_type=voucher_type,
+        period=period,
+        sort_by=sort_by,
+        sort_dir=sort_dir,
+        rows=rows,
+        totals=totals,
+    )
+
+
+def _csv_response(buffer: StringIO, filename: str) -> StreamingResponse:
+    # utf-8-sig: the BOM is what makes Excel read the currency symbols correctly.
+    csv_bytes = buffer.getvalue().encode("utf-8-sig")
+    return StreamingResponse(
+        BytesIO(csv_bytes),
+        media_type="text/csv; charset=utf-8",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
+@router.get("/sales-by-month", response_model=MonthlySalesReport)
+def get_sales_by_month(
+    voucher_type: VoucherType = Query("sales"),
+    financial_year_id: int | None = Query(None),
+    from_date: date | None = Query(None),
+    to_date: date | None = Query(None),
+    ledger_id: int | None = Query(None),
+    db: Session = Depends(get_db),
+    _: User = Depends(get_current_user),
+    active_company: CompanyProfile = Depends(get_active_company),
+):
+    period = _resolve_period(
+        db,
+        company_id=active_company.id,
+        financial_year_id=financial_year_id,
+        from_date=from_date,
+        to_date=to_date,
+    )
+    return _monthly_report(
+        db,
+        active_company=active_company,
+        voucher_type=voucher_type,
+        period=period,
+        ledger_id=ledger_id,
+    )
+
+
+@router.get("/sales-by-month/csv")
+def download_sales_by_month_csv(
+    voucher_type: VoucherType = Query("sales"),
+    financial_year_id: int | None = Query(None),
+    from_date: date | None = Query(None),
+    to_date: date | None = Query(None),
+    ledger_id: int | None = Query(None),
+    db: Session = Depends(get_db),
+    _: User = Depends(get_current_user),
+    active_company: CompanyProfile = Depends(get_active_company),
+):
+    period = _resolve_period(
+        db,
+        company_id=active_company.id,
+        financial_year_id=financial_year_id,
+        from_date=from_date,
+        to_date=to_date,
+    )
+    report = _monthly_report(
+        db,
+        active_company=active_company,
+        voucher_type=voucher_type,
+        period=period,
+        ledger_id=ledger_id,
+    )
+
+    buffer = StringIO(newline="")
+    writer = csv.writer(buffer)
+    writer.writerow([
+        "Month", "Invoices", "Total Sales", "Taxable Value",
+        "GST Collected", "Discount Given", "Average Invoice Value",
+    ])
+    for row in report.rows:
+        writer.writerow([
+            row.label,
+            row.invoice_count,
+            f"{row.total_sales:.2f}",
+            f"{row.taxable_value:.2f}",
+            f"{row.gst_collected:.2f}",
+            f"{row.discount_given:.2f}",
+            f"{row.average_invoice_value:.2f}",
+        ])
+    writer.writerow([])
+    writer.writerow([
+        "Totals",
+        report.totals.invoice_count,
+        f"{report.totals.total_sales:.2f}",
+        f"{report.totals.taxable_value:.2f}",
+        f"{report.totals.gst_collected:.2f}",
+        f"{report.totals.discount_given:.2f}",
+        f"{report.totals.average_invoice_value:.2f}",
+    ])
+
+    filename = f"sales_by_month_{period.from_date}_{period.to_date}.csv"
+    return _csv_response(buffer, filename)
+
+
+@router.get("/sales-by-product", response_model=ProductSalesReport)
+def get_sales_by_product(
+    voucher_type: VoucherType = Query("sales"),
+    financial_year_id: int | None = Query(None),
+    from_date: date | None = Query(None),
+    to_date: date | None = Query(None),
+    ledger_id: int | None = Query(None),
+    product_id: int | None = Query(None),
+    sort_by: SortBy = Query("revenue"),
+    sort_dir: SortDir = Query("desc"),
+    limit: int | None = Query(None, ge=1, le=1000),
+    db: Session = Depends(get_db),
+    _: User = Depends(get_current_user),
+    active_company: CompanyProfile = Depends(get_active_company),
+):
+    period = _resolve_period(
+        db,
+        company_id=active_company.id,
+        financial_year_id=financial_year_id,
+        from_date=from_date,
+        to_date=to_date,
+    )
+    return _product_report(
+        db,
+        active_company=active_company,
+        voucher_type=voucher_type,
+        period=period,
+        ledger_id=ledger_id,
+        product_id=product_id,
+        sort_by=sort_by,
+        sort_dir=sort_dir,
+        limit=limit,
+    )
+
+
+@router.get("/sales-by-product/csv")
+def download_sales_by_product_csv(
+    voucher_type: VoucherType = Query("sales"),
+    financial_year_id: int | None = Query(None),
+    from_date: date | None = Query(None),
+    to_date: date | None = Query(None),
+    ledger_id: int | None = Query(None),
+    product_id: int | None = Query(None),
+    sort_by: SortBy = Query("revenue"),
+    sort_dir: SortDir = Query("desc"),
+    limit: int | None = Query(None, ge=1, le=1000),
+    db: Session = Depends(get_db),
+    _: User = Depends(get_current_user),
+    active_company: CompanyProfile = Depends(get_active_company),
+):
+    period = _resolve_period(
+        db,
+        company_id=active_company.id,
+        financial_year_id=financial_year_id,
+        from_date=from_date,
+        to_date=to_date,
+    )
+    report = _product_report(
+        db,
+        active_company=active_company,
+        voucher_type=voucher_type,
+        period=period,
+        ledger_id=ledger_id,
+        product_id=product_id,
+        sort_by=sort_by,
+        sort_dir=sort_dir,
+        limit=limit,
+    )
+
+    buffer = StringIO(newline="")
+    writer = csv.writer(buffer)
+    writer.writerow([
+        "Product", "Item Code", "Quantity Sold", "Sales Amount", "Average Selling Price",
+        "Total Revenue", "Total GST", "Invoices", "Current Stock",
+    ])
+    for row in report.rows:
+        writer.writerow([
+            row.name,
+            row.sku or "",
+            f"{row.quantity_sold:g}",
+            f"{row.sales_amount:.2f}",
+            f"{row.average_selling_price:.2f}",
+            f"{row.total_revenue:.2f}",
+            f"{row.total_gst:.2f}",
+            row.invoice_count,
+            f"{row.current_stock:g}" if row.current_stock is not None else "",
+        ])
+    writer.writerow([])
+    writer.writerow([
+        "Totals",
+        "",
+        f"{report.totals.quantity_sold:g}",
+        f"{report.totals.sales_amount:.2f}",
+        "",
+        f"{report.totals.total_revenue:.2f}",
+        f"{report.totals.total_gst:.2f}",
+        report.totals.invoice_count,
+        "",
+    ])
+
+    filename = f"sales_by_product_{period.from_date}_{period.to_date}.csv"
+    return _csv_response(buffer, filename)

--- a/backend/src/api/routes/dashboard.py
+++ b/backend/src/api/routes/dashboard.py
@@ -24,25 +24,10 @@ from src.schemas.dashboard import (
     SalesMetrics,
     TopProduct,
 )
+from src.services.analytics_reports import month_label, month_window
 from src.services.invoice_payments import build_invoice_payment_summaries
 
 router = APIRouter()
-
-MONTHS_IN_TREND = 12
-_MONTH_LABELS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
-
-
-def _month_window(today: date) -> list[tuple[int, int]]:
-    """Return (year, month) tuples for the trailing MONTHS_IN_TREND months, oldest first."""
-    months: list[tuple[int, int]] = []
-    year, month = today.year, today.month
-    for _ in range(MONTHS_IN_TREND):
-        months.append((year, month))
-        month -= 1
-        if month == 0:
-            month = 12
-            year -= 1
-    return list(reversed(months))
 
 
 @router.get("/metrics", response_model=DashboardMetrics)
@@ -202,7 +187,7 @@ def get_dashboard_metrics(
     )
 
     # --- Monthly trend (DB-agnostic bucketing in Python) -----------------
-    months = _month_window(today)
+    months = month_window(today)
     window_start = date(months[0][0], months[0][1], 1)
     buckets: dict[tuple[int, int], dict[str, Decimal]] = {
         m: {"sales": Decimal("0"), "purchases": Decimal("0"), "receipts": Decimal("0")} for m in months
@@ -244,7 +229,7 @@ def get_dashboard_metrics(
     monthly = [
         MonthlyPoint(
             month=f"{year:04d}-{month:02d}",
-            label=f"{_MONTH_LABELS[month - 1]} {year % 100:02d}",
+            label=month_label(year, month),
             sales=float(buckets[(year, month)]["sales"]),
             purchases=float(buckets[(year, month)]["purchases"]),
             receipts=float(buckets[(year, month)]["receipts"]),

--- a/backend/src/schemas/analytics.py
+++ b/backend/src/schemas/analytics.py
@@ -1,0 +1,76 @@
+from datetime import date
+
+from pydantic import BaseModel
+
+
+class ReportPeriod(BaseModel):
+    """The date window a report actually covers, after server-side resolution.
+
+    Echoed back because the client may send no dates at all and let the server
+    fall back to the active financial year — the UI needs to show what it got.
+    """
+
+    from_date: date
+    to_date: date
+    financial_year_id: int | None = None
+    fy_label: str | None = None
+
+
+class MonthlySalesRow(BaseModel):
+    month: str  # "2026-04"
+    label: str  # "Apr 26"
+    invoice_count: int
+    total_sales: float  # sum of invoice total_amount, incl. GST and round-off
+    taxable_value: float  # sum of invoice taxable_amount, ex-GST
+    gst_collected: float  # sum of invoice total_tax_amount
+    discount_given: float  # derived — see src.services.invoice_discounts
+    average_invoice_value: float
+
+
+class MonthlySalesTotals(BaseModel):
+    invoice_count: int
+    total_sales: float
+    taxable_value: float
+    gst_collected: float
+    discount_given: float
+    average_invoice_value: float
+
+
+class MonthlySalesReport(BaseModel):
+    currency_code: str
+    voucher_type: str
+    period: ReportPeriod
+    rows: list[MonthlySalesRow]
+    totals: MonthlySalesTotals
+
+
+class ProductSalesRow(BaseModel):
+    product_id: int
+    name: str
+    sku: str | None = None
+    quantity_sold: float
+    sales_amount: float  # sum of line taxable_amount, ex-GST
+    average_selling_price: float  # sales_amount / quantity_sold
+    total_revenue: float  # sum of line_total, incl. GST
+    total_gst: float  # sum of line tax_amount
+    invoice_count: int  # distinct invoices, not line items
+    current_stock: float | None = None  # None when the product isn't stock-tracked
+
+
+class ProductSalesTotals(BaseModel):
+    product_count: int
+    quantity_sold: float
+    sales_amount: float
+    total_revenue: float
+    total_gst: float
+    invoice_count: int  # distinct invoices across all rows
+
+
+class ProductSalesReport(BaseModel):
+    currency_code: str
+    voucher_type: str
+    period: ReportPeriod
+    sort_by: str
+    sort_dir: str
+    rows: list[ProductSalesRow]
+    totals: ProductSalesTotals

--- a/backend/src/services/analytics_reports.py
+++ b/backend/src/services/analytics_reports.py
@@ -1,0 +1,335 @@
+"""Sales analytics report builders.
+
+The JSON and CSV routes both call these builders so the two can never disagree
+about a number — the same split :mod:`src.api.routes.ledgers` uses for the day
+book.
+
+Month bucketing happens in Python rather than via ``date_trunc``: the test suite
+runs on SQLite while production runs on Postgres, and the dashboard already set
+this precedent.
+"""
+
+from dataclasses import dataclass
+from datetime import date, datetime, time
+from decimal import Decimal
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from src.models.inventory import Inventory
+from src.models.invoice import Invoice, InvoiceItem
+from src.models.product import Product
+from src.services.gst_tax_service import money as _money
+from src.services.invoice_discounts import build_invoice_discount_totals
+
+MONTHS_IN_TREND = 12
+_MONTH_LABELS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
+
+
+def month_window(today: date, months: int = MONTHS_IN_TREND) -> list[tuple[int, int]]:
+    """Return (year, month) tuples for the trailing ``months`` months, oldest first."""
+    window: list[tuple[int, int]] = []
+    year, month = today.year, today.month
+    for _ in range(months):
+        window.append((year, month))
+        month -= 1
+        if month == 0:
+            month = 12
+            year -= 1
+    return list(reversed(window))
+
+
+def month_label(year: int, month: int) -> str:
+    """Format a month as "Apr 26". Shared with the dashboard so labels match."""
+    return f"{_MONTH_LABELS[month - 1]} {year % 100:02d}"
+
+
+def months_between(from_date: date, to_date: date) -> list[tuple[int, int]]:
+    """Every (year, month) touched by the range, inclusive, oldest first."""
+    window: list[tuple[int, int]] = []
+    year, month = from_date.year, from_date.month
+    while (year, month) <= (to_date.year, to_date.month):
+        window.append((year, month))
+        month += 1
+        if month == 13:
+            month = 1
+            year += 1
+    return window
+
+
+@dataclass
+class MonthlyBucket:
+    invoice_count: int = 0
+    total_sales: Decimal = Decimal("0")
+    taxable_value: Decimal = Decimal("0")
+    gst_collected: Decimal = Decimal("0")
+    discount_given: Decimal = Decimal("0")
+
+
+@dataclass
+class MonthlySalesData:
+    rows: list[tuple[int, int, MonthlyBucket]]
+    totals: MonthlyBucket
+
+
+@dataclass
+class ProductSalesData:
+    rows: list[dict]
+    totals: dict
+
+
+def _date_bounds(from_date: date, to_date: date) -> tuple[datetime, datetime]:
+    """Convert a date range to datetime bounds covering the whole end day.
+
+    ``Invoice.invoice_date`` is a DateTime; comparing it against a bare date
+    silently drops invoices dated on ``to_date`` that carry a time component.
+    """
+    return datetime.combine(from_date, time.min), datetime.combine(to_date, time.max)
+
+
+def _scoped_invoice_query(
+    db: Session,
+    *,
+    company_id: int,
+    voucher_type: str,
+    from_date: date,
+    to_date: date,
+    ledger_id: int | None = None,
+):
+    start, end = _date_bounds(from_date, to_date)
+    # Strict company_id equality (not the NULL-tolerant form used by
+    # invoice_payments for legacy rows): on a reporting surface a NULL-company
+    # invoice would leak into every company's revenue. Legacy rows were
+    # populated by migration 20260424000002_backfill_company_scope_data.
+    query = db.query(Invoice).filter(
+        Invoice.company_id == company_id,
+        Invoice.status == "active",
+        Invoice.voucher_type == voucher_type,
+        Invoice.invoice_date >= start,
+        Invoice.invoice_date <= end,
+    )
+    if ledger_id is not None:
+        query = query.filter(Invoice.ledger_id == ledger_id)
+    return query
+
+
+def build_monthly_sales_report(
+    db: Session,
+    *,
+    company_id: int,
+    voucher_type: str,
+    from_date: date,
+    to_date: date,
+    ledger_id: int | None = None,
+) -> MonthlySalesData:
+    """Aggregate invoices into one row per calendar month in the range.
+
+    Every month in the range is emitted, including empty ones — a chart with
+    gaps silently omitted would misrepresent a quiet month as no month.
+    """
+    invoices = _scoped_invoice_query(
+        db,
+        company_id=company_id,
+        voucher_type=voucher_type,
+        from_date=from_date,
+        to_date=to_date,
+        ledger_id=ledger_id,
+    ).all()
+
+    discounts = build_invoice_discount_totals(db, invoices)
+
+    buckets: dict[tuple[int, int], MonthlyBucket] = {
+        key: MonthlyBucket() for key in months_between(from_date, to_date)
+    }
+
+    for invoice in invoices:
+        key = (invoice.invoice_date.year, invoice.invoice_date.month)
+        bucket = buckets.get(key)
+        if bucket is None:
+            # Defensive: the query is already bounded to the range.
+            continue
+        bucket.invoice_count += 1
+        bucket.total_sales += Decimal(str(invoice.total_amount or 0))
+        bucket.taxable_value += Decimal(str(invoice.taxable_amount or 0))
+        bucket.gst_collected += Decimal(str(invoice.total_tax_amount or 0))
+        bucket.discount_given += discounts[invoice.id].total_discount
+
+    totals = MonthlyBucket()
+    for bucket in buckets.values():
+        totals.invoice_count += bucket.invoice_count
+        totals.total_sales += bucket.total_sales
+        totals.taxable_value += bucket.taxable_value
+        totals.gst_collected += bucket.gst_collected
+        totals.discount_given += bucket.discount_given
+
+    rows = [(year, month, buckets[(year, month)]) for year, month in months_between(from_date, to_date)]
+    return MonthlySalesData(rows=rows, totals=totals)
+
+
+def average_of(total: Decimal, count) -> Decimal:
+    """Mean guarded against a zero denominator (empty months, zero-qty lines)."""
+    if not count:
+        return Decimal("0.00")
+    return _money(total / Decimal(str(count)))
+
+
+def build_product_sales_report(
+    db: Session,
+    *,
+    company_id: int,
+    voucher_type: str,
+    from_date: date,
+    to_date: date,
+    ledger_id: int | None = None,
+    product_id: int | None = None,
+    sort_by: str = "revenue",
+    sort_dir: str = "desc",
+    limit: int | None = None,
+) -> ProductSalesData:
+    """Aggregate invoice lines into one row per product."""
+    start, end = _date_bounds(from_date, to_date)
+
+    query = (
+        db.query(
+            Product.id,
+            Product.name,
+            Product.sku,
+            Product.maintain_inventory,
+            func.coalesce(func.sum(InvoiceItem.quantity), 0),
+            func.coalesce(func.sum(InvoiceItem.taxable_amount), 0),
+            func.coalesce(func.sum(InvoiceItem.tax_amount), 0),
+            func.coalesce(func.sum(InvoiceItem.line_total), 0),
+            # Distinct: a product appearing on two lines of one invoice must
+            # count that invoice once.
+            func.count(func.distinct(InvoiceItem.invoice_id)),
+        )
+        .join(Invoice, InvoiceItem.invoice_id == Invoice.id)
+        .join(Product, Product.id == InvoiceItem.product_id)
+        .filter(
+            # InvoiceItem carries no company_id — scope comes via the Invoice join.
+            Invoice.company_id == company_id,
+            Invoice.status == "active",
+            Invoice.voucher_type == voucher_type,
+            Invoice.invoice_date >= start,
+            Invoice.invoice_date <= end,
+        )
+    )
+    if ledger_id is not None:
+        query = query.filter(Invoice.ledger_id == ledger_id)
+    if product_id is not None:
+        query = query.filter(Product.id == product_id)
+
+    grouped = query.group_by(Product.id, Product.name, Product.sku, Product.maintain_inventory).all()
+
+    # Stock is fetched separately rather than outer-joined: a product with
+    # maintain_inventory=False has no meaningful stock, and a join would report
+    # a misleading 0 instead of "not tracked".
+    stock_map: dict[int, Decimal] = {}
+    if grouped:
+        stock_rows = (
+            db.query(Inventory.product_id, Inventory.quantity)
+            .filter(
+                Inventory.company_id == company_id,
+                Inventory.product_id.in_([row[0] for row in grouped]),
+            )
+            .all()
+        )
+        stock_map = {pid: Decimal(str(qty or 0)) for pid, qty in stock_rows}
+
+    rows: list[dict] = []
+    for pid, name, sku, maintain_inventory, quantity, taxable, tax, revenue, invoice_count in grouped:
+        qty = Decimal(str(quantity or 0))
+        sales_amount = Decimal(str(taxable or 0))
+        rows.append({
+            "product_id": pid,
+            "name": name,
+            "sku": sku,
+            "quantity_sold": qty,
+            "sales_amount": sales_amount,
+            "average_selling_price": average_of(sales_amount, qty),
+            "total_revenue": Decimal(str(revenue or 0)),
+            "total_gst": Decimal(str(tax or 0)),
+            "invoice_count": int(invoice_count or 0),
+            "current_stock": stock_map.get(pid, Decimal("0")) if maintain_inventory else None,
+        })
+
+    _sort_rows(rows, sort_by=sort_by, sort_dir=sort_dir)
+
+    if limit is not None:
+        rows = rows[:limit]
+
+    totals = {
+        "product_count": len(rows),
+        "quantity_sold": sum((row["quantity_sold"] for row in rows), Decimal("0")),
+        "sales_amount": sum((row["sales_amount"] for row in rows), Decimal("0")),
+        "total_revenue": sum((row["total_revenue"] for row in rows), Decimal("0")),
+        "total_gst": sum((row["total_gst"] for row in rows), Decimal("0")),
+        "invoice_count": _distinct_invoice_count(
+            db,
+            company_id=company_id,
+            voucher_type=voucher_type,
+            from_date=from_date,
+            to_date=to_date,
+            ledger_id=ledger_id,
+            product_ids=[row["product_id"] for row in rows],
+        ),
+    }
+
+    return ProductSalesData(rows=rows, totals=totals)
+
+
+def _sort_rows(rows: list[dict], *, sort_by: str, sort_dir: str) -> None:
+    reverse = sort_dir == "desc"
+
+    if sort_by == "stock":
+        # Stock isn't in the grouped query, so this can't be pushed into SQL.
+        # Untracked products (None) sort last in both directions rather than
+        # being treated as zero.
+        tracked = [row for row in rows if row["current_stock"] is not None]
+        untracked = [row for row in rows if row["current_stock"] is None]
+        tracked.sort(key=lambda row: row["current_stock"], reverse=reverse)
+        rows[:] = tracked + untracked
+        return
+
+    keys = {
+        "quantity": lambda row: row["quantity_sold"],
+        "revenue": lambda row: row["total_revenue"],
+        "name": lambda row: (row["name"] or "").lower(),
+    }
+    rows.sort(key=keys[sort_by], reverse=reverse)
+
+
+def _distinct_invoice_count(
+    db: Session,
+    *,
+    company_id: int,
+    voucher_type: str,
+    from_date: date,
+    to_date: date,
+    ledger_id: int | None,
+    product_ids: list[int],
+) -> int:
+    """Count invoices touching the listed products.
+
+    Summing each row's invoice_count would double-count an invoice that carries
+    two different products, so the total needs its own distinct query.
+    """
+    if not product_ids:
+        return 0
+
+    start, end = _date_bounds(from_date, to_date)
+    query = (
+        db.query(func.count(func.distinct(Invoice.id)))
+        .join(InvoiceItem, InvoiceItem.invoice_id == Invoice.id)
+        .filter(
+            Invoice.company_id == company_id,
+            Invoice.status == "active",
+            Invoice.voucher_type == voucher_type,
+            Invoice.invoice_date >= start,
+            Invoice.invoice_date <= end,
+            InvoiceItem.product_id.in_(product_ids),
+        )
+    )
+    if ledger_id is not None:
+        query = query.filter(Invoice.ledger_id == ledger_id)
+    return int(query.scalar() or 0)

--- a/backend/src/services/invoice_discounts.py
+++ b/backend/src/services/invoice_discounts.py
@@ -1,0 +1,152 @@
+"""Discount amount derivation for reporting.
+
+Invoices do not store discount *amounts* — :mod:`src.services.invoice_processor`
+computes them at write time and persists only ``discount_type`` and
+``discount_value``, with ``taxable_amount`` already net of any line discount.
+Reports that need a "Discount Given" figure therefore have to recover it.
+
+This module recovers it by *inverting* the write path's algebra rather than
+re-running its arithmetic.  That matters: re-running would have to reproduce
+both of the processor's clamps (``min(discount, taxable)`` on net line
+discounts, ``min(discount, raw_total)`` on invoice discounts) and would
+accumulate its own rounding.  Subtracting stored values gets both for free and
+is exact.
+
+The derivation is coupled to ``InvoiceProcessor.calculate_totals`` and
+``InvoiceProcessor._apply_totals``.  If the discount write path changes, the
+figures here go silently wrong — see ``tests/services/test_invoice_discounts.py``,
+which round-trips against the processor to catch exactly that.
+"""
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+from sqlalchemy.orm import Session
+
+from src.models.invoice import Invoice, InvoiceItem
+from src.services.gst_tax_service import money as _money
+
+
+@dataclass
+class InvoiceDiscountSummary:
+    """Discount amounts for one invoice, all positive Decimals.
+
+    Amounts stay ``Decimal`` rather than ``float`` (unlike
+    :class:`~src.services.invoice_payments.InvoicePaymentSummary`) because
+    reports sum these across every invoice in a period; float accumulation
+    drifts. Convert at the schema boundary.
+    """
+
+    invoice_id: int
+    item_discount_total: Decimal
+    invoice_discount_amount: Decimal
+    total_discount: Decimal
+
+
+def _dec(value) -> Decimal:
+    """Coerce a DB value to Decimal.
+
+    Numeric columns come back as Decimal on Postgres but float on SQLite (the
+    test engine), so route through ``str`` to avoid binary float artefacts.
+    """
+    return Decimal(str(value or 0))
+
+
+def _pre_discount_taxable(item: InvoiceItem, *, tax_inclusive: bool) -> Decimal:
+    """Reconstruct a line's taxable amount *before* its discount was applied.
+
+    Mirrors ``InvoiceProcessor.calculate_totals`` exactly, including its
+    intermediate rounding — the tax-inclusive branch rounds ``line_total``
+    first and *then* divides, so collapsing the two steps would drift a paisa.
+    """
+    quantity = _dec(item.quantity)
+    unit_price = _dec(item.unit_price)
+    gst_rate = _dec(item.gst_rate)
+
+    if tax_inclusive:
+        line_total = _money(unit_price * quantity)
+        return _money(line_total / (1 + gst_rate / Decimal("100")))
+    return _money(unit_price * quantity)
+
+
+def _item_discount_totals(db: Session, invoice_ids: list[int], tax_inclusive_by_invoice: dict[int, bool]) -> dict[int, Decimal]:
+    """Sum per-line discounts for each invoice.
+
+    Only lines carrying a ``discount_type`` are fetched: an undiscounted line
+    stores its pre-discount taxable unchanged, so it contributes exactly zero
+    and reconstructing it would be pure rounding risk for no gain.
+    """
+    if not invoice_ids:
+        return {}
+
+    items = (
+        db.query(InvoiceItem)
+        .filter(
+            InvoiceItem.invoice_id.in_(invoice_ids),
+            InvoiceItem.discount_type.isnot(None),
+        )
+        .all()
+    )
+
+    totals: dict[int, Decimal] = {}
+    for item in items:
+        tax_inclusive = tax_inclusive_by_invoice.get(item.invoice_id, False)
+        discount = _pre_discount_taxable(item, tax_inclusive=tax_inclusive) - _dec(item.taxable_amount)
+        # A stored taxable above the reconstruction would mean the write path
+        # changed shape; clamp rather than report a negative discount.
+        if discount <= 0:
+            continue
+        totals[item.invoice_id] = totals.get(item.invoice_id, Decimal("0")) + discount
+
+    return {invoice_id: _money(total) for invoice_id, total in totals.items()}
+
+
+def _invoice_discount_amount(invoice: Invoice) -> Decimal:
+    """Recover the invoice-level discount by inverting the processor's totals.
+
+    ``_apply_totals`` ends with ``total_amount = raw_total + round_off`` in both
+    the round-off and non-round-off branches (``round_off`` being 0 in the
+    latter), where ``raw_total`` is already net of the invoice discount and
+    ``raw_total`` before the discount is ``taxable_amount + total_tax_amount``.
+    Rearranged, the discount falls straight out.
+    """
+    discount = (
+        _dec(invoice.taxable_amount)
+        + _dec(invoice.total_tax_amount)
+        + _dec(invoice.round_off_amount)
+        - _dec(invoice.total_amount)
+    )
+    if discount <= 0:
+        return Decimal("0.00")
+    return _money(discount)
+
+
+def build_invoice_discount_totals(
+    db: Session,
+    invoices: list[Invoice],
+) -> dict[int, InvoiceDiscountSummary]:
+    """Derive discount amounts for a batch of invoices, keyed by invoice id.
+
+    Batch-shaped like
+    :func:`~src.services.invoice_payments.build_invoice_payment_summaries`: one
+    grouped query for the whole set rather than per-invoice lookups.
+    """
+    if not invoices:
+        return {}
+
+    invoice_ids = [invoice.id for invoice in invoices]
+    tax_inclusive_by_invoice = {invoice.id: bool(invoice.tax_inclusive) for invoice in invoices}
+    item_totals = _item_discount_totals(db, invoice_ids, tax_inclusive_by_invoice)
+
+    summaries: dict[int, InvoiceDiscountSummary] = {}
+    for invoice in invoices:
+        item_total = item_totals.get(invoice.id, Decimal("0.00"))
+        invoice_discount = _invoice_discount_amount(invoice)
+        summaries[invoice.id] = InvoiceDiscountSummary(
+            invoice_id=invoice.id,
+            item_discount_total=item_total,
+            invoice_discount_amount=invoice_discount,
+            total_discount=_money(item_total + invoice_discount),
+        )
+
+    return summaries

--- a/backend/src/services/invoice_processor.py
+++ b/backend/src/services/invoice_processor.py
@@ -236,6 +236,12 @@ class InvoiceProcessor:
 
         Accepts the output of :meth:`validate_items` and returns a list of
         dicts with the calculated fields for each line item.
+
+        Note: the discount amount is not persisted — only ``discount_type`` and
+        ``discount_value`` are, and ``taxable_amount`` is stored net of it.
+        :mod:`src.services.invoice_discounts` recovers the amount by inverting
+        the arithmetic below for analytics reporting, so changes to the shape of
+        this calculation must be mirrored there.
         """
         results = []
         for item_schema, product, quantity_value in validated_items:

--- a/backend/tests/api/test_analytics_reports.py
+++ b/backend/tests/api/test_analytics_reports.py
@@ -1,0 +1,406 @@
+"""Tests for the sales analytics endpoints."""
+
+from datetime import datetime, timedelta
+
+
+def _create_product(client, sku, name, price, *, stock=1000, **extra):
+    """Create a product, stocked by default so sales invoices can be raised.
+
+    Pass stock=0 when the test sets its own stock level.
+    """
+    payload = {"sku": sku, "name": name, "price": price, "gst_rate": 18}
+    payload.update(extra)
+    response = client.post("/api/products/", json=payload)
+    assert response.status_code == 200, response.text
+    product_id = response.json()["id"]
+
+    if stock and extra.get("maintain_inventory", True):
+        adjust = client.post("/api/inventory/adjust", json={"product_id": product_id, "quantity": stock})
+        assert adjust.status_code == 200, adjust.text
+
+    return product_id
+
+
+def _create_ledger(client, name):
+    response = client.post(
+        "/api/ledgers/",
+        json={"name": name, "address": "1 Market St", "phone_number": "1234567890"},
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["id"]
+
+
+def _create_invoice(client, ledger_id, items, *, voucher_type="sales", invoice_date=None):
+    """Create an invoice. Omitting invoice_date lets the column default to
+    datetime.utcnow — which, unlike the API's date-only input, carries a real
+    time component (see test_invoice_dated_today_is_included)."""
+    payload = {"voucher_type": voucher_type, "ledger_id": ledger_id, "items": items}
+    if invoice_date is not None:
+        payload["invoice_date"] = invoice_date.date().isoformat()
+    response = client.post("/api/invoices/", json=payload)
+    assert response.status_code == 200, response.text
+    return response.json()
+
+
+class TestMonthlySales:
+    def test_buckets_invoices_by_month(self, client):
+        product = _create_product(client, "MON-1", "Widget", 100)
+        ledger = _create_ledger(client, "Acme")
+
+        march = datetime(2026, 3, 10, 12, 0)
+        april = datetime(2026, 4, 12, 12, 0)
+        _create_invoice(client, ledger, [{"product_id": product, "quantity": 1, "unit_price": 100, "gst_rate": 18}], invoice_date=march)
+        _create_invoice(client, ledger, [{"product_id": product, "quantity": 2, "unit_price": 100, "gst_rate": 18}], invoice_date=april)
+
+        res = client.get("/api/analytics/sales-by-month", params={"from_date": "2026-03-01", "to_date": "2026-04-30"})
+        assert res.status_code == 200, res.text
+        data = res.json()
+
+        assert [row["month"] for row in data["rows"]] == ["2026-03", "2026-04"]
+        assert [row["label"] for row in data["rows"]] == ["Mar 26", "Apr 26"]
+        assert data["rows"][0]["invoice_count"] == 1
+        assert data["rows"][0]["total_sales"] == 118.00
+        assert data["rows"][0]["taxable_value"] == 100.00
+        assert data["rows"][0]["gst_collected"] == 18.00
+        assert data["rows"][1]["invoice_count"] == 1
+        assert data["rows"][1]["total_sales"] == 236.00
+
+    def test_empty_months_are_emitted_with_zeros(self, client):
+        """A quiet month must appear as zero, not be omitted — charts read gaps."""
+        product = _create_product(client, "MON-2", "Widget", 100)
+        ledger = _create_ledger(client, "Acme")
+        _create_invoice(client, ledger, [{"product_id": product, "quantity": 1, "unit_price": 100, "gst_rate": 18}],
+                        invoice_date=datetime(2026, 1, 15, 12, 0))
+
+        res = client.get("/api/analytics/sales-by-month", params={"from_date": "2026-01-01", "to_date": "2026-03-31"})
+        data = res.json()
+
+        assert len(data["rows"]) == 3
+        assert data["rows"][1]["invoice_count"] == 0
+        assert data["rows"][1]["total_sales"] == 0.0
+        assert data["rows"][1]["average_invoice_value"] == 0.0
+
+    def test_totals_match_sum_of_rows(self, client):
+        product = _create_product(client, "MON-3", "Widget", 100)
+        ledger = _create_ledger(client, "Acme")
+        for day in (10, 20):
+            _create_invoice(client, ledger, [{"product_id": product, "quantity": 1, "unit_price": 100, "gst_rate": 18}],
+                            invoice_date=datetime(2026, 5, day, 12, 0))
+
+        res = client.get("/api/analytics/sales-by-month", params={"from_date": "2026-05-01", "to_date": "2026-05-31"})
+        data = res.json()
+
+        assert data["totals"]["invoice_count"] == sum(r["invoice_count"] for r in data["rows"])
+        assert data["totals"]["total_sales"] == sum(r["total_sales"] for r in data["rows"])
+        assert data["totals"]["average_invoice_value"] == 118.00
+
+    def test_discount_given_is_derived(self, client):
+        product = _create_product(client, "MON-4", "Widget", 100)
+        ledger = _create_ledger(client, "Acme")
+        # 10% off a 100 line = 10.00 given away.
+        _create_invoice(
+            client, ledger,
+            [{"product_id": product, "quantity": 1, "unit_price": 100, "gst_rate": 18,
+              "discount_type": "percentage", "discount_value": 10}],
+            invoice_date=datetime(2026, 6, 10, 12, 0),
+        )
+
+        res = client.get("/api/analytics/sales-by-month", params={"from_date": "2026-06-01", "to_date": "2026-06-30"})
+        assert res.json()["rows"][0]["discount_given"] == 10.00
+
+    def test_voucher_type_splits_sales_and_purchase(self, client):
+        product = _create_product(client, "MON-5", "Widget", 100)
+        ledger = _create_ledger(client, "Acme")
+        when = datetime(2026, 7, 10, 12, 0)
+        _create_invoice(client, ledger, [{"product_id": product, "quantity": 1, "unit_price": 100, "gst_rate": 18}],
+                        voucher_type="sales", invoice_date=when)
+        _create_invoice(client, ledger, [{"product_id": product, "quantity": 5, "unit_price": 60, "gst_rate": 18}],
+                        voucher_type="purchase", invoice_date=when)
+
+        params = {"from_date": "2026-07-01", "to_date": "2026-07-31"}
+        sales = client.get("/api/analytics/sales-by-month", params={**params, "voucher_type": "sales"}).json()
+        purchases = client.get("/api/analytics/sales-by-month", params={**params, "voucher_type": "purchase"}).json()
+
+        assert sales["totals"]["invoice_count"] == 1
+        assert sales["totals"]["taxable_value"] == 100.00
+        assert purchases["totals"]["invoice_count"] == 1
+        assert purchases["totals"]["taxable_value"] == 300.00
+
+    def test_cancelled_invoices_excluded(self, client):
+        product = _create_product(client, "MON-6", "Widget", 100)
+        ledger = _create_ledger(client, "Acme")
+        invoice = _create_invoice(client, ledger, [{"product_id": product, "quantity": 1, "unit_price": 100, "gst_rate": 18}],
+                                  invoice_date=datetime(2026, 8, 10, 12, 0))
+        # DELETE is a soft-delete that sets status="cancelled".
+        assert client.delete(f"/api/invoices/{invoice['id']}").status_code == 200
+
+        res = client.get("/api/analytics/sales-by-month", params={"from_date": "2026-08-01", "to_date": "2026-08-31"})
+        assert res.json()["totals"]["invoice_count"] == 0
+
+    def test_ledger_filter_narrows_results(self, client):
+        product = _create_product(client, "MON-7", "Widget", 100)
+        acme = _create_ledger(client, "Acme")
+        globex = _create_ledger(client, "Globex")
+        when = datetime(2026, 9, 10, 12, 0)
+        _create_invoice(client, acme, [{"product_id": product, "quantity": 1, "unit_price": 100, "gst_rate": 18}], invoice_date=when)
+        _create_invoice(client, globex, [{"product_id": product, "quantity": 3, "unit_price": 100, "gst_rate": 18}], invoice_date=when)
+
+        params = {"from_date": "2026-09-01", "to_date": "2026-09-30"}
+        assert client.get("/api/analytics/sales-by-month", params=params).json()["totals"]["invoice_count"] == 2
+        narrowed = client.get("/api/analytics/sales-by-month", params={**params, "ledger_id": acme}).json()
+        assert narrowed["totals"]["invoice_count"] == 1
+        assert narrowed["totals"]["taxable_value"] == 100.00
+
+    def test_invoice_dated_today_is_included(self, client):
+        """The DateTime/date boundary.
+
+        An invoice created without an explicit date gets invoice_date =
+        datetime.utcnow(), i.e. today at a real wall-clock time. Reporting up to
+        and including today must still count it — comparing the DateTime column
+        against a bare date would silently drop every invoice raised today.
+        """
+        product = _create_product(client, "MON-8", "Widget", 100)
+        ledger = _create_ledger(client, "Acme")
+        _create_invoice(client, ledger, [{"product_id": product, "quantity": 1, "unit_price": 100, "gst_rate": 18}])
+
+        today = datetime.utcnow().date()
+        res = client.get("/api/analytics/sales-by-month", params={
+            "from_date": today.replace(day=1).isoformat(),
+            "to_date": today.isoformat(),
+        })
+        assert res.json()["totals"]["invoice_count"] == 1
+
+    def test_from_date_after_to_date_is_rejected(self, client):
+        res = client.get("/api/analytics/sales-by-month", params={"from_date": "2026-05-01", "to_date": "2026-04-01"})
+        assert res.status_code == 400
+
+    def test_empty_company_returns_zeros(self, client):
+        res = client.get("/api/analytics/sales-by-month", params={"from_date": "2026-01-01", "to_date": "2026-01-31"})
+        assert res.status_code == 200
+        data = res.json()
+        assert data["totals"]["invoice_count"] == 0
+        assert data["totals"]["total_sales"] == 0.0
+        assert len(data["rows"]) == 1
+
+    def test_period_is_echoed_back(self, client):
+        res = client.get("/api/analytics/sales-by-month", params={"from_date": "2026-02-01", "to_date": "2026-02-28"})
+        period = res.json()["period"]
+        assert period["from_date"] == "2026-02-01"
+        assert period["to_date"] == "2026-02-28"
+
+
+class TestProductSales:
+    def test_aggregates_per_product(self, client):
+        widget = _create_product(client, "PRD-1", "Widget", 100)
+        gadget = _create_product(client, "PRD-2", "Gadget", 50)
+        ledger = _create_ledger(client, "Acme")
+        _create_invoice(client, ledger, [
+            {"product_id": widget, "quantity": 2, "unit_price": 100, "gst_rate": 18},
+            {"product_id": gadget, "quantity": 4, "unit_price": 50, "gst_rate": 18},
+        ], invoice_date=datetime(2026, 3, 10, 12, 0))
+
+        res = client.get("/api/analytics/sales-by-product", params={"from_date": "2026-03-01", "to_date": "2026-03-31"})
+        assert res.status_code == 200, res.text
+        rows = {row["name"]: row for row in res.json()["rows"]}
+
+        assert rows["Widget"]["quantity_sold"] == 2
+        assert rows["Widget"]["sales_amount"] == 200.00  # ex-GST
+        assert rows["Widget"]["total_gst"] == 36.00
+        assert rows["Widget"]["total_revenue"] == 236.00  # incl. GST
+        assert rows["Widget"]["average_selling_price"] == 100.00
+        assert rows["Widget"]["sku"] == "PRD-1"
+        assert rows["Gadget"]["quantity_sold"] == 4
+
+    def test_invoice_count_is_distinct_per_invoice(self, client):
+        """One invoice listing the same product twice must count as one invoice.
+
+        A plain count() over line items reports 2 here.
+        """
+        product = _create_product(client, "PRD-3", "Widget", 100)
+        ledger = _create_ledger(client, "Acme")
+        _create_invoice(client, ledger, [
+            {"product_id": product, "quantity": 1, "unit_price": 100, "gst_rate": 18},
+            {"product_id": product, "quantity": 3, "unit_price": 100, "gst_rate": 18},
+        ], invoice_date=datetime(2026, 4, 10, 12, 0))
+
+        res = client.get("/api/analytics/sales-by-product", params={"from_date": "2026-04-01", "to_date": "2026-04-30"})
+        row = res.json()["rows"][0]
+        assert row["invoice_count"] == 1
+        assert row["quantity_sold"] == 4
+
+    def test_current_stock_is_null_when_not_tracked(self, client):
+        tracked = _create_product(client, "PRD-4", "Tracked", 100, stock=0, maintain_inventory=True)
+        untracked = _create_product(client, "PRD-5", "Untracked", 100, maintain_inventory=False)
+        assert client.post("/api/inventory/adjust", json={"product_id": tracked, "quantity": 25}).status_code == 200
+
+        ledger = _create_ledger(client, "Acme")
+        _create_invoice(client, ledger, [
+            {"product_id": tracked, "quantity": 1, "unit_price": 100, "gst_rate": 18},
+            {"product_id": untracked, "quantity": 1, "unit_price": 100, "gst_rate": 18},
+        ], invoice_date=datetime(2026, 5, 10, 12, 0))
+
+        res = client.get("/api/analytics/sales-by-product", params={"from_date": "2026-05-01", "to_date": "2026-05-31"})
+        rows = {row["name"]: row for row in res.json()["rows"]}
+
+        assert rows["Untracked"]["current_stock"] is None
+        assert rows["Tracked"]["current_stock"] == 24  # 25 in, 1 sold
+
+    def test_sort_by_revenue(self, client):
+        small = _create_product(client, "PRD-6", "Small", 10)
+        big = _create_product(client, "PRD-7", "Big", 500)
+        ledger = _create_ledger(client, "Acme")
+        _create_invoice(client, ledger, [
+            {"product_id": small, "quantity": 1, "unit_price": 10, "gst_rate": 18},
+            {"product_id": big, "quantity": 1, "unit_price": 500, "gst_rate": 18},
+        ], invoice_date=datetime(2026, 6, 10, 12, 0))
+
+        params = {"from_date": "2026-06-01", "to_date": "2026-06-30"}
+        desc = client.get("/api/analytics/sales-by-product", params={**params, "sort_by": "revenue", "sort_dir": "desc"}).json()
+        asc = client.get("/api/analytics/sales-by-product", params={**params, "sort_by": "revenue", "sort_dir": "asc"}).json()
+
+        assert [r["name"] for r in desc["rows"]] == ["Big", "Small"]
+        assert [r["name"] for r in asc["rows"]] == ["Small", "Big"]
+
+    def test_sort_by_quantity_and_name(self, client):
+        alpha = _create_product(client, "PRD-8", "Alpha", 100)
+        zulu = _create_product(client, "PRD-9", "Zulu", 100)
+        ledger = _create_ledger(client, "Acme")
+        _create_invoice(client, ledger, [
+            {"product_id": alpha, "quantity": 1, "unit_price": 100, "gst_rate": 18},
+            {"product_id": zulu, "quantity": 9, "unit_price": 100, "gst_rate": 18},
+        ], invoice_date=datetime(2026, 7, 10, 12, 0))
+
+        params = {"from_date": "2026-07-01", "to_date": "2026-07-31"}
+        by_qty = client.get("/api/analytics/sales-by-product", params={**params, "sort_by": "quantity", "sort_dir": "desc"}).json()
+        by_name = client.get("/api/analytics/sales-by-product", params={**params, "sort_by": "name", "sort_dir": "asc"}).json()
+
+        assert [r["name"] for r in by_qty["rows"]] == ["Zulu", "Alpha"]
+        assert [r["name"] for r in by_name["rows"]] == ["Alpha", "Zulu"]
+
+    def test_sort_by_stock_puts_untracked_last_in_both_directions(self, client):
+        tracked = _create_product(client, "PRD-10", "Tracked", 100, stock=0, maintain_inventory=True)
+        untracked = _create_product(client, "PRD-11", "Untracked", 100, maintain_inventory=False)
+        assert client.post("/api/inventory/adjust", json={"product_id": tracked, "quantity": 50}).status_code == 200
+
+        ledger = _create_ledger(client, "Acme")
+        _create_invoice(client, ledger, [
+            {"product_id": tracked, "quantity": 1, "unit_price": 100, "gst_rate": 18},
+            {"product_id": untracked, "quantity": 1, "unit_price": 100, "gst_rate": 18},
+        ], invoice_date=datetime(2026, 8, 10, 12, 0))
+
+        params = {"from_date": "2026-08-01", "to_date": "2026-08-31", "sort_by": "stock"}
+        desc = client.get("/api/analytics/sales-by-product", params={**params, "sort_dir": "desc"}).json()
+        asc = client.get("/api/analytics/sales-by-product", params={**params, "sort_dir": "asc"}).json()
+
+        assert [r["name"] for r in desc["rows"]] == ["Tracked", "Untracked"]
+        assert [r["name"] for r in asc["rows"]] == ["Tracked", "Untracked"]
+
+    def test_limit_truncates_rows(self, client):
+        ledger = _create_ledger(client, "Acme")
+        items = []
+        for index in range(3):
+            pid = _create_product(client, f"PRD-LIM-{index}", f"Item {index}", 100)
+            items.append({"product_id": pid, "quantity": index + 1, "unit_price": 100, "gst_rate": 18})
+        _create_invoice(client, ledger, items, invoice_date=datetime(2026, 9, 10, 12, 0))
+
+        res = client.get("/api/analytics/sales-by-product", params={
+            "from_date": "2026-09-01", "to_date": "2026-09-30", "limit": 2,
+        })
+        assert len(res.json()["rows"]) == 2
+
+    def test_product_filter_narrows_results(self, client):
+        widget = _create_product(client, "PRD-12", "Widget", 100)
+        gadget = _create_product(client, "PRD-13", "Gadget", 100)
+        ledger = _create_ledger(client, "Acme")
+        _create_invoice(client, ledger, [
+            {"product_id": widget, "quantity": 1, "unit_price": 100, "gst_rate": 18},
+            {"product_id": gadget, "quantity": 1, "unit_price": 100, "gst_rate": 18},
+        ], invoice_date=datetime(2026, 10, 10, 12, 0))
+
+        res = client.get("/api/analytics/sales-by-product", params={
+            "from_date": "2026-10-01", "to_date": "2026-10-31", "product_id": widget,
+        })
+        rows = res.json()["rows"]
+        assert len(rows) == 1
+        assert rows[0]["name"] == "Widget"
+
+    def test_totals_do_not_double_count_shared_invoices(self, client):
+        """Two products on one invoice is one invoice in the totals, not two."""
+        widget = _create_product(client, "PRD-14", "Widget", 100)
+        gadget = _create_product(client, "PRD-15", "Gadget", 100)
+        ledger = _create_ledger(client, "Acme")
+        _create_invoice(client, ledger, [
+            {"product_id": widget, "quantity": 1, "unit_price": 100, "gst_rate": 18},
+            {"product_id": gadget, "quantity": 1, "unit_price": 100, "gst_rate": 18},
+        ], invoice_date=datetime(2026, 11, 10, 12, 0))
+
+        res = client.get("/api/analytics/sales-by-product", params={"from_date": "2026-11-01", "to_date": "2026-11-30"})
+        totals = res.json()["totals"]
+        assert totals["product_count"] == 2
+        assert totals["invoice_count"] == 1
+        assert totals["sales_amount"] == 200.00
+
+    def test_cancelled_invoices_excluded(self, client):
+        product = _create_product(client, "PRD-16", "Widget", 100)
+        ledger = _create_ledger(client, "Acme")
+        invoice = _create_invoice(client, ledger, [{"product_id": product, "quantity": 1, "unit_price": 100, "gst_rate": 18}],
+                                  invoice_date=datetime(2026, 12, 10, 12, 0))
+        # DELETE is a soft-delete that sets status="cancelled".
+        assert client.delete(f"/api/invoices/{invoice['id']}").status_code == 200
+
+        res = client.get("/api/analytics/sales-by-product", params={"from_date": "2026-12-01", "to_date": "2026-12-31"})
+        assert res.json()["rows"] == []
+
+    def test_empty_company_returns_zeros(self, client):
+        res = client.get("/api/analytics/sales-by-product", params={"from_date": "2026-01-01", "to_date": "2026-01-31"})
+        assert res.status_code == 200
+        data = res.json()
+        assert data["rows"] == []
+        assert data["totals"]["product_count"] == 0
+        assert data["totals"]["invoice_count"] == 0
+
+    def test_invalid_sort_field_is_rejected(self, client):
+        res = client.get("/api/analytics/sales-by-product", params={
+            "from_date": "2026-01-01", "to_date": "2026-01-31", "sort_by": "bogus",
+        })
+        assert res.status_code == 422
+
+
+class TestCsvExports:
+    def test_monthly_csv(self, client):
+        product = _create_product(client, "CSV-1", "Widget", 100)
+        ledger = _create_ledger(client, "Acme")
+        _create_invoice(client, ledger, [{"product_id": product, "quantity": 1, "unit_price": 100, "gst_rate": 18}],
+                        invoice_date=datetime(2026, 3, 10, 12, 0))
+
+        res = client.get("/api/analytics/sales-by-month/csv", params={"from_date": "2026-03-01", "to_date": "2026-03-31"})
+        assert res.status_code == 200
+        assert res.headers["content-type"].startswith("text/csv")
+        assert "attachment" in res.headers["content-disposition"]
+        assert "sales_by_month_2026-03-01_2026-03-31.csv" in res.headers["content-disposition"]
+
+        body = res.content.decode("utf-8-sig")
+        assert "Month,Invoices,Total Sales" in body
+        assert "Mar 26" in body
+        assert "Totals" in body
+
+    def test_product_csv(self, client):
+        product = _create_product(client, "CSV-2", "Widget", 100)
+        ledger = _create_ledger(client, "Acme")
+        _create_invoice(client, ledger, [{"product_id": product, "quantity": 2, "unit_price": 100, "gst_rate": 18}],
+                        invoice_date=datetime(2026, 4, 10, 12, 0))
+
+        res = client.get("/api/analytics/sales-by-product/csv", params={"from_date": "2026-04-01", "to_date": "2026-04-30"})
+        assert res.status_code == 200
+        assert res.headers["content-type"].startswith("text/csv")
+
+        body = res.content.decode("utf-8-sig")
+        assert "Product,Item Code,Quantity Sold" in body
+        assert "Widget" in body
+        assert "CSV-2" in body
+        assert "Totals" in body
+
+    def test_csv_has_excel_bom(self, client):
+        """The BOM is what makes Excel render the currency correctly."""
+        res = client.get("/api/analytics/sales-by-month/csv", params={"from_date": "2026-01-01", "to_date": "2026-01-31"})
+        assert res.content.startswith(b"\xef\xbb\xbf")

--- a/backend/tests/services/test_invoice_discounts.py
+++ b/backend/tests/services/test_invoice_discounts.py
@@ -1,0 +1,376 @@
+"""Tests for discount amount derivation.
+
+Invoices store discount_type/discount_value but never the discount *amount*, so
+src.services.invoice_discounts recovers it by inverting the write path. These
+tests guard that inversion: the known-answer cases pin the arithmetic, and
+TestRoundTripAgainstProcessor catches the real risk — the write path changing
+shape and the derivation silently drifting away from it.
+"""
+
+from datetime import datetime
+from decimal import Decimal
+
+import pytest
+
+from src.models.buyer import Buyer
+from src.models.company import CompanyProfile
+from src.models.inventory import Inventory
+from src.models.invoice import Invoice
+from src.models.product import Product
+from src.models.user import User, UserRole
+from src.schemas.invoice import InvoiceCreate, InvoiceItemCreate
+from src.services.invoice_discounts import build_invoice_discount_totals
+from src.services.invoice_processor import InvoiceProcessor
+
+
+@pytest.fixture
+def processor(db_session):
+    return InvoiceProcessor(db_session)
+
+
+def _seed(db_session):
+    user = User(email="admin@test.com", full_name="Admin", hashed_password="x", role=UserRole.admin)
+    ledger = Buyer(name="Test Buyer", address="Addr", gst="07AABB1234C1Z5", phone_number="9999999999")
+    company = CompanyProfile(name="Test Co", address="HQ", gst="07AAMPB1274B1Z8", phone_number="8888888888", currency_code="INR")
+    db_session.add_all([user, ledger, company])
+    db_session.flush()
+    return user, ledger
+
+
+def _product(db_session, sku="SKU01", price=100.0, gst_rate=18.0):
+    p = Product(sku=sku, name=f"Product {sku}", price=price, gst_rate=gst_rate)
+    db_session.add(p)
+    db_session.flush()
+    db_session.add(Inventory(product_id=p.id, quantity=100))
+    db_session.flush()
+    return p
+
+
+def _inv(db_session):
+    invoice = Invoice(total_amount=0, created_by=1, invoice_date=datetime.utcnow())
+    db_session.add(invoice)
+    db_session.flush()
+    return invoice
+
+
+def _apply(db_session, processor, ledger, **payload_kwargs):
+    """Build an invoice through the real processor and return it."""
+    invoice = _inv(db_session)
+    payload = InvoiceCreate(ledger_id=ledger.id, voucher_type="sales", **payload_kwargs)
+    processor.apply_payload(invoice, payload, created_by=1, regenerate_number=False)
+    db_session.flush()
+    db_session.refresh(invoice)
+    return invoice
+
+
+def _summary(db_session, invoice):
+    summaries = build_invoice_discount_totals(db_session, [invoice])
+    assert invoice.id in summaries
+    return summaries[invoice.id]
+
+
+class TestItemLevelDiscounts:
+    def test_percentage_discount(self, db_session, processor):
+        _, ledger = _seed(db_session)
+        product = _product(db_session)
+        # 10% off 100 taxable = 10.00 discount.
+        invoice = _apply(
+            db_session, processor, ledger,
+            tax_inclusive=False,
+            items=[InvoiceItemCreate(
+                product_id=product.id, quantity=1, unit_price=100.00,
+                discount_type="percentage", discount_value=10.0,
+            )],
+        )
+
+        summary = _summary(db_session, invoice)
+        assert summary.item_discount_total == Decimal("10.00")
+        assert summary.invoice_discount_amount == Decimal("0.00")
+        assert summary.total_discount == Decimal("10.00")
+
+    def test_net_discount(self, db_session, processor):
+        _, ledger = _seed(db_session)
+        product = _product(db_session)
+        invoice = _apply(
+            db_session, processor, ledger,
+            tax_inclusive=False,
+            items=[InvoiceItemCreate(
+                product_id=product.id, quantity=1, unit_price=100.00,
+                discount_type="net", discount_value=25.00,
+            )],
+        )
+
+        assert _summary(db_session, invoice).item_discount_total == Decimal("25.00")
+
+    def test_net_discount_clamped_to_line_value(self, db_session, processor):
+        """A 100 discount on a 50 line is clamped to 50 by the write path.
+
+        This is the case a discount_value-based derivation gets wrong — it would
+        report 100 given away on a 50 line.
+        """
+        _, ledger = _seed(db_session)
+        product = _product(db_session, price=50.0)
+        invoice = _apply(
+            db_session, processor, ledger,
+            tax_inclusive=False,
+            items=[InvoiceItemCreate(
+                product_id=product.id, quantity=1, unit_price=50.00,
+                discount_type="net", discount_value=100.00,
+            )],
+        )
+
+        assert _summary(db_session, invoice).item_discount_total == Decimal("50.00")
+
+    def test_tax_inclusive_discount(self, db_session, processor):
+        """Tax-inclusive lines discount the ex-tax taxable, not the gross."""
+        _, ledger = _seed(db_session)
+        product = _product(db_session)
+        # 118 incl. 18% → 100.00 taxable; 10% off = 10.00.
+        invoice = _apply(
+            db_session, processor, ledger,
+            tax_inclusive=True,
+            items=[InvoiceItemCreate(
+                product_id=product.id, quantity=1, unit_price=118.00,
+                discount_type="percentage", discount_value=10.0,
+            )],
+        )
+
+        assert _summary(db_session, invoice).item_discount_total == Decimal("10.00")
+
+    def test_multiple_lines_sum(self, db_session, processor):
+        _, ledger = _seed(db_session)
+        p1 = _product(db_session, "SKU-A", 200.00)
+        p2 = _product(db_session, "SKU-B", 300.00)
+        invoice = _apply(
+            db_session, processor, ledger,
+            tax_inclusive=False,
+            items=[
+                # 10% off 200 = 20.00
+                InvoiceItemCreate(product_id=p1.id, quantity=1, unit_price=200.00,
+                                  discount_type="percentage", discount_value=10.0),
+                # flat 50 off 300 = 50.00
+                InvoiceItemCreate(product_id=p2.id, quantity=1, unit_price=300.00,
+                                  discount_type="net", discount_value=50.00),
+            ],
+        )
+
+        assert _summary(db_session, invoice).item_discount_total == Decimal("70.00")
+
+
+class TestInvoiceLevelDiscounts:
+    def test_percentage_discount(self, db_session, processor):
+        _, ledger = _seed(db_session)
+        product = _product(db_session)
+        # 200 taxable + 36 tax = 236 gross; 10% = 23.60.
+        invoice = _apply(
+            db_session, processor, ledger,
+            tax_inclusive=False,
+            discount_type="percentage", discount_value=10.0,
+            items=[InvoiceItemCreate(product_id=product.id, quantity=2, unit_price=100.00)],
+        )
+
+        summary = _summary(db_session, invoice)
+        assert summary.invoice_discount_amount == Decimal("23.60")
+        assert summary.item_discount_total == Decimal("0.00")
+        assert summary.total_discount == Decimal("23.60")
+
+    def test_net_discount(self, db_session, processor):
+        _, ledger = _seed(db_session)
+        product = _product(db_session, price=500.0)
+        invoice = _apply(
+            db_session, processor, ledger,
+            tax_inclusive=False,
+            discount_type="net", discount_value=50.00,
+            items=[InvoiceItemCreate(product_id=product.id, quantity=1, unit_price=500.00)],
+        )
+
+        assert _summary(db_session, invoice).invoice_discount_amount == Decimal("50.00")
+
+    def test_discount_with_round_off(self, db_session, processor):
+        """Round-off must not be mistaken for discount.
+
+        Taxable 123.45 + tax 22.22 = 145.67 gross; 5% = 7.28 discount → 138.39;
+        rounded to 138.00 with round_off -0.39. The derivation has to add the
+        round_off back to recover 7.28 rather than reporting 7.67.
+        """
+        _, ledger = _seed(db_session)
+        product = _product(db_session, price=123.45)
+        invoice = _apply(
+            db_session, processor, ledger,
+            tax_inclusive=False,
+            apply_round_off=True,
+            discount_type="percentage", discount_value=5.0,
+            items=[InvoiceItemCreate(product_id=product.id, quantity=1, unit_price=123.45)],
+        )
+
+        assert float(invoice.round_off_amount) == pytest.approx(-0.39)
+        assert _summary(db_session, invoice).invoice_discount_amount == Decimal("7.28")
+
+    def test_round_off_without_discount_is_not_a_discount(self, db_session, processor):
+        """Round-off alone must derive to exactly zero discount."""
+        _, ledger = _seed(db_session)
+        product = _product(db_session, price=123.45)
+        invoice = _apply(
+            db_session, processor, ledger,
+            tax_inclusive=False,
+            apply_round_off=True,
+            items=[InvoiceItemCreate(product_id=product.id, quantity=1, unit_price=123.45)],
+        )
+
+        assert _summary(db_session, invoice).total_discount == Decimal("0.00")
+
+
+class TestCombined:
+    def test_item_and_invoice_discounts(self, db_session, processor):
+        _, ledger = _seed(db_session)
+        p1 = _product(db_session, "SKU-A", 200.00)
+        p2 = _product(db_session, "SKU-B", 300.00)
+        # Item discounts: 10% off 200 = 20.00, flat 50 off 300 = 50.00 → 70.00
+        # Invoice discount: flat 20.00
+        invoice = _apply(
+            db_session, processor, ledger,
+            tax_inclusive=False,
+            discount_type="net", discount_value=20.00,
+            items=[
+                InvoiceItemCreate(product_id=p1.id, quantity=1, unit_price=200.00,
+                                  discount_type="percentage", discount_value=10.0),
+                InvoiceItemCreate(product_id=p2.id, quantity=1, unit_price=300.00,
+                                  discount_type="net", discount_value=50.00),
+            ],
+        )
+
+        summary = _summary(db_session, invoice)
+        assert summary.item_discount_total == Decimal("70.00")
+        assert summary.invoice_discount_amount == Decimal("20.00")
+        assert summary.total_discount == Decimal("90.00")
+
+
+class TestEdgeCases:
+    def test_no_discount_is_exactly_zero(self, db_session, processor):
+        _, ledger = _seed(db_session)
+        product = _product(db_session)
+        invoice = _apply(
+            db_session, processor, ledger,
+            tax_inclusive=False,
+            items=[InvoiceItemCreate(product_id=product.id, quantity=1, unit_price=100.00)],
+        )
+
+        summary = _summary(db_session, invoice)
+        assert summary.total_discount == Decimal("0.00")
+
+    def test_zero_discount_value_is_zero(self, db_session, processor):
+        """discount_type set with a zero value is ignored by the write path."""
+        _, ledger = _seed(db_session)
+        product = _product(db_session)
+        invoice = _apply(
+            db_session, processor, ledger,
+            tax_inclusive=False,
+            items=[InvoiceItemCreate(
+                product_id=product.id, quantity=1, unit_price=100.00,
+                discount_type="percentage", discount_value=0,
+            )],
+        )
+
+        assert _summary(db_session, invoice).total_discount == Decimal("0.00")
+
+    def test_fully_wiped_line(self, db_session, processor):
+        _, ledger = _seed(db_session)
+        product = _product(db_session)
+        invoice = _apply(
+            db_session, processor, ledger,
+            tax_inclusive=False,
+            items=[InvoiceItemCreate(
+                product_id=product.id, quantity=1, unit_price=100.00,
+                discount_type="percentage", discount_value=100.0,
+            )],
+        )
+
+        assert _summary(db_session, invoice).item_discount_total == Decimal("100.00")
+
+    def test_empty_invoice_list(self, db_session):
+        assert build_invoice_discount_totals(db_session, []) == {}
+
+    def test_batches_multiple_invoices(self, db_session, processor):
+        _, ledger = _seed(db_session)
+        product = _product(db_session)
+        first = _apply(
+            db_session, processor, ledger, tax_inclusive=False,
+            items=[InvoiceItemCreate(product_id=product.id, quantity=1, unit_price=100.00,
+                                     discount_type="net", discount_value=10.00)],
+        )
+        second = _apply(
+            db_session, processor, ledger, tax_inclusive=False,
+            items=[InvoiceItemCreate(product_id=product.id, quantity=1, unit_price=100.00,
+                                     discount_type="net", discount_value=30.00)],
+        )
+
+        summaries = build_invoice_discount_totals(db_session, [first, second])
+        assert summaries[first.id].total_discount == Decimal("10.00")
+        assert summaries[second.id].total_discount == Decimal("30.00")
+
+
+class TestRoundTripAgainstProcessor:
+    """The derivation must agree with what the processor itself computed.
+
+    These assert against the processor's own output rather than hand-computed
+    constants, so they fail if the write path changes shape — which is the
+    failure mode the derivation is exposed to.
+    """
+
+    @pytest.mark.parametrize("tax_inclusive", [False, True])
+    @pytest.mark.parametrize("apply_round_off", [False, True])
+    @pytest.mark.parametrize(
+        "item_discount,invoice_discount",
+        [
+            (None, None),
+            (("percentage", 10.0), None),
+            (("net", 25.0), None),
+            (None, ("percentage", 10.0)),
+            (None, ("net", 50.0)),
+            (("percentage", 7.5), ("net", 20.0)),
+            (("net", 33.33), ("percentage", 12.5)),
+        ],
+    )
+    def test_derived_matches_processor(
+        self, db_session, processor, tax_inclusive, apply_round_off, item_discount, invoice_discount
+    ):
+        _, ledger = _seed(db_session)
+        product = _product(db_session, price=137.77)
+
+        item_kwargs = {}
+        if item_discount:
+            item_kwargs = {"discount_type": item_discount[0], "discount_value": item_discount[1]}
+        invoice_kwargs = {}
+        if invoice_discount:
+            invoice_kwargs = {"discount_type": invoice_discount[0], "discount_value": invoice_discount[1]}
+
+        # apply_inventory_changes=False — this call only computes the expected
+        # discount; the real stock movement happens in _apply below.
+        validated = processor.validate_items(
+            [InvoiceItemCreate(product_id=product.id, quantity=3, unit_price=137.77, **item_kwargs)],
+            company_id=None,
+            voucher_type="sales",
+            apply_inventory_changes=False,
+        )
+        expected_item_discount = sum(
+            (row["discount_amount"] for row in processor.calculate_totals(validated, tax_inclusive)),
+            Decimal("0"),
+        )
+
+        invoice = _apply(
+            db_session, processor, ledger,
+            tax_inclusive=tax_inclusive,
+            apply_round_off=apply_round_off,
+            items=[InvoiceItemCreate(product_id=product.id, quantity=3, unit_price=137.77, **item_kwargs)],
+            **invoice_kwargs,
+        )
+
+        summary = _summary(db_session, invoice)
+        assert summary.item_discount_total == expected_item_discount
+
+        # The invoice-level discount is recoverable from the processor's own
+        # published totals the same way a reader would: gross minus what was
+        # actually charged, net of round-off.
+        gross = Decimal(str(invoice.taxable_amount)) + Decimal(str(invoice.total_tax_amount))
+        charged = Decimal(str(invoice.total_amount)) - Decimal(str(invoice.round_off_amount))
+        assert summary.invoice_discount_amount == max(gross - charged, Decimal("0.00"))

--- a/frontend/e2e/analytics.spec.ts
+++ b/frontend/e2e/analytics.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from './fixtures';
+
+test.describe('Analytics', () => {
+  test('is reachable from the sidebar Analytics group', async ({ authedPage: page }) => {
+    await page.click('.sidebar [href="/analytics"]');
+    await expect(page).toHaveURL(/\/analytics/);
+    await expect(page.locator('.page-title')).toHaveText('Analytics');
+  });
+
+  test('defaults to the month-wise tab', async ({ authedPage: page }) => {
+    await page.goto('/analytics');
+    await expect(page.getByRole('tab', { name: 'Month-wise Sales' })).toHaveAttribute('aria-selected', 'true');
+  });
+
+  test('switching tabs updates the URL', async ({ authedPage: page }) => {
+    await page.goto('/analytics');
+    await page.getByRole('tab', { name: 'Product-wise Sales' }).click();
+
+    await expect(page).toHaveURL(/tab=product-wise/);
+    await expect(page.getByRole('tab', { name: 'Product-wise Sales' })).toHaveAttribute('aria-selected', 'true');
+  });
+
+  test('deep-linking a tab opens it', async ({ authedPage: page }) => {
+    await page.goto('/analytics?tab=product-wise');
+    await expect(page.getByRole('tab', { name: 'Product-wise Sales' })).toHaveAttribute('aria-selected', 'true');
+  });
+
+  test('tabs are keyboard navigable', async ({ authedPage: page }) => {
+    await page.goto('/analytics');
+    await page.getByRole('tab', { name: 'Month-wise Sales' }).focus();
+    await page.keyboard.press('ArrowRight');
+
+    await expect(page.getByRole('tab', { name: 'Product-wise Sales' })).toHaveAttribute('aria-selected', 'true');
+  });
+
+  test('renders a chart or an empty state, never an error', async ({ authedPage: page }) => {
+    await page.goto('/analytics');
+    await expect(page.locator('.chart-frame svg, .empty-state').first()).toBeVisible();
+  });
+
+  test('changing the voucher type refetches and syncs the URL', async ({ authedPage: page }) => {
+    await page.goto('/analytics');
+
+    const response = page.waitForResponse((res) =>
+      res.url().includes('/analytics/sales-by-month') && res.url().includes('voucher_type=purchase'),
+    );
+    await page.getByLabel('Type').selectOption('purchase');
+    await response;
+
+    await expect(page).toHaveURL(/type=purchase/);
+  });
+
+  test('exports month-wise CSV', async ({ authedPage: page }) => {
+    await page.goto('/analytics');
+
+    const downloadPromise = page.waitForEvent('download');
+    await page.getByRole('button', { name: /Export CSV/ }).click();
+    const download = await downloadPromise;
+
+    expect(download.suggestedFilename()).toMatch(/^sales_by_month_.*\.csv$/);
+  });
+
+  test('exports product-wise CSV', async ({ authedPage: page }) => {
+    await page.goto('/analytics?tab=product-wise');
+
+    const downloadPromise = page.waitForEvent('download');
+    await page.getByRole('button', { name: /Export CSV/ }).click();
+    const download = await downloadPromise;
+
+    expect(download.suggestedFilename()).toMatch(/^sales_by_product_.*\.csv$/);
+  });
+});

--- a/frontend/e2e/sidebar.spec.ts
+++ b/frontend/e2e/sidebar.spec.ts
@@ -14,8 +14,10 @@ test.describe('Sidebar', () => {
   });
 
   // 3. All nav groups present
-  test('sidebar renders Management and Settings groups', async ({ authedPage: page }) => {
-    await expect(page.locator('.sidebar__group-label', { hasText: 'Management' })).toBeVisible();
+  test('sidebar renders the nav groups', async ({ authedPage: page }) => {
+    await expect(page.locator('.sidebar__group-label', { hasText: 'Analytics' })).toBeVisible();
+    await expect(page.locator('.sidebar__group-label', { hasText: 'Catalogue' })).toBeVisible();
+    await expect(page.locator('.sidebar__group-label', { hasText: 'Organisation' })).toBeVisible();
     await expect(page.locator('.sidebar__group-label', { hasText: 'Settings' })).toBeVisible();
   });
 
@@ -38,5 +40,39 @@ test.describe('Sidebar', () => {
     await expect(page.locator('.sidebar')).toBeVisible();
     await page.click('[href="/invoices"]');
     await expect(page.locator('.sidebar')).toBeVisible();
+  });
+
+  // 7. Desktop collapse rail
+  test('collapse toggle puts the shell into rail mode', async ({ authedPage: page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await expect(page.locator('.app-shell')).not.toHaveClass(/app-shell--rail/);
+
+    await page.click('.sidebar__collapse');
+    await expect(page.locator('.app-shell')).toHaveClass(/app-shell--rail/);
+
+    await page.click('.sidebar__collapse');
+    await expect(page.locator('.app-shell')).not.toHaveClass(/app-shell--rail/);
+  });
+
+  test('rail state survives a reload', async ({ authedPage: page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await page.click('.sidebar__collapse');
+    await expect(page.locator('.app-shell')).toHaveClass(/app-shell--rail/);
+
+    await page.reload();
+    await expect(page.locator('.app-shell')).toHaveClass(/app-shell--rail/);
+  });
+
+  test('nav links keep accessible names in rail mode', async ({ authedPage: page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await page.click('.sidebar__collapse');
+
+    // Labels are clipped, not removed — they must stay reachable by name.
+    await expect(page.locator('.sidebar').getByRole('link', { name: 'Invoices' })).toBeAttached();
+  });
+
+  test('collapse toggle is hidden on mobile', async ({ authedPage: page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await expect(page.locator('.sidebar__collapse')).toBeHidden();
   });
 });

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.26.2",
+        "recharts": "^2.15.4",
         "zustand": "^5.0.12"
       },
       "devDependencies": {
@@ -281,6 +282,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -657,6 +667,24 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
@@ -674,6 +702,24 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
@@ -689,6 +735,24 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
@@ -1945,6 +2009,69 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -2717,6 +2844,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2805,8 +2941,128 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -2825,6 +3081,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -2865,6 +3127,16 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -3262,6 +3534,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -3278,6 +3556,15 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-equals": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.1.tgz",
+      "integrity": "sha512-DjlFSM5Pk9cGcL0q5QXl66eGzx0N6szNgaswwc5ZphlBohjTVJSnGgI+rJVOgOi65qUoQnDZN4nDqi33udtydQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -3684,6 +3971,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-binary-path": {
@@ -4152,6 +4448,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -4351,7 +4653,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4735,6 +5036,23 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -4797,6 +5115,12 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -4839,6 +5163,37 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/react-smooth": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -4860,6 +5215,39 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
+      "integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
+      "deprecated": "1.x and 2.x branches are no longer active. Bump to Recharts v3 to receive latest features and bugfixes. See https://github.com/recharts/recharts/wiki/3.0-migration-guide",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^18.3.1",
+        "react-smooth": "^4.0.4",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "license": "MIT",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
       }
     },
     "node_modules/resolve": {
@@ -5210,6 +5598,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -5399,6 +5793,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
+    },
     "node_modules/vite": {
       "version": "5.4.21",
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
@@ -5549,6 +5965,420 @@
         }
       }
     },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/vitest/node_modules/@vitest/mocker": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
@@ -5574,6 +6404,50 @@
         "vite": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/vitest/node_modules/picomatch": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.26.2",
+    "recharts": "^2.15.4",
     "zustand": "^5.0.12"
   },
   "devDependencies": {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,3 +1,4 @@
+import { Suspense, lazy } from 'react';
 import { Navigate, Route, Routes } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { AuthProvider, useAuth } from './context/AuthContext';
@@ -31,6 +32,10 @@ import ChangePasswordPage from './pages/ChangePasswordPage';
 import ApiKeysPage from './pages/ApiKeysPage';
 import EmailHistoryPage from './pages/EmailHistoryPage';
 import Layout from './components/Layout';
+
+// Lazily loaded: this is the only route that pulls in recharts (~100kb gz), and
+// every other route here is imported eagerly — they shouldn't pay for it.
+const AnalyticsPage = lazy(() => import('./pages/AnalyticsPage'));
 
 function Protected({ children }: { children: React.ReactNode }) {
   const { isAuthenticated } = useAuth();
@@ -107,6 +112,7 @@ function AppRoutes() {
       <Route path="/ledgers/new" element={<Protected><CompanyRequired><Layout><LedgerCreatePage /></Layout></CompanyRequired></Protected>} />
       <Route path="/ledgers/:id" element={<Protected><CompanyRequired><Layout><LedgerViewPage /></Layout></CompanyRequired></Protected>} />
       <Route path="/ledgers/:id/edit" element={<Protected><CompanyRequired><Layout><LedgerCreatePage /></Layout></CompanyRequired></Protected>} />
+      <Route path="/analytics" element={<Protected><CompanyRequired><Layout><Suspense fallback={<div className="empty-state">Loading analytics…</div>}><AnalyticsPage /></Suspense></Layout></CompanyRequired></Protected>} />
       <Route path="/day-book" element={<Protected><CompanyRequired><Layout><DayBookPage /></Layout></CompanyRequired></Protected>} />
       <Route path="/tax-ledger" element={<Protected><CompanyRequired><Layout><TaxLedgerPage /></Layout></CompanyRequired></Protected>} />
       <Route path="/cash-bank" element={<Protected><CompanyRequired><Layout><CashBankPage /></Layout></CompanyRequired></Protected>} />

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,7 +1,10 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
 import { useLocation, useNavigate } from 'react-router-dom';
+import { NAV_SHORTCUTS, resolveDocumentTitle } from '../config/navigation';
 import { useShortcuts } from '../context/ShortcutsContext';
+import { useEscapeClose } from '../hooks/useEscapeClose';
+import { useSidebarStore } from '../store/useSidebarStore';
 import Sidebar from './Sidebar';
 import InvoiceCancelDialog from './InvoiceCancelDialog';
 
@@ -9,75 +12,34 @@ export default function Layout({ children }: { children: React.ReactNode }) {
   const location = useLocation();
   const { registerAction } = useShortcuts();
   const navigate = useNavigate();
+  const collapsed = useSidebarStore((state) => state.collapsed);
 
+  // The mobile drawer is ephemeral; only the desktop rail persists.
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
-  useEffect(() => {
-    if (!sidebarOpen) return;
-    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setSidebarOpen(false); };
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, [sidebarOpen]);
+  const closeSidebar = useCallback(() => setSidebarOpen(false), []);
+  useEscapeClose(closeSidebar);
 
   useEffect(() => {
-    const cleanups = [
-      registerAction('go_invoices', () => navigate('/invoices')),
-      registerAction('go_ledgers', () => navigate('/ledgers')),
-      registerAction('go_products', () => navigate('/products')),
-      registerAction('go_inventory', () => navigate('/inventory')),
-      registerAction('go_products_inventory', () => navigate('/products-inventory')),
-      registerAction('go_day_book', () => navigate('/day-book')),
-      registerAction('go_tax_ledger', () => navigate('/tax-ledger')),
-      registerAction('open_reports', () => navigate('/day-book')),
-      registerAction('new_customer', () => navigate('/ledgers/new')),
-    ];
+    const cleanups = NAV_SHORTCUTS.map(({ action, to }) =>
+      registerAction(action, () => navigate(to)),
+    );
     return () => cleanups.forEach(fn => fn());
   }, [registerAction, navigate]);
 
   useEffect(() => {
-    const routeTitles: Record<string, string> = {
-      '/': 'Dashboard',
-      '/products': 'Products',
-      '/inventory': 'Inventory',
-      '/products-inventory': 'Products & Inventory',
-      '/ledgers': 'Ledgers',
-      '/ledgers/new': 'New Ledger',
-      '/day-book': 'Day Book',
-      '/tax-ledger': 'Tax Ledger',
-      '/cash-bank': 'Cash & Bank',
-      '/cash-bank/accounts': 'Bank Accounts',
-      '/invoices': 'Invoices',
-      '/invoice-dues': 'Invoice Dues',
-      '/invoices-view': 'Advanced Invoice View',
-      '/credit-notes': 'Credit Notes',
-      '/company': 'Company Profile',
-      '/smtp-settings': 'Email Settings',
-      '/backups': 'Database Backups',
-      '/shortcuts': 'Keyboard Shortcuts',
-      '/change-password': 'Security',
-      '/api-keys': 'API Keys',
-    };
-
-
-    let pageName = 'Simple Invoicing';
-    if (location.pathname.startsWith('/ledgers/')) {
-      pageName = location.pathname.endsWith('/edit') ? 'Edit Ledger' : 'View Ledger';
-    } else {
-      pageName = routeTitles[location.pathname] || 'Simple Invoicing';
-    }
-
-    document.title = `${pageName} | Simple Invoicing`;
+    document.title = `${resolveDocumentTitle(location.pathname)} | Simple Invoicing`;
   }, [location.pathname]);
 
   return (
-    <div className="app-shell">
+    <div className={`app-shell${collapsed ? ' app-shell--rail' : ''}`}>
       <div className="app-shell__sidebar">
-        <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
+        <Sidebar isOpen={sidebarOpen} onClose={closeSidebar} />
       </div>
       {sidebarOpen && (
         <div
           className="sidebar-backdrop"
-          onClick={() => setSidebarOpen(false)}
+          onClick={closeSidebar}
           aria-hidden="true"
         />
       )}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,362 +1,106 @@
-import { useEffect, useRef, useState } from 'react';
-import axios from 'axios';
-import { AnimatePresence, motion } from 'framer-motion';
+import { LogOut, PanelLeftClose, PanelLeftOpen } from 'lucide-react';
 import { Link, NavLink } from 'react-router-dom';
-import CompanySelector from './CompanySelector';
+import SidebarFYSwitcher from './SidebarFYSwitcher';
+import { visibleNavGroups } from '../config/navigation';
 import { useAuth } from '../context/AuthContext';
-import { useFY } from '../context/FYContext';
-
-type NavItem = { to: string; label: string; end?: boolean };
+import { useSidebarStore } from '../store/useSidebarStore';
 
 interface SidebarProps {
   isOpen?: boolean;
   onClose?: () => void;
 }
 
-const mainGroup: NavItem[] = [
-  { to: '/', label: 'Overview', end: true },
-  { to: '/invoices', label: 'Invoices' },
-  { to: '/invoice-dues', label: 'Invoice Dues' },
-  { to: '/credit-notes', label: 'Credit Notes' },
-  { to: '/day-book', label: 'Day Book' },
-  { to: '/tax-ledger', label: 'Tax Ledger' },
-  { to: '/cash-bank', label: 'Cash & Bank' },
-];
-
-const managementGroup: NavItem[] = [
-  { to: '/products', label: 'Products' },
-  { to: '/inventory', label: 'Inventory' },
-  { to: '/products-inventory', label: 'Products & Inventory' },
-  { to: '/produce-items', label: 'Produce Items' },
-  { to: '/ledgers', label: 'Ledgers' },
-  { to: '/company', label: 'Company' },
-];
-
-const settingsGroup = (isAdmin: boolean): NavItem[] => [
-  ...(isAdmin ? [{ to: '/smtp-settings', label: 'SMTP Settings' }] : []),
-  ...(isAdmin ? [{ to: '/backups', label: 'Backups' }] : []),
-  ...(isAdmin ? [{ to: '/email-history', label: 'Email History' }] : []),
-  ...(isAdmin ? [{ to: '/api-keys', label: 'API Keys' }] : []),
-  { to: '/change-password', label: 'Change Password' },
-  { to: '/shortcuts', label: 'Keyboard Shortcuts' },
-];
-
-function fyFromStartYear(year: number) {
-  const end = year + 1;
-  return {
-    label: `${year}-${String(end).slice(-2)}`,
-    start_date: `${year}-04-01`,
-    end_date: `${end}-03-31`,
-  };
-}
-
 export default function Sidebar({ isOpen = false, onClose }: SidebarProps) {
-  const { isAdmin, isAuthenticated, userEmail, logout } = useAuth();
-  const showCompanySwitcher = isAuthenticated;
-  const { activeFY, fyList, switchFY, createFY } = useFY();
+  const { isAdmin, userEmail, logout } = useAuth();
+  const { collapsed, toggleCollapsed } = useSidebarStore();
+  const groups = visibleNavGroups(isAdmin);
 
-  const [fyDropdownOpen, setFyDropdownOpen] = useState(false);
-  const [newFYModalOpen, setNewFYModalOpen] = useState(false);
-  const [newFYStartYear, setNewFYStartYear] = useState('');
-  const [newFYError, setNewFYError] = useState('');
-  const [newFYSubmitting, setNewFYSubmitting] = useState(false);
-  const fyDropdownRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!fyDropdownOpen) return;
-    const onClickOutside = (e: MouseEvent) => {
-      if (fyDropdownRef.current && !fyDropdownRef.current.contains(e.target as Node)) {
-        setFyDropdownOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', onClickOutside);
-    return () => document.removeEventListener('mousedown', onClickOutside);
-  }, [fyDropdownOpen]);
-
-  useEffect(() => {
-    if (!isOpen) return;
-    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose?.(); };
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, [isOpen, onClose]);
+  // Escape-to-close lives in Layout, which owns the drawer state.
 
   return (
-    <>
-      <aside
-        className={`sidebar${isOpen ? ' sidebar--open' : ''}`}
-        {...(isOpen ? { role: 'dialog', 'aria-modal': 'true', 'aria-label': 'Navigation drawer' } : {})}
-      >
-        <div className="sidebar__header">
-          <button
-            className="sidebar__close"
-            onClick={onClose}
-            aria-label="Close navigation"
+    <aside
+      className={`sidebar${isOpen ? ' sidebar--open' : ''}`}
+      {...(isOpen ? { role: 'dialog', 'aria-modal': 'true', 'aria-label': 'Navigation drawer' } : {})}
+    >
+      <div className="sidebar__header">
+        <button
+          className="sidebar__close"
+          onClick={onClose}
+          aria-label="Close navigation"
+        >
+          ✕
+        </button>
+        <Link to="/" className="sidebar__brand" onClick={() => onClose?.()}>
+          <span>⚡</span>
+          <div>
+            <span className="sidebar__brand-name">Simple Invoicing</span>
+            <span className="sidebar__brand-tagline">Stock &amp; billing</span>
+          </div>
+        </Link>
+        <button
+          className="sidebar__collapse"
+          onClick={toggleCollapsed}
+          aria-label={collapsed ? 'Expand navigation' : 'Collapse navigation'}
+          aria-expanded={!collapsed}
+          aria-controls="sidebar-nav"
+        >
+          {collapsed ? <PanelLeftOpen size={18} aria-hidden="true" /> : <PanelLeftClose size={18} aria-hidden="true" />}
+        </button>
+      </div>
+
+      <nav className="sidebar__nav" id="sidebar-nav" aria-label="Sidebar navigation">
+        {groups.map((group) => (
+          <div
+            className="sidebar__group"
+            key={group.id}
+            role="group"
+            {...(group.label ? { 'aria-labelledby': `nav-group-${group.id}` } : {})}
           >
-            ✕
-          </button>
-          <Link to="/" className="sidebar__brand" onClick={() => onClose?.()}>
-            <span>⚡</span>
-            <div>
-              <span className="sidebar__brand-name">Simple Invoicing</span>
-              <span className="sidebar__brand-tagline">Stock &amp; billing</span>
-            </div>
-          </Link>
-        </div>
-
-        <nav className="sidebar__nav" aria-label="Sidebar navigation">
-          {/* Main group — no label */}
-          <div className="sidebar__group">
-            {mainGroup.map((item) => (
-              <NavLink
-                key={item.to}
-                to={item.to}
-                end={item.end}
-                className={({ isActive }) =>
-                  `sidebar__link${isActive ? ' sidebar__link--active' : ''}`
-                }
-                onClick={() => onClose?.()}
-              >
-                {item.label}
-              </NavLink>
-            ))}
-          </div>
-
-          {/* Management group */}
-          <div className="sidebar__group">
-            <p className="sidebar__group-label">Management</p>
-            {managementGroup.map((item) => (
-              <NavLink
-                key={item.to}
-                to={item.to}
-                className={({ isActive }) =>
-                  `sidebar__link${isActive ? ' sidebar__link--active' : ''}`
-                }
-                onClick={() => onClose?.()}
-              >
-                {item.label}
-              </NavLink>
-            ))}
-          </div>
-
-          {/* Settings group */}
-          <div className="sidebar__group">
-            <p className="sidebar__group-label">Settings</p>
-            {settingsGroup(isAdmin).map((item) => (
-              <NavLink
-                key={item.to}
-                to={item.to}
-                className={({ isActive }) =>
-                  `sidebar__link${isActive ? ' sidebar__link--active' : ''}`
-                }
-                onClick={() => onClose?.()}
-              >
-                {item.label}
-              </NavLink>
-            ))}
-          </div>
-        </nav>
-
-        {/* FY section — above footer */}
-        <div style={{ padding: '12px 10px', borderTop: '1px solid var(--sidebar-border)' }}>
-          {showCompanySwitcher && <CompanySelector />}
-
-          <p className="sidebar__group-label" style={{ marginBottom: '6px' }}>Financial Year</p>
-          <div ref={fyDropdownRef} style={{ position: 'relative' }}>
-            <button
-              className="button button--ghost"
-              style={{ width: '100%', textAlign: 'left', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}
-              onClick={() => setFyDropdownOpen((v) => !v)}
-              aria-haspopup="listbox"
-              aria-expanded={fyDropdownOpen}
-            >
-              <span>{activeFY ? activeFY.label : 'No active FY'}</span>
-              <span style={{ fontSize: '0.75rem', opacity: 0.6 }}>▾</span>
-            </button>
-            {fyDropdownOpen && (
-              <div
-                role="listbox"
-                style={{
-                  position: 'absolute',
-                  left: 0,
-                  right: 0,
-                  top: 'calc(100% + 4px)',
-                  background: 'var(--bg-card-strong)',
-                  border: '1px solid var(--line-strong)',
-                  borderRadius: '0.5rem',
-                  boxShadow: '0 4px 24px rgba(0,0,0,0.45)',
-                  zIndex: 100,
-                  overflow: 'hidden',
-                  color: 'var(--text)',
-                }}
-              >
-                {fyList.length === 0 && (
-                  <p style={{ padding: '0.5rem 0.75rem', fontSize: '0.85rem', opacity: 0.6 }}>No financial years</p>
-                )}
-                {fyList.map((fy) => (
-                  <button
-                    key={fy.id}
-                    role="option"
-                    aria-selected={fy.is_active}
-                    style={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: '0.5rem',
-                      width: '100%',
-                      textAlign: 'left',
-                      padding: '0.5rem 0.75rem',
-                      background: 'none',
-                      border: 'none',
-                      cursor: 'pointer',
-                      fontWeight: fy.is_active ? 700 : 400,
-                      fontSize: '0.875rem',
-                      color: 'inherit',
-                    }}
-                    onClick={() => {
-                      switchFY(fy.id);
-                      setFyDropdownOpen(false);
-                    }}
-                  >
-                    <span style={{ width: '1rem' }}>{fy.is_active ? '✓' : ''}</span>
-                    {fy.label}
-                  </button>
-                ))}
-                <hr style={{ margin: '0.25rem 0', border: 'none', borderTop: '1px solid var(--line)' }} />
-                <button
-                  style={{
-                    display: 'block',
-                    width: '100%',
-                    textAlign: 'left',
-                    padding: '0.5rem 0.75rem',
-                    background: 'none',
-                    border: 'none',
-                    cursor: 'pointer',
-                    fontSize: '0.875rem',
-                    color: 'inherit',
-                    fontWeight: 500,
-                  }}
-                  onClick={() => {
-                    setFyDropdownOpen(false);
-                    setNewFYStartYear('');
-                    setNewFYError('');
-                    setNewFYModalOpen(true);
-                  }}
-                >
-                  + New FY
-                </button>
-              </div>
+            {group.label && (
+              <p className="sidebar__group-label" id={`nav-group-${group.id}`}>
+                {group.label}
+              </p>
             )}
+            {group.items.map((item) => {
+              const Icon = item.icon;
+              return (
+                <NavLink
+                  key={item.to}
+                  to={item.to}
+                  end={item.end}
+                  className={({ isActive }) =>
+                    `sidebar__link${isActive ? ' sidebar__link--active' : ''}`
+                  }
+                  onClick={() => onClose?.()}
+                  // Tooltip stands in for the label once the rail collapses.
+                  title={item.label}
+                >
+                  <Icon size={18} aria-hidden="true" />
+                  <span className="sidebar__link-label">{item.label}</span>
+                </NavLink>
+              );
+            })}
+          </div>
+        ))}
+      </nav>
+
+      <SidebarFYSwitcher />
+
+      <div className="sidebar__footer">
+        <div className="sidebar__user">
+          <div className="sidebar__user-avatar">
+            {userEmail ? userEmail[0].toUpperCase() : 'U'}
+          </div>
+          <div className="sidebar__user-meta">
+            <span className="sidebar__user-email">{userEmail ?? 'Active user'}</span>
+            <span className="sidebar__user-role">{isAdmin ? 'Admin' : 'User'}</span>
           </div>
         </div>
-
-        <div className="sidebar__footer">
-          <div className="sidebar__user">
-            <div className="sidebar__user-avatar">
-              {userEmail ? userEmail[0].toUpperCase() : 'U'}
-            </div>
-            <div>
-              <span className="sidebar__user-email">{userEmail ?? 'Active user'}</span>
-              <span className="sidebar__user-role">{isAdmin ? 'Admin' : 'User'}</span>
-            </div>
-          </div>
-          <button className="button button--ghost" onClick={logout}>
-            Logout
-          </button>
-        </div>
-      </aside>
-
-      {/* New FY Modal */}
-      <AnimatePresence>
-        {newFYModalOpen && (
-          <motion.div
-            className="modal-overlay"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: 0.2 }}
-            onClick={(e) => { if (e.target === e.currentTarget) setNewFYModalOpen(false); }}
-          >
-            <motion.div
-              className="modal-panel"
-              role="dialog"
-              aria-modal="true"
-              aria-label="Create new financial year"
-              initial={{ scale: 0.95, opacity: 0 }}
-              animate={{ scale: 1, opacity: 1 }}
-              exit={{ scale: 0.95, opacity: 0 }}
-              transition={{ duration: 0.2 }}
-              style={{ maxWidth: '28rem' }}
-            >
-              <h2 style={{ marginBottom: '1.25rem', fontSize: '1.125rem', fontWeight: 700 }}>New Financial Year</h2>
-              <form
-                onSubmit={async (e) => {
-                  e.preventDefault();
-                  const yr = parseInt(newFYStartYear, 10);
-                  if (isNaN(yr) || yr < 2000 || yr > 2099) {
-                    setNewFYError('Please enter a valid starting year (2000–2099).');
-                    return;
-                  }
-                  const { label, start_date, end_date } = fyFromStartYear(yr);
-                  if (fyList.some((fy) => fy.label === label)) {
-                    setNewFYError(`Financial year ${label} already exists.`);
-                    return;
-                  }
-                  setNewFYError('');
-                  setNewFYSubmitting(true);
-                  try {
-                    await createFY(label, start_date, end_date);
-                    setNewFYModalOpen(false);
-                  } catch (err) {
-                    if (axios.isAxiosError(err) && err.response?.status === 409) {
-                      setNewFYError(`Financial year ${label} already exists.`);
-                    } else {
-                      setNewFYError('Failed to create financial year. Please try again.');
-                    }
-                  } finally {
-                    setNewFYSubmitting(false);
-                  }
-                }}
-              >
-                <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
-                  <label style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem', fontSize: '0.875rem', fontWeight: 500 }}>
-                    Starting year (e.g. 2025)
-                    <input
-                      className="input"
-                      type="number"
-                      min="2000"
-                      max="2099"
-                      value={newFYStartYear}
-                      onChange={(e) => setNewFYStartYear(e.target.value)}
-                      autoFocus
-                    />
-                  </label>
-                  {newFYStartYear && (() => {
-                    const yr = parseInt(newFYStartYear, 10);
-                    if (!isNaN(yr) && yr >= 2000 && yr <= 2099) {
-                      const p = fyFromStartYear(yr);
-                      return (
-                        <p style={{ fontSize: '0.825rem', opacity: 0.7, margin: 0 }}>
-                          FY {p.label} · Apr 1, {yr} → Mar 31, {yr + 1}
-                        </p>
-                      );
-                    }
-                    return null;
-                  })()}
-                  {newFYError && <p style={{ color: 'var(--error, #ef4444)', fontSize: '0.85rem' }}>{newFYError}</p>}
-                  <div style={{ display: 'flex', gap: '0.75rem', justifyContent: 'flex-end', marginTop: '0.5rem' }}>
-                    <button type="button" className="button button--ghost" onClick={() => setNewFYModalOpen(false)}>
-                      Cancel
-                    </button>
-                    <button type="submit" className="button" disabled={newFYSubmitting}>
-                      {newFYSubmitting ? 'Creating…' : 'Create'}
-                    </button>
-                  </div>
-                </div>
-              </form>
-            </motion.div>
-          </motion.div>
-        )}
-      </AnimatePresence>
-    </>
+        <button className="button button--ghost sidebar__logout" onClick={logout} title="Logout">
+          <LogOut size={16} aria-hidden="true" />
+          <span className="sidebar__link-label">Logout</span>
+        </button>
+      </div>
+    </aside>
   );
 }
-

--- a/frontend/src/components/SidebarFYSwitcher.tsx
+++ b/frontend/src/components/SidebarFYSwitcher.tsx
@@ -1,0 +1,244 @@
+import { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import axios from 'axios';
+import { AnimatePresence, motion } from 'framer-motion';
+import CompanySelector from './CompanySelector';
+import { useAuth } from '../context/AuthContext';
+import { useFY } from '../context/FYContext';
+
+/**
+ * Company selector + financial-year dropdown + "New FY" modal.
+ *
+ * Extracted from Sidebar.tsx — behaviour and styling are unchanged — so that
+ * the sidebar's own file stays about navigation.
+ *
+ * The modal is portalled to document.body because this component renders inside
+ * <aside class="sidebar">, which takes `transform: translateX()` on mobile. A
+ * transformed ancestor becomes the containing block for position:fixed
+ * descendants, so an inline .modal-overlay would slide off-screen with the
+ * drawer instead of covering the viewport.
+ */
+
+function fyFromStartYear(year: number) {
+  const end = year + 1;
+  return {
+    label: `${year}-${String(end).slice(-2)}`,
+    start_date: `${year}-04-01`,
+    end_date: `${end}-03-31`,
+  };
+}
+
+export default function SidebarFYSwitcher() {
+  const { isAuthenticated } = useAuth();
+  const showCompanySwitcher = isAuthenticated;
+  const { activeFY, fyList, switchFY, createFY } = useFY();
+
+  const [fyDropdownOpen, setFyDropdownOpen] = useState(false);
+  const [newFYModalOpen, setNewFYModalOpen] = useState(false);
+  const [newFYStartYear, setNewFYStartYear] = useState('');
+  const [newFYError, setNewFYError] = useState('');
+  const [newFYSubmitting, setNewFYSubmitting] = useState(false);
+  const fyDropdownRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!fyDropdownOpen) return;
+    const onClickOutside = (e: MouseEvent) => {
+      if (fyDropdownRef.current && !fyDropdownRef.current.contains(e.target as Node)) {
+        setFyDropdownOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', onClickOutside);
+    return () => document.removeEventListener('mousedown', onClickOutside);
+  }, [fyDropdownOpen]);
+
+  return (
+    <>
+      <div className="sidebar__fy">
+        {showCompanySwitcher && <CompanySelector />}
+
+        <p className="sidebar__group-label" style={{ marginBottom: '6px' }}>Financial Year</p>
+        <div ref={fyDropdownRef} style={{ position: 'relative' }}>
+          <button
+            className="button button--ghost"
+            style={{ width: '100%', textAlign: 'left', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}
+            onClick={() => setFyDropdownOpen((v) => !v)}
+            aria-haspopup="listbox"
+            aria-expanded={fyDropdownOpen}
+          >
+            <span>{activeFY ? activeFY.label : 'No active FY'}</span>
+            <span style={{ fontSize: '0.75rem', opacity: 0.6 }}>▾</span>
+          </button>
+          {fyDropdownOpen && (
+            <div
+              role="listbox"
+              style={{
+                position: 'absolute',
+                left: 0,
+                right: 0,
+                top: 'calc(100% + 4px)',
+                background: 'var(--bg-card-strong)',
+                border: '1px solid var(--line-strong)',
+                borderRadius: '0.5rem',
+                boxShadow: '0 4px 24px rgba(0,0,0,0.45)',
+                zIndex: 100,
+                overflow: 'hidden',
+                color: 'var(--text)',
+              }}
+            >
+              {fyList.length === 0 && (
+                <p style={{ padding: '0.5rem 0.75rem', fontSize: '0.85rem', opacity: 0.6 }}>No financial years</p>
+              )}
+              {fyList.map((fy) => (
+                <button
+                  key={fy.id}
+                  role="option"
+                  aria-selected={fy.is_active}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '0.5rem',
+                    width: '100%',
+                    textAlign: 'left',
+                    padding: '0.5rem 0.75rem',
+                    background: 'none',
+                    border: 'none',
+                    cursor: 'pointer',
+                    fontWeight: fy.is_active ? 700 : 400,
+                    fontSize: '0.875rem',
+                    color: 'inherit',
+                  }}
+                  onClick={() => {
+                    switchFY(fy.id);
+                    setFyDropdownOpen(false);
+                  }}
+                >
+                  <span style={{ width: '1rem' }}>{fy.is_active ? '✓' : ''}</span>
+                  {fy.label}
+                </button>
+              ))}
+              <hr style={{ margin: '0.25rem 0', border: 'none', borderTop: '1px solid var(--line)' }} />
+              <button
+                style={{
+                  display: 'block',
+                  width: '100%',
+                  textAlign: 'left',
+                  padding: '0.5rem 0.75rem',
+                  background: 'none',
+                  border: 'none',
+                  cursor: 'pointer',
+                  fontSize: '0.875rem',
+                  color: 'inherit',
+                  fontWeight: 500,
+                }}
+                onClick={() => {
+                  setFyDropdownOpen(false);
+                  setNewFYStartYear('');
+                  setNewFYError('');
+                  setNewFYModalOpen(true);
+                }}
+              >
+                + New FY
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* New FY Modal — portalled; see the note at the top of this file. */}
+      {createPortal(
+        <AnimatePresence>
+          {newFYModalOpen && (
+          <motion.div
+            className="modal-overlay"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            onClick={(e) => { if (e.target === e.currentTarget) setNewFYModalOpen(false); }}
+          >
+            <motion.div
+              className="modal-panel"
+              role="dialog"
+              aria-modal="true"
+              aria-label="Create new financial year"
+              initial={{ scale: 0.95, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              exit={{ scale: 0.95, opacity: 0 }}
+              transition={{ duration: 0.2 }}
+              style={{ maxWidth: '28rem' }}
+            >
+              <h2 style={{ marginBottom: '1.25rem', fontSize: '1.125rem', fontWeight: 700 }}>New Financial Year</h2>
+              <form
+                onSubmit={async (e) => {
+                  e.preventDefault();
+                  const yr = parseInt(newFYStartYear, 10);
+                  if (isNaN(yr) || yr < 2000 || yr > 2099) {
+                    setNewFYError('Please enter a valid starting year (2000–2099).');
+                    return;
+                  }
+                  const { label, start_date, end_date } = fyFromStartYear(yr);
+                  if (fyList.some((fy) => fy.label === label)) {
+                    setNewFYError(`Financial year ${label} already exists.`);
+                    return;
+                  }
+                  setNewFYError('');
+                  setNewFYSubmitting(true);
+                  try {
+                    await createFY(label, start_date, end_date);
+                    setNewFYModalOpen(false);
+                  } catch (err) {
+                    if (axios.isAxiosError(err) && err.response?.status === 409) {
+                      setNewFYError(`Financial year ${label} already exists.`);
+                    } else {
+                      setNewFYError('Failed to create financial year. Please try again.');
+                    }
+                  } finally {
+                    setNewFYSubmitting(false);
+                  }
+                }}
+              >
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+                  <label style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem', fontSize: '0.875rem', fontWeight: 500 }}>
+                    Starting year (e.g. 2025)
+                    <input
+                      className="input"
+                      type="number"
+                      min="2000"
+                      max="2099"
+                      value={newFYStartYear}
+                      onChange={(e) => setNewFYStartYear(e.target.value)}
+                      autoFocus
+                    />
+                  </label>
+                  {newFYStartYear && (() => {
+                    const yr = parseInt(newFYStartYear, 10);
+                    if (!isNaN(yr) && yr >= 2000 && yr <= 2099) {
+                      const p = fyFromStartYear(yr);
+                      return (
+                        <p style={{ fontSize: '0.825rem', opacity: 0.7, margin: 0 }}>
+                          FY {p.label} · Apr 1, {yr} → Mar 31, {yr + 1}
+                        </p>
+                      );
+                    }
+                    return null;
+                  })()}
+                  {newFYError && <p style={{ color: 'var(--error, #ef4444)', fontSize: '0.85rem' }}>{newFYError}</p>}
+                  <div style={{ display: 'flex', gap: '0.75rem', justifyContent: 'flex-end', marginTop: '0.5rem' }}>
+                    <button type="button" className="button button--ghost" onClick={() => setNewFYModalOpen(false)}>
+                      Cancel
+                    </button>
+                    <button type="submit" className="button" disabled={newFYSubmitting}>
+                      {newFYSubmitting ? 'Creating…' : 'Create'}
+                    </button>
+                  </div>
+                </div>
+              </form>
+            </motion.div>
+          </motion.div>
+          )}
+        </AnimatePresence>,
+        document.body,
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/Tabs.tsx
+++ b/frontend/src/components/Tabs.tsx
@@ -1,0 +1,105 @@
+import { useRef } from 'react';
+
+/**
+ * Accessible tab bar.
+ *
+ * Keeps the app's existing segmented-control look (button--primary for the
+ * selected tab, button--ghost otherwise — the idiom TaxLedgerPage and
+ * InvoicesAdvancedView already use by hand) while adding the ARIA roles and
+ * arrow-key navigation those ad-hoc versions lack. They can adopt this later.
+ */
+
+export type TabItem<T extends string> = {
+  id: T;
+  label: string;
+};
+
+type TabsProps<T extends string> = {
+  tabs: TabItem<T>[];
+  value: T;
+  onChange: (id: T) => void;
+  /** Accessible name for the tablist. */
+  label: string;
+  /** id of the panel each tab controls, derived from the tab id. */
+  panelId?: (id: T) => string;
+};
+
+export function tabPanelId(id: string) {
+  return `tabpanel-${id}`;
+}
+
+export function tabId(id: string) {
+  return `tab-${id}`;
+}
+
+export default function Tabs<T extends string>({
+  tabs,
+  value,
+  onChange,
+  label,
+  panelId = tabPanelId,
+}: TabsProps<T>) {
+  const refs = useRef<Record<string, HTMLButtonElement | null>>({});
+
+  const focusTab = (id: T) => {
+    onChange(id);
+    refs.current[id]?.focus();
+  };
+
+  const onKeyDown = (event: React.KeyboardEvent) => {
+    const index = tabs.findIndex((tab) => tab.id === value);
+    if (index === -1) return;
+
+    if (event.key === 'ArrowRight' || event.key === 'ArrowLeft') {
+      event.preventDefault();
+      const offset = event.key === 'ArrowRight' ? 1 : -1;
+      // Wrap around, per the WAI-ARIA tabs pattern.
+      focusTab(tabs[(index + offset + tabs.length) % tabs.length].id);
+    } else if (event.key === 'Home') {
+      event.preventDefault();
+      focusTab(tabs[0].id);
+    } else if (event.key === 'End') {
+      event.preventDefault();
+      focusTab(tabs[tabs.length - 1].id);
+    }
+  };
+
+  return (
+    <div className="tab-bar" role="tablist" aria-label={label} onKeyDown={onKeyDown}>
+      {tabs.map((tab) => {
+        const selected = tab.id === value;
+        return (
+          <button
+            key={tab.id}
+            ref={(node) => { refs.current[tab.id] = node; }}
+            id={tabId(tab.id)}
+            role="tab"
+            type="button"
+            aria-selected={selected}
+            aria-controls={panelId(tab.id)}
+            // Roving tabindex: only the selected tab is in the tab order.
+            tabIndex={selected ? 0 : -1}
+            className={`button ${selected ? 'button--primary' : 'button--ghost'}`}
+            onClick={() => onChange(tab.id)}
+          >
+            {tab.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+export function TabPanel({
+  id,
+  children,
+}: {
+  id: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div role="tabpanel" id={tabPanelId(id)} aria-labelledby={tabId(id)} tabIndex={0}>
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/config/navigation.test.ts
+++ b/frontend/src/config/navigation.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+import {
+  FALLBACK_TITLE,
+  NAV_ITEMS,
+  NAV_SHORTCUTS,
+  ROUTE_TITLES,
+  resolveDocumentTitle,
+  visibleNavGroups,
+} from './navigation';
+import { ACTION_KEYS } from '../utils/shortcutDefaults';
+
+describe('resolveDocumentTitle', () => {
+  it('titles a static route from its nav item', () => {
+    expect(resolveDocumentTitle('/invoices')).toBe('Invoices');
+  });
+
+  it('prefers an explicit title over the sidebar label', () => {
+    // The sidebar says "Overview"; the title bar has always said "Dashboard".
+    expect(resolveDocumentTitle('/')).toBe('Dashboard');
+    expect(resolveDocumentTitle('/company')).toBe('Company Profile');
+  });
+
+  it('titles the routes that the old hand-written map had missed', () => {
+    expect(resolveDocumentTitle('/produce-items')).toBe('Produce Items');
+    expect(resolveDocumentTitle('/email-history')).toBe('Email History');
+  });
+
+  it('titles hidden routes', () => {
+    expect(resolveDocumentTitle('/invoices-view')).toBe('Advanced Invoice View');
+  });
+
+  it('titles child paths declared via alsoTitles', () => {
+    expect(resolveDocumentTitle('/cash-bank/accounts')).toBe('Bank Accounts');
+  });
+
+  it('titles dynamic ledger routes', () => {
+    expect(resolveDocumentTitle('/ledgers/42')).toBe('View Ledger');
+    expect(resolveDocumentTitle('/ledgers/42/edit')).toBe('Edit Ledger');
+  });
+
+  it('prefers an exact match over the dynamic ledger patterns', () => {
+    expect(resolveDocumentTitle('/ledgers/new')).toBe('New Ledger');
+    expect(resolveDocumentTitle('/ledgers')).toBe('Ledgers');
+  });
+
+  it('falls back for unknown paths', () => {
+    expect(resolveDocumentTitle('/nope')).toBe(FALLBACK_TITLE);
+  });
+});
+
+describe('visibleNavGroups', () => {
+  it('hides admin-only items from non-admins', () => {
+    const paths = visibleNavGroups(false).flatMap((group) => group.items.map((item) => item.to));
+    expect(paths).not.toContain('/api-keys');
+    expect(paths).not.toContain('/smtp-settings');
+    expect(paths).toContain('/change-password');
+  });
+
+  it('shows admin-only items to admins', () => {
+    const paths = visibleNavGroups(true).flatMap((group) => group.items.map((item) => item.to));
+    expect(paths).toContain('/api-keys');
+    expect(paths).toContain('/smtp-settings');
+  });
+
+  it('never surfaces hidden items', () => {
+    for (const isAdmin of [true, false]) {
+      const paths = visibleNavGroups(isAdmin).flatMap((group) => group.items.map((item) => item.to));
+      expect(paths).not.toContain('/invoices-view');
+      expect(paths).not.toContain('/ledgers/new');
+    }
+  });
+
+  it('still titles hidden items even though they are not linked', () => {
+    expect(ROUTE_TITLES['/invoices-view']).toBeDefined();
+    expect(ROUTE_TITLES['/ledgers/new']).toBeDefined();
+  });
+
+  it('drops groups left empty after filtering', () => {
+    for (const group of visibleNavGroups(false)) {
+      expect(group.items.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('exposes an Analytics group containing the analytics route', () => {
+    const analytics = visibleNavGroups(false).find((group) => group.id === 'analytics');
+    expect(analytics?.label).toBe('Analytics');
+    expect(analytics?.items.map((item) => item.to)).toContain('/analytics');
+  });
+
+  it('gives every item an icon', () => {
+    for (const item of NAV_ITEMS) {
+      expect(item.icon).toBeDefined();
+    }
+  });
+});
+
+describe('NAV_SHORTCUTS', () => {
+  it('only uses action keys the shortcut system knows about', () => {
+    // TypeScript enforces this too, but the backend keeps its own DEFAULTS dict
+    // and rejects unknown keys with a 400 — so adding a nav shortcut means
+    // touching backend/src/api/routes/shortcuts.py as well.
+    for (const { action } of NAV_SHORTCUTS) {
+      expect(ACTION_KEYS).toContain(action);
+    }
+  });
+
+  it('points every shortcut at a registered route', () => {
+    const paths = NAV_ITEMS.map((item) => item.to);
+    for (const { to } of NAV_SHORTCUTS) {
+      expect(paths).toContain(to);
+    }
+  });
+
+  it('declares no duplicate actions', () => {
+    const actions = NAV_SHORTCUTS.map((entry) => entry.action);
+    expect(new Set(actions).size).toBe(actions.length);
+  });
+
+  it('routes open_reports to analytics', () => {
+    // It used to land on /day-book, which was never what the name meant.
+    expect(NAV_SHORTCUTS.find((entry) => entry.action === 'open_reports')?.to).toBe('/analytics');
+  });
+});

--- a/frontend/src/config/navigation.ts
+++ b/frontend/src/config/navigation.ts
@@ -1,0 +1,176 @@
+import {
+  AlarmClock,
+  BookOpen,
+  Boxes,
+  Building2,
+  ChartColumn,
+  DatabaseBackup,
+  Factory,
+  FileMinus2,
+  FileText,
+  KeyRound,
+  Keyboard,
+  LayoutDashboard,
+  Lock,
+  Mail,
+  MailCheck,
+  Package,
+  PackageSearch,
+  Percent,
+  Users,
+  Wallet,
+  type LucideIcon,
+} from 'lucide-react';
+import type { ActionKey } from '../utils/shortcutDefaults';
+
+/**
+ * Single source of truth for navigation.
+ *
+ * Sidebar links, document titles, and keyboard-shortcut nav targets all derive
+ * from NAV_GROUPS below. Before this existed the three lived in three files and
+ * had already drifted — /produce-items and /email-history had no title at all,
+ * and '/' was "Dashboard" in the title bar but "Overview" in the sidebar.
+ *
+ * Routes and guards deliberately stay in App.tsx: it composes four guards in
+ * five different combinations, which costs more to express as data than it
+ * saves. `adminOnly` here therefore duplicates <AdminOnly> there — it only
+ * controls whether a link is *shown*; the route guard remains authoritative.
+ */
+
+export type NavItem = {
+  to: string;
+  /** Sidebar label. */
+  label: string;
+  /** document.title, when it should differ from the sidebar label. */
+  title?: string;
+  icon: LucideIcon;
+  /** NavLink `end` — only '/' needs it. */
+  end?: boolean;
+  /** Hide the link from admins-only users. Visibility only; see file header. */
+  adminOnly?: boolean;
+  /** Routed but intentionally not linked in the sidebar. */
+  hidden?: boolean;
+  shortcutAction?: ActionKey;
+  /** Child paths that share this item's identity for titling purposes. */
+  alsoTitles?: { path: string; title: string }[];
+};
+
+export type NavGroup = {
+  id: string;
+  /** null renders the group without a heading. */
+  label: string | null;
+  items: NavItem[];
+};
+
+export const NAV_GROUPS: NavGroup[] = [
+  {
+    id: 'main',
+    label: null,
+    items: [
+      { to: '/', label: 'Overview', title: 'Dashboard', icon: LayoutDashboard, end: true },
+      { to: '/invoices', label: 'Invoices', icon: FileText, shortcutAction: 'go_invoices' },
+      { to: '/invoice-dues', label: 'Invoice Dues', icon: AlarmClock },
+      { to: '/credit-notes', label: 'Credit Notes', icon: FileMinus2 },
+      {
+        to: '/cash-bank',
+        label: 'Cash & Bank',
+        icon: Wallet,
+        alsoTitles: [{ path: '/cash-bank/accounts', title: 'Bank Accounts' }],
+      },
+      { to: '/invoices-view', label: 'Advanced Invoice View', icon: FileText, hidden: true },
+    ],
+  },
+  {
+    id: 'analytics',
+    label: 'Analytics',
+    // Day Book and Tax Ledger live here rather than under the main group: they
+    // are reports, and grouping them keeps Analytics from being a lone item.
+    items: [
+      { to: '/analytics', label: 'Analytics', icon: ChartColumn, shortcutAction: 'open_reports' },
+      { to: '/day-book', label: 'Day Book', icon: BookOpen, shortcutAction: 'go_day_book' },
+      { to: '/tax-ledger', label: 'Tax Ledger', icon: Percent, shortcutAction: 'go_tax_ledger' },
+    ],
+  },
+  {
+    id: 'catalogue',
+    label: 'Catalogue',
+    items: [
+      { to: '/products', label: 'Products', icon: Package, shortcutAction: 'go_products' },
+      { to: '/inventory', label: 'Inventory', icon: Boxes, shortcutAction: 'go_inventory' },
+      {
+        to: '/products-inventory',
+        label: 'Products & Inventory',
+        icon: PackageSearch,
+        shortcutAction: 'go_products_inventory',
+      },
+      { to: '/produce-items', label: 'Produce Items', icon: Factory },
+    ],
+  },
+  {
+    id: 'organisation',
+    label: 'Organisation',
+    items: [
+      { to: '/ledgers', label: 'Ledgers', icon: Users, shortcutAction: 'go_ledgers' },
+      { to: '/ledgers/new', label: 'New Ledger', icon: Users, hidden: true, shortcutAction: 'new_customer' },
+      { to: '/company', label: 'Company', title: 'Company Profile', icon: Building2 },
+    ],
+  },
+  {
+    id: 'settings',
+    label: 'Settings',
+    items: [
+      { to: '/smtp-settings', label: 'SMTP Settings', title: 'Email Settings', icon: Mail, adminOnly: true },
+      { to: '/backups', label: 'Backups', title: 'Database Backups', icon: DatabaseBackup, adminOnly: true },
+      { to: '/email-history', label: 'Email History', icon: MailCheck, adminOnly: true },
+      { to: '/api-keys', label: 'API Keys', icon: KeyRound, adminOnly: true },
+      { to: '/change-password', label: 'Change Password', title: 'Security', icon: Lock },
+      { to: '/shortcuts', label: 'Keyboard Shortcuts', icon: Keyboard },
+    ],
+  },
+];
+
+/** Every registered item, including hidden ones. */
+export const NAV_ITEMS: NavItem[] = NAV_GROUPS.flatMap((group) => group.items);
+
+/** Groups with hidden/unauthorised items removed, and emptied groups dropped. */
+export function visibleNavGroups(isAdmin: boolean): NavGroup[] {
+  return NAV_GROUPS.map((group) => ({
+    ...group,
+    items: group.items.filter((item) => !item.hidden && (!item.adminOnly || isAdmin)),
+  })).filter((group) => group.items.length > 0);
+}
+
+/** Static path -> document title. Hidden items are titled too. */
+export const ROUTE_TITLES: Record<string, string> = NAV_ITEMS.reduce<Record<string, string>>(
+  (titles, item) => {
+    titles[item.to] = item.title ?? item.label;
+    for (const child of item.alsoTitles ?? []) {
+      titles[child.path] = child.title;
+    }
+    return titles;
+  },
+  {},
+);
+
+/** Titles for paths with params, which can't be keyed statically. */
+const DYNAMIC_TITLES: { test: (pathname: string) => boolean; title: string }[] = [
+  { test: (p) => p.startsWith('/ledgers/') && p.endsWith('/edit'), title: 'Edit Ledger' },
+  { test: (p) => p.startsWith('/ledgers/'), title: 'View Ledger' },
+];
+
+export const FALLBACK_TITLE = 'Simple Invoicing';
+
+export function resolveDocumentTitle(pathname: string): string {
+  // Exact registered paths win over the patterns, so /ledgers/new titles as
+  // "New Ledger" rather than being caught by the /ledgers/:id rule.
+  const exact = ROUTE_TITLES[pathname];
+  if (exact) return exact;
+
+  const dynamic = DYNAMIC_TITLES.find((entry) => entry.test(pathname));
+  return dynamic ? dynamic.title : FALLBACK_TITLE;
+}
+
+/** Nav targets for the keyboard shortcut actions that navigate. */
+export const NAV_SHORTCUTS: { action: ActionKey; to: string }[] = NAV_ITEMS.filter(
+  (item): item is NavItem & { shortcutAction: ActionKey } => item.shortcutAction !== undefined,
+).map((item) => ({ action: item.shortcutAction, to: item.to }));

--- a/frontend/src/features/analytics/api.ts
+++ b/frontend/src/features/analytics/api.ts
@@ -1,0 +1,80 @@
+import api from '../../api/client';
+import type {
+  AnalyticsFilters,
+  MonthlySalesReport,
+  ProductSalesReport,
+  ProductSortBy,
+  SortDir,
+} from './types';
+
+/**
+ * Reports can scan a multi-year book, which comfortably exceeds the client's
+ * 10s default. Downloads run even longer.
+ */
+const REPORT_TIMEOUT_MS = 60_000;
+
+function toParams(filters: AnalyticsFilters) {
+  return {
+    voucher_type: filters.voucherType,
+    financial_year_id: filters.financialYearId,
+    from_date: filters.fromDate,
+    to_date: filters.toDate,
+    ledger_id: filters.ledgerId,
+  };
+}
+
+export async function fetchMonthlySales(filters: AnalyticsFilters): Promise<MonthlySalesReport> {
+  const response = await api.get<MonthlySalesReport>('/analytics/sales-by-month', {
+    params: toParams(filters),
+    timeout: REPORT_TIMEOUT_MS,
+  });
+  return response.data;
+}
+
+export async function fetchProductSales(
+  filters: AnalyticsFilters,
+  sortBy: ProductSortBy,
+  sortDir: SortDir,
+): Promise<ProductSalesReport> {
+  const response = await api.get<ProductSalesReport>('/analytics/sales-by-product', {
+    params: { ...toParams(filters), product_id: filters.productId, sort_by: sortBy, sort_dir: sortDir },
+    timeout: REPORT_TIMEOUT_MS,
+  });
+  return response.data;
+}
+
+async function downloadCsv(path: string, params: Record<string, unknown>, filename: string) {
+  const response = await api.get(path, {
+    params,
+    responseType: 'blob',
+    timeout: REPORT_TIMEOUT_MS,
+  });
+
+  const url = window.URL.createObjectURL(response.data as Blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  link.click();
+  window.URL.revokeObjectURL(url);
+}
+
+export function downloadMonthlySalesCsv(filters: AnalyticsFilters, period: { from: string; to: string }) {
+  return downloadCsv(
+    '/analytics/sales-by-month/csv',
+    toParams(filters),
+    `sales_by_month_${period.from}_${period.to}.csv`,
+  );
+}
+
+export function downloadProductSalesCsv(
+  filters: AnalyticsFilters,
+  sortBy: ProductSortBy,
+  sortDir: SortDir,
+  period: { from: string; to: string },
+) {
+  return downloadCsv(
+    '/analytics/sales-by-product/csv',
+    { ...toParams(filters), product_id: filters.productId, sort_by: sortBy, sort_dir: sortDir },
+    `sales_by_product_${period.from}_${period.to}.csv`,
+  );
+}

--- a/frontend/src/features/analytics/queryKeys.ts
+++ b/frontend/src/features/analytics/queryKeys.ts
@@ -1,0 +1,28 @@
+import type { AnalyticsFilters, ProductSortBy, SortDir } from './types';
+
+export const analyticsQueryKeys = {
+  all: ['analytics'] as const,
+  monthlySales: (filters: AnalyticsFilters) =>
+    [
+      'analytics',
+      'sales-by-month',
+      filters.voucherType,
+      filters.financialYearId ?? 'all',
+      filters.fromDate ?? 'auto',
+      filters.toDate ?? 'auto',
+      filters.ledgerId ?? 'all',
+    ] as const,
+  productSales: (filters: AnalyticsFilters, sortBy: ProductSortBy, sortDir: SortDir) =>
+    [
+      'analytics',
+      'sales-by-product',
+      filters.voucherType,
+      filters.financialYearId ?? 'all',
+      filters.fromDate ?? 'auto',
+      filters.toDate ?? 'auto',
+      filters.ledgerId ?? 'all',
+      filters.productId ?? 'all',
+      sortBy,
+      sortDir,
+    ] as const,
+};

--- a/frontend/src/features/analytics/types.ts
+++ b/frontend/src/features/analytics/types.ts
@@ -1,0 +1,75 @@
+export type VoucherType = 'sales' | 'purchase';
+export type ProductSortBy = 'quantity' | 'revenue' | 'name' | 'stock';
+export type SortDir = 'asc' | 'desc';
+
+/** The window the server actually reported on, after resolving FY/date fallbacks. */
+export type ReportPeriod = {
+  from_date: string;
+  to_date: string;
+  financial_year_id: number | null;
+  fy_label: string | null;
+};
+
+export type MonthlySalesRow = {
+  month: string;
+  label: string;
+  invoice_count: number;
+  total_sales: number;
+  taxable_value: number;
+  gst_collected: number;
+  discount_given: number;
+  average_invoice_value: number;
+};
+
+export type MonthlySalesTotals = Omit<MonthlySalesRow, 'month' | 'label'>;
+
+export type MonthlySalesReport = {
+  currency_code: string;
+  voucher_type: VoucherType;
+  period: ReportPeriod;
+  rows: MonthlySalesRow[];
+  totals: MonthlySalesTotals;
+};
+
+export type ProductSalesRow = {
+  product_id: number;
+  name: string;
+  sku: string | null;
+  quantity_sold: number;
+  sales_amount: number;
+  average_selling_price: number;
+  total_revenue: number;
+  total_gst: number;
+  invoice_count: number;
+  /** null when the product isn't stock-tracked — render as "—", not 0. */
+  current_stock: number | null;
+};
+
+export type ProductSalesTotals = {
+  product_count: number;
+  quantity_sold: number;
+  sales_amount: number;
+  total_revenue: number;
+  total_gst: number;
+  invoice_count: number;
+};
+
+export type ProductSalesReport = {
+  currency_code: string;
+  voucher_type: VoucherType;
+  period: ReportPeriod;
+  sort_by: ProductSortBy;
+  sort_dir: SortDir;
+  rows: ProductSalesRow[];
+  totals: ProductSalesTotals;
+};
+
+/** Filters shared by both reports; product-only fields are optional. */
+export type AnalyticsFilters = {
+  voucherType: VoucherType;
+  financialYearId?: number;
+  fromDate?: string;
+  toDate?: string;
+  ledgerId?: number;
+  productId?: number;
+};

--- a/frontend/src/pages/AnalyticsPage.tsx
+++ b/frontend/src/pages/AnalyticsPage.tsx
@@ -1,0 +1,111 @@
+import { useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import Tabs, { TabPanel, type TabItem } from '../components/Tabs';
+import { useFY } from '../context/FYContext';
+import type { AnalyticsFilters as Filters, VoucherType } from '../features/analytics/types';
+import AnalyticsFilters from './analytics/AnalyticsFilters';
+import MonthlySalesTab from './analytics/MonthlySalesTab';
+import ProductSalesTab from './analytics/ProductSalesTab';
+
+type TabId = 'month-wise' | 'product-wise';
+
+const TABS: TabItem<TabId>[] = [
+  { id: 'month-wise', label: 'Month-wise Sales' },
+  { id: 'product-wise', label: 'Product-wise Sales' },
+];
+
+/**
+ * Tabs and filters live in the query string rather than component state, so a
+ * report is linkable and bookmarkable — you can send someone the exact view.
+ * (The app's two older tab bars keep this in local state and can't.)
+ */
+export default function AnalyticsPage() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const { activeFY } = useFY();
+
+  const tab: TabId = searchParams.get('tab') === 'product-wise' ? 'product-wise' : 'month-wise';
+
+  const filters: Filters = useMemo(() => {
+    const fyParam = searchParams.get('fy');
+    const from = searchParams.get('from') ?? undefined;
+    const to = searchParams.get('to') ?? undefined;
+
+    // With nothing in the URL, default to the active FY. Its dates are sent
+    // explicitly so the view doesn't silently change when the FY is switched.
+    if (!fyParam && !from && !to && activeFY) {
+      return {
+        voucherType: (searchParams.get('type') as VoucherType) ?? 'sales',
+        financialYearId: activeFY.id,
+        fromDate: activeFY.start_date,
+        toDate: activeFY.end_date,
+        ledgerId: searchParams.get('ledger') ? Number(searchParams.get('ledger')) : undefined,
+        productId: searchParams.get('product') ? Number(searchParams.get('product')) : undefined,
+      };
+    }
+
+    return {
+      voucherType: (searchParams.get('type') as VoucherType) ?? 'sales',
+      financialYearId: fyParam ? Number(fyParam) : undefined,
+      fromDate: from,
+      toDate: to,
+      ledgerId: searchParams.get('ledger') ? Number(searchParams.get('ledger')) : undefined,
+      productId: searchParams.get('product') ? Number(searchParams.get('product')) : undefined,
+    };
+  }, [searchParams, activeFY]);
+
+  const patchParams = (patch: Record<string, string | undefined>) => {
+    const next = new URLSearchParams(searchParams);
+    for (const [key, value] of Object.entries(patch)) {
+      if (value === undefined || value === '') next.delete(key);
+      else next.set(key, value);
+    }
+    // replace: switching tabs or nudging a filter shouldn't stack history entries.
+    setSearchParams(next, { replace: true });
+  };
+
+  const onFiltersChange = (next: Filters) => {
+    patchParams({
+      type: next.voucherType,
+      fy: next.financialYearId ? String(next.financialYearId) : undefined,
+      from: next.fromDate,
+      to: next.toDate,
+      ledger: next.ledgerId ? String(next.ledgerId) : undefined,
+      product: next.productId ? String(next.productId) : undefined,
+    });
+  };
+
+  return (
+    <div className="page-grid">
+      <section className="page-hero">
+        <div>
+          <p className="eyebrow">Reports</p>
+          <h1 className="page-title">Analytics</h1>
+          <p className="section-copy">
+            Sales performance by month and by product, across any date range.
+          </p>
+        </div>
+      </section>
+
+      <AnalyticsFilters
+        filters={filters}
+        onChange={onFiltersChange}
+        showProductFilter={tab === 'product-wise'}
+      />
+
+      <Tabs
+        tabs={TABS}
+        value={tab}
+        onChange={(id) => patchParams({ tab: id })}
+        label="Analytics reports"
+      />
+
+      <TabPanel id={tab}>
+        {tab === 'month-wise' ? (
+          <MonthlySalesTab filters={filters} />
+        ) : (
+          <ProductSalesTab filters={filters} />
+        )}
+      </TabPanel>
+    </div>
+  );
+}

--- a/frontend/src/pages/analytics/AnalyticsFilters.tsx
+++ b/frontend/src/pages/analytics/AnalyticsFilters.tsx
@@ -1,0 +1,122 @@
+import { useQuery } from '@tanstack/react-query';
+import api from '../../api/client';
+import LedgerCombobox from '../../components/LedgerCombobox';
+import ProductCombobox from '../../components/ProductCombobox';
+import { useFY } from '../../context/FYContext';
+import type { AnalyticsFilters as Filters } from '../../features/analytics/types';
+import type { Ledger, Product } from '../../types/api';
+
+type Props = {
+  filters: Filters;
+  onChange: (next: Filters) => void;
+  /** The product picker only applies to the product report. */
+  showProductFilter?: boolean;
+};
+
+export default function AnalyticsFilters({ filters, onChange, showProductFilter = false }: Props) {
+  const { fyList } = useFY();
+
+  const ledgersQuery = useQuery({
+    queryKey: ['ledgers', 'lookup'],
+    queryFn: async () => {
+      const response = await api.get<{ items: Ledger[] }>('/ledgers/', { params: { page_size: 500 } });
+      return response.data.items ?? [];
+    },
+  });
+
+  const productsQuery = useQuery({
+    queryKey: ['products', 'lookup'],
+    queryFn: async () => {
+      const response = await api.get<{ items: Product[] }>('/products/', { params: { page_size: 500 } });
+      return response.data.items ?? [];
+    },
+    enabled: showProductFilter,
+  });
+
+  const selectFY = (value: string) => {
+    if (!value) {
+      onChange({ ...filters, financialYearId: undefined, fromDate: undefined, toDate: undefined });
+      return;
+    }
+    const fy = fyList.find((entry) => String(entry.id) === value);
+    if (!fy) return;
+    onChange({ ...filters, financialYearId: fy.id, fromDate: fy.start_date, toDate: fy.end_date });
+  };
+
+  // Explicit dates win server-side, so clear the FY selection to match.
+  const setDate = (key: 'fromDate' | 'toDate', value: string) => {
+    onChange({ ...filters, [key]: value || undefined, financialYearId: undefined });
+  };
+
+  return (
+    <div className="analytics-filters">
+      <label className="analytics-filters__field">
+        <span>Financial Year</span>
+        <select
+          className="input"
+          value={filters.financialYearId ? String(filters.financialYearId) : ''}
+          onChange={(event) => selectFY(event.target.value)}
+        >
+          <option value="">Custom range</option>
+          {fyList.map((fy) => (
+            <option key={fy.id} value={String(fy.id)}>{fy.label}</option>
+          ))}
+        </select>
+      </label>
+
+      <label className="analytics-filters__field">
+        <span>From</span>
+        <input
+          className="input"
+          type="date"
+          value={filters.fromDate ?? ''}
+          onChange={(event) => setDate('fromDate', event.target.value)}
+        />
+      </label>
+
+      <label className="analytics-filters__field">
+        <span>To</span>
+        <input
+          className="input"
+          type="date"
+          value={filters.toDate ?? ''}
+          onChange={(event) => setDate('toDate', event.target.value)}
+        />
+      </label>
+
+      <label className="analytics-filters__field">
+        <span>Type</span>
+        <select
+          className="input"
+          value={filters.voucherType}
+          onChange={(event) => onChange({ ...filters, voucherType: event.target.value as Filters['voucherType'] })}
+        >
+          <option value="sales">Sales</option>
+          <option value="purchase">Purchase</option>
+        </select>
+      </label>
+
+      <div className="analytics-filters__field">
+        <span>Customer</span>
+        <LedgerCombobox
+          id="analytics-ledger"
+          ledgers={ledgersQuery.data ?? []}
+          value={filters.ledgerId ? String(filters.ledgerId) : ''}
+          onChange={(ledgerId) => onChange({ ...filters, ledgerId: ledgerId ? Number(ledgerId) : undefined })}
+        />
+      </div>
+
+      {showProductFilter && (
+        <div className="analytics-filters__field">
+          <span>Product</span>
+          <ProductCombobox
+            id="analytics-product"
+            products={productsQuery.data ?? []}
+            value={filters.productId ? String(filters.productId) : ''}
+            onChange={(productId) => onChange({ ...filters, productId: productId ? Number(productId) : undefined })}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/analytics/MonthlySalesTab.tsx
+++ b/frontend/src/pages/analytics/MonthlySalesTab.tsx
@@ -1,0 +1,111 @@
+import { useState } from 'react';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { Download } from 'lucide-react';
+import { getBlobErrorMessage } from '../../api/client';
+import StatusToasts from '../../components/StatusToasts';
+import { downloadMonthlySalesCsv, fetchMonthlySales } from '../../features/analytics/api';
+import { analyticsQueryKeys } from '../../features/analytics/queryKeys';
+import type { AnalyticsFilters } from '../../features/analytics/types';
+import formatCurrency from '../../utils/formatting';
+import MonthlySalesChart from './charts/MonthlySalesChart';
+
+export default function MonthlySalesTab({ filters }: { filters: AnalyticsFilters }) {
+  const [downloading, setDownloading] = useState(false);
+  const [error, setError] = useState('');
+
+  const query = useQuery({
+    queryKey: analyticsQueryKeys.monthlySales(filters),
+    queryFn: () => fetchMonthlySales(filters),
+    // Keeps the previous report on screen while a filter change loads, so the
+    // chart doesn't flash empty.
+    placeholderData: keepPreviousData,
+  });
+
+  async function handleDownload() {
+    if (!query.data) return;
+    try {
+      setDownloading(true);
+      setError('');
+      await downloadMonthlySalesCsv(filters, {
+        from: query.data.period.from_date,
+        to: query.data.period.to_date,
+      });
+    } catch (err) {
+      // Blob-mode errors arrive as an unreadable Blob; this helper unwraps them.
+      setError(await getBlobErrorMessage(err, 'Unable to download the CSV'));
+    } finally {
+      setDownloading(false);
+    }
+  }
+
+  if (query.isLoading) {
+    return <div className="empty-state">Loading month-wise sales…</div>;
+  }
+
+  if (query.error || !query.data) {
+    return <div className="empty-state">Unable to load month-wise sales.</div>;
+  }
+
+  const { rows, totals, currency_code: currency } = query.data;
+
+  return (
+    <div className="analytics-tab">
+      <StatusToasts error={error} onClearError={() => setError('')} onClearSuccess={() => {}} />
+
+      <div className="analytics-tab__actions">
+        <button className="button button--ghost" onClick={handleDownload} disabled={downloading}>
+          <Download size={16} aria-hidden="true" />
+          {downloading ? 'Preparing…' : 'Export CSV'}
+        </button>
+      </div>
+
+      {totals.invoice_count === 0 ? (
+        <div className="empty-state">No invoices in this period.</div>
+      ) : (
+        <>
+          <MonthlySalesChart rows={rows} currencyCode={currency} />
+
+          <div className="analytics-table-scroll">
+            <table className="invoice-feed-table">
+              <thead>
+                <tr>
+                  <th>Month</th>
+                  <th className="text-right">Invoices</th>
+                  <th className="text-right">Total Sales</th>
+                  <th className="text-right">Taxable Value</th>
+                  <th className="text-right">GST Collected</th>
+                  <th className="text-right">Discount Given</th>
+                  <th className="text-right">Avg Invoice Value</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row) => (
+                  <tr key={row.month}>
+                    <td>{row.label}</td>
+                    <td className="text-right">{row.invoice_count}</td>
+                    <td className="text-right">{formatCurrency(row.total_sales, currency)}</td>
+                    <td className="text-right">{formatCurrency(row.taxable_value, currency)}</td>
+                    <td className="text-right">{formatCurrency(row.gst_collected, currency)}</td>
+                    <td className="text-right">{formatCurrency(row.discount_given, currency)}</td>
+                    <td className="text-right">{formatCurrency(row.average_invoice_value, currency)}</td>
+                  </tr>
+                ))}
+              </tbody>
+              <tfoot>
+                <tr>
+                  <th>Totals</th>
+                  <th className="text-right">{totals.invoice_count}</th>
+                  <th className="text-right">{formatCurrency(totals.total_sales, currency)}</th>
+                  <th className="text-right">{formatCurrency(totals.taxable_value, currency)}</th>
+                  <th className="text-right">{formatCurrency(totals.gst_collected, currency)}</th>
+                  <th className="text-right">{formatCurrency(totals.discount_given, currency)}</th>
+                  <th className="text-right">{formatCurrency(totals.average_invoice_value, currency)}</th>
+                </tr>
+              </tfoot>
+            </table>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/analytics/ProductSalesTab.tsx
+++ b/frontend/src/pages/analytics/ProductSalesTab.tsx
@@ -1,0 +1,175 @@
+import { useState } from 'react';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { Download } from 'lucide-react';
+import { getBlobErrorMessage } from '../../api/client';
+import StatusToasts from '../../components/StatusToasts';
+import { downloadProductSalesCsv, fetchProductSales } from '../../features/analytics/api';
+import { analyticsQueryKeys } from '../../features/analytics/queryKeys';
+import type { AnalyticsFilters, ProductSortBy, SortDir } from '../../features/analytics/types';
+import formatCurrency from '../../utils/formatting';
+import ProductSalesChart, { type ProductMetric } from './charts/ProductSalesChart';
+
+const CHART_ROWS = 10;
+
+export default function ProductSalesTab({ filters }: { filters: AnalyticsFilters }) {
+  const [sortBy, setSortBy] = useState<ProductSortBy>('revenue');
+  const [sortDir, setSortDir] = useState<SortDir>('desc');
+  const [metric, setMetric] = useState<ProductMetric>('revenue');
+  const [ranking, setRanking] = useState<'top' | 'bottom'>('top');
+  const [downloading, setDownloading] = useState(false);
+  const [error, setError] = useState('');
+
+  const query = useQuery({
+    queryKey: analyticsQueryKeys.productSales(filters, sortBy, sortDir),
+    queryFn: () => fetchProductSales(filters, sortBy, sortDir),
+    placeholderData: keepPreviousData,
+  });
+
+  async function handleDownload() {
+    if (!query.data) return;
+    try {
+      setDownloading(true);
+      setError('');
+      await downloadProductSalesCsv(filters, sortBy, sortDir, {
+        from: query.data.period.from_date,
+        to: query.data.period.to_date,
+      });
+    } catch (err) {
+      setError(await getBlobErrorMessage(err, 'Unable to download the CSV'));
+    } finally {
+      setDownloading(false);
+    }
+  }
+
+  if (query.isLoading) {
+    return <div className="empty-state">Loading product-wise sales…</div>;
+  }
+
+  if (query.error || !query.data) {
+    return <div className="empty-state">Unable to load product-wise sales.</div>;
+  }
+
+  const { rows, totals, currency_code: currency } = query.data;
+
+  // Rank for the chart independently of the table's sort, so changing the table
+  // sort doesn't silently redefine what "Top 10" means.
+  const ranked = [...rows].sort((a, b) =>
+    metric === 'revenue' ? b.total_revenue - a.total_revenue : b.quantity_sold - a.quantity_sold,
+  );
+  const chartRows = ranking === 'top' ? ranked.slice(0, CHART_ROWS) : ranked.slice(-CHART_ROWS).reverse();
+
+  return (
+    <div className="analytics-tab">
+      <StatusToasts error={error} onClearError={() => setError('')} onClearSuccess={() => {}} />
+
+      <div className="analytics-tab__actions">
+        <label className="analytics-filters__field">
+          <span>Sort by</span>
+          <select className="input" value={sortBy} onChange={(e) => setSortBy(e.target.value as ProductSortBy)}>
+            <option value="revenue">Revenue</option>
+            <option value="quantity">Quantity Sold</option>
+            <option value="name">Product Name</option>
+            <option value="stock">Current Stock</option>
+          </select>
+        </label>
+        <label className="analytics-filters__field">
+          <span>Order</span>
+          <select className="input" value={sortDir} onChange={(e) => setSortDir(e.target.value as SortDir)}>
+            <option value="desc">Descending</option>
+            <option value="asc">Ascending</option>
+          </select>
+        </label>
+        <button className="button button--ghost" onClick={handleDownload} disabled={downloading}>
+          <Download size={16} aria-hidden="true" />
+          {downloading ? 'Preparing…' : 'Export CSV'}
+        </button>
+      </div>
+
+      {rows.length === 0 ? (
+        <div className="empty-state">No products sold in this period.</div>
+      ) : (
+        <>
+          <div className="analytics-chart-controls">
+            <div className="tab-bar">
+              <button
+                className={`button ${ranking === 'top' ? 'button--primary' : 'button--ghost'}`}
+                onClick={() => setRanking('top')}
+              >
+                Top {CHART_ROWS}
+              </button>
+              <button
+                className={`button ${ranking === 'bottom' ? 'button--primary' : 'button--ghost'}`}
+                onClick={() => setRanking('bottom')}
+              >
+                Bottom {CHART_ROWS}
+              </button>
+            </div>
+            <div className="tab-bar">
+              <button
+                className={`button ${metric === 'revenue' ? 'button--primary' : 'button--ghost'}`}
+                onClick={() => setMetric('revenue')}
+              >
+                By Revenue
+              </button>
+              <button
+                className={`button ${metric === 'quantity' ? 'button--primary' : 'button--ghost'}`}
+                onClick={() => setMetric('quantity')}
+              >
+                By Quantity
+              </button>
+            </div>
+          </div>
+
+          <ProductSalesChart rows={chartRows} metric={metric} currencyCode={currency} />
+
+          <div className="analytics-table-scroll">
+            <table className="invoice-feed-table">
+              <thead>
+                <tr>
+                  <th>Product</th>
+                  <th>Item Code</th>
+                  <th className="text-right">Qty Sold</th>
+                  <th className="text-right">Sales Amount</th>
+                  <th className="text-right">Avg Selling Price</th>
+                  <th className="text-right">Total Revenue</th>
+                  <th className="text-right">Total GST</th>
+                  <th className="text-right">Invoices</th>
+                  <th className="text-right">Current Stock</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row) => (
+                  <tr key={row.product_id}>
+                    <td>{row.name}</td>
+                    <td>{row.sku ?? '—'}</td>
+                    <td className="text-right">{row.quantity_sold}</td>
+                    <td className="text-right">{formatCurrency(row.sales_amount, currency)}</td>
+                    <td className="text-right">{formatCurrency(row.average_selling_price, currency)}</td>
+                    <td className="text-right">{formatCurrency(row.total_revenue, currency)}</td>
+                    <td className="text-right">{formatCurrency(row.total_gst, currency)}</td>
+                    <td className="text-right">{row.invoice_count}</td>
+                    {/* Not tracked reads as "—" rather than a misleading 0. */}
+                    <td className="text-right">{row.current_stock ?? '—'}</td>
+                  </tr>
+                ))}
+              </tbody>
+              <tfoot>
+                <tr>
+                  <th>Totals</th>
+                  <th>{totals.product_count} products</th>
+                  <th className="text-right">{totals.quantity_sold}</th>
+                  <th className="text-right">{formatCurrency(totals.sales_amount, currency)}</th>
+                  <th className="text-right">—</th>
+                  <th className="text-right">{formatCurrency(totals.total_revenue, currency)}</th>
+                  <th className="text-right">{formatCurrency(totals.total_gst, currency)}</th>
+                  <th className="text-right">{totals.invoice_count}</th>
+                  <th className="text-right">—</th>
+                </tr>
+              </tfoot>
+            </table>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/analytics/charts/MonthlySalesChart.tsx
+++ b/frontend/src/pages/analytics/charts/MonthlySalesChart.tsx
@@ -1,0 +1,71 @@
+import {
+  Bar,
+  CartesianGrid,
+  ComposedChart,
+  Legend,
+  Line,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import type { MonthlySalesRow } from '../../../features/analytics/types';
+import formatCurrency, { formatCompactCurrency } from '../../../utils/formatting';
+import { chartColors, tooltipStyle } from './chartTheme';
+
+/**
+ * Sales bars with the average invoice value overlaid as a line.
+ *
+ * One chart rather than the separate bar and line charts the issue listed:
+ * the two series share an x-axis, and overlaying them shows whether a strong
+ * month came from more invoices or bigger ones — which two charts side by side
+ * make the reader work out for themselves.
+ */
+export default function MonthlySalesChart({
+  rows,
+  currencyCode,
+}: {
+  rows: MonthlySalesRow[];
+  currencyCode: string;
+}) {
+  return (
+    <div className="chart-frame">
+      <ResponsiveContainer width="100%" height={320}>
+        <ComposedChart data={rows} margin={{ top: 8, right: 16, bottom: 8, left: 8 }}>
+          <CartesianGrid stroke={chartColors.grid} vertical={false} />
+          <XAxis dataKey="label" stroke={chartColors.axis} tickLine={false} fontSize={12} />
+          <YAxis
+            yAxisId="left"
+            stroke={chartColors.axis}
+            tickLine={false}
+            fontSize={12}
+            tickFormatter={(value: number) => formatCompactCurrency(value, currencyCode)}
+          />
+          <YAxis
+            yAxisId="right"
+            orientation="right"
+            stroke={chartColors.axis}
+            tickLine={false}
+            fontSize={12}
+            tickFormatter={(value: number) => formatCompactCurrency(value, currencyCode)}
+          />
+          <Tooltip
+            contentStyle={tooltipStyle}
+            formatter={(value: number, name: string) => [formatCurrency(value, currencyCode), name]}
+          />
+          <Legend wrapperStyle={{ fontSize: '0.8rem' }} />
+          <Bar yAxisId="left" dataKey="total_sales" name="Total Sales" fill={chartColors.sales} radius={[4, 4, 0, 0]} />
+          <Line
+            yAxisId="right"
+            type="monotone"
+            dataKey="average_invoice_value"
+            name="Avg Invoice Value"
+            stroke={chartColors.secondary}
+            strokeWidth={2}
+            dot={false}
+          />
+        </ComposedChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/frontend/src/pages/analytics/charts/ProductSalesChart.tsx
+++ b/frontend/src/pages/analytics/charts/ProductSalesChart.tsx
@@ -1,0 +1,67 @@
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import type { ProductSalesRow } from '../../../features/analytics/types';
+import formatCurrency, { formatCompactCurrency } from '../../../utils/formatting';
+import { chartColors, tooltipStyle } from './chartTheme';
+
+export type ProductMetric = 'revenue' | 'quantity';
+
+/**
+ * Horizontal ranked bars — product names are long, and vertical bars would
+ * either truncate them or turn the axis into diagonal text.
+ */
+export default function ProductSalesChart({
+  rows,
+  metric,
+  currencyCode,
+}: {
+  rows: ProductSalesRow[];
+  metric: ProductMetric;
+  currencyCode: string;
+}) {
+  const dataKey = metric === 'revenue' ? 'total_revenue' : 'quantity_sold';
+  const name = metric === 'revenue' ? 'Revenue' : 'Quantity Sold';
+  const fill = metric === 'revenue' ? chartColors.revenue : chartColors.sales;
+
+  const format = (value: number) =>
+    metric === 'revenue' ? formatCurrency(value, currencyCode) : String(value);
+  const formatAxis = (value: number) =>
+    metric === 'revenue' ? formatCompactCurrency(value, currencyCode) : String(value);
+
+  // Grow with the row count so bars stay legible whether there are 3 or 10.
+  const height = Math.max(220, rows.length * 34 + 60);
+
+  return (
+    <div className="chart-frame">
+      <ResponsiveContainer width="100%" height={height}>
+        <BarChart data={rows} layout="vertical" margin={{ top: 8, right: 24, bottom: 8, left: 8 }}>
+          <CartesianGrid stroke={chartColors.grid} horizontal={false} />
+          <XAxis
+            type="number"
+            stroke={chartColors.axis}
+            tickLine={false}
+            fontSize={12}
+            tickFormatter={formatAxis}
+          />
+          <YAxis
+            type="category"
+            dataKey="name"
+            stroke={chartColors.axis}
+            tickLine={false}
+            fontSize={12}
+            width={140}
+          />
+          <Tooltip contentStyle={tooltipStyle} formatter={(value: number) => [format(value), name]} />
+          <Bar dataKey={dataKey} name={name} fill={fill} radius={[0, 4, 4, 0]} />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/frontend/src/pages/analytics/charts/chartTheme.ts
+++ b/frontend/src/pages/analytics/charts/chartTheme.ts
@@ -1,0 +1,22 @@
+/**
+ * Chart palette.
+ *
+ * The app commits to a single dark theme (`:root { color-scheme: dark }`), so
+ * these are fixed rather than media-query branched. Values track the sidebar
+ * and chart custom properties already in styles.css.
+ */
+export const chartColors = {
+  sales: '#6ea8fe',
+  secondary: '#f6d67b',
+  revenue: '#7ee0c0',
+  grid: 'rgba(148, 184, 255, 0.14)',
+  axis: 'rgba(156, 173, 207, 0.75)',
+};
+
+export const tooltipStyle = {
+  background: '#0d1426',
+  border: '1px solid rgba(148, 184, 255, 0.24)',
+  borderRadius: '8px',
+  color: '#e6eefb',
+  fontSize: '0.8rem',
+};

--- a/frontend/src/store/useSidebarStore.ts
+++ b/frontend/src/store/useSidebarStore.ts
@@ -1,0 +1,38 @@
+import { create } from 'zustand';
+
+const STORAGE_KEY = 'sidebar_collapsed';
+
+function readCollapsed(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+type SidebarState = {
+  /** Desktop rail mode. The mobile drawer is separate, ephemeral state in Layout. */
+  collapsed: boolean;
+  toggleCollapsed: () => void;
+};
+
+/**
+ * localStorage is read in the initializer rather than an effect so a collapsed
+ * rail doesn't flash open on first paint.
+ *
+ * Persistence is hand-rolled to match the house style — useAuthStore and
+ * api/client.ts do the same; nothing here uses zustand's persist middleware.
+ */
+export const useSidebarStore = create<SidebarState>((set) => ({
+  collapsed: readCollapsed(),
+  toggleCollapsed: () =>
+    set((state) => {
+      const collapsed = !state.collapsed;
+      try {
+        localStorage.setItem(STORAGE_KEY, String(collapsed));
+      } catch {
+        // Private browsing / storage disabled — keep the in-memory toggle working.
+      }
+      return { collapsed };
+    }),
+}));

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -2481,3 +2481,198 @@ textarea {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
+
+/* ── Sidebar icons & collapsible desktop rail ─────────────────────── */
+
+.sidebar__link svg {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+}
+
+.sidebar__header {
+  display: flex;
+  flex-direction: column;
+}
+
+.sidebar__collapse {
+  display: none;
+  background: none;
+  border: 1px solid var(--sidebar-border);
+  color: var(--sidebar-muted);
+  cursor: pointer;
+  padding: 6px;
+  border-radius: 8px;
+  line-height: 1;
+  transition: 180ms ease;
+  align-items: center;
+  justify-content: center;
+}
+
+.sidebar__collapse:hover {
+  background: var(--sidebar-hover-bg);
+  color: var(--sidebar-text);
+}
+
+.sidebar__fy {
+  padding: 12px 10px;
+  border-top: 1px solid var(--sidebar-border);
+}
+
+.sidebar__user-meta {
+  min-width: 0;
+}
+
+/* The rail is desktop-only: the mobile drawer is always full width, so every
+   rule below stays inside this breakpoint. */
+@media (min-width: 768px) {
+  .sidebar__collapse {
+    display: flex;
+    margin-top: 12px;
+    align-self: flex-start;
+  }
+
+  .app-shell,
+  .sidebar {
+    transition: grid-template-columns 180ms ease, width 180ms ease;
+  }
+
+  /* --sidebar-width is consumed by both .app-shell's grid and .sidebar's
+     width, so overriding the token here is the whole rail mechanic. */
+  .app-shell--rail {
+    --sidebar-width: 68px;
+  }
+
+  .app-shell--rail .sidebar__link {
+    justify-content: center;
+    padding: 9px 0;
+  }
+
+  .app-shell--rail .sidebar__nav,
+  .app-shell--rail .sidebar__header,
+  .app-shell--rail .sidebar__footer {
+    padding-left: 8px;
+    padding-right: 8px;
+  }
+
+  /* Labels are clipped rather than display:none'd so they stay in the
+     accessibility tree; the NavLink title attribute supplies a hover tooltip. */
+  .app-shell--rail .sidebar__link-label,
+  .app-shell--rail .sidebar__brand-name,
+  .app-shell--rail .sidebar__brand-tagline,
+  .app-shell--rail .sidebar__user-meta {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  /* Group headings collapse to a rule so the grouping still reads at 68px. */
+  .app-shell--rail .sidebar__group-label {
+    height: 0;
+    padding: 0;
+    overflow: hidden;
+    border-top: 1px solid var(--sidebar-border);
+    margin: 8px 4px;
+  }
+
+  .app-shell--rail .sidebar__brand {
+    justify-content: center;
+  }
+
+  .app-shell--rail .sidebar__collapse {
+    align-self: center;
+  }
+
+  /* 68px cannot hold a company name or an FY label. */
+  .app-shell--rail .sidebar__fy {
+    display: none;
+  }
+
+  .app-shell--rail .sidebar__user {
+    justify-content: center;
+  }
+
+  .app-shell--rail .sidebar__logout {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+.sidebar__logout {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+
+/* ── Tabs ─────────────────────────────────────────────────────────── */
+.tab-bar {
+  display: flex;
+  gap: 0;
+  flex-wrap: wrap;
+}
+
+/* ── Analytics ────────────────────────────────────────────────────── */
+.analytics-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: flex-end;
+}
+
+.analytics-filters__field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 160px;
+  flex: 1 1 160px;
+}
+
+.analytics-filters__field > span {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.analytics-tab {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.analytics-tab__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: flex-end;
+  justify-content: flex-end;
+}
+
+.analytics-chart-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: space-between;
+}
+
+.chart-frame {
+  background: var(--bg-card);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 16px 8px 8px;
+}
+
+/* Wide report tables scroll inside their own container so the page body never
+   scrolls horizontally. */
+.analytics-table-scroll {
+  overflow-x: auto;
+  width: 100%;
+}


### PR DESCRIPTION
Adds a dedicated Analytics section rather than embedding reports in the invoice view: the reports asked for in #391 — plus the future ones — are a section, not a panel, and most of them (receivables ageing, inventory valuation) have nothing to do with invoices.

Backend
- GET /api/analytics/sales-by-month{,/csv} and /sales-by-product{,/csv}, with voucher_type (sales|purchase), FY/date-range/customer/product filters and sorting. JSON and CSV share one builder so they cannot disagree.
- invoice_discounts.py derives "Discount Given", which is not stored: the write path persists only discount_type/discount_value and taxable_amount is already net of it. Recovered by inverting the write path's algebra rather than re-running its arithmetic, which handles both of its clamps and avoids rounding drift. Coupled to invoice_processor — round-trip tests guard against it drifting.
- Product rows count distinct invoices; a plain count() inflates whenever a product appears on two lines of one invoice (real data: 30 vs 33).
- current_stock is null, not 0, for products that aren't stock-tracked.
- Strict company_id scoping: on a reporting surface a legacy NULL-company invoice would leak into every company's revenue.
- Month bucketing stays in Python (SQLite in tests, Postgres in prod); the month helpers move out of dashboard.py so both surfaces share labels.

Frontend
- config/navigation.ts is now the single source of truth for nav. Sidebar links, document titles and shortcut targets all derive from it, so the three-way drift is gone (/produce-items and /email-history had no title; '/' disagreed with the sidebar).
- Sidebar: icons, regrouped (Analytics/Catalogue/Organisation), and a collapsible desktop rail persisted to localStorage. Labels stay in the a11y tree when collapsed. FY switcher extracted; its modal is portalled because the mobile drawer's transform would contain a fixed overlay.
- Tabs.tsx keeps the existing segmented look but adds the ARIA roles and arrow-key handling the ad-hoc tab bars lack.
- Analytics page syncs tabs and filters to the query string so a report is linkable. Lazy-loaded — it's the only route pulling in recharts.
- open_reports now points at /analytics, which is what it always meant.

Not included, and why: Category/Brand/Salesperson filters from the issue have no backing columns and need a schema change; PDF/print deferred.

Verified against real data: totals match independent SQL exactly, and the discount derivation recovers the exact figure on Postgres.

## Summary

Describe what changed and why.

## Type of change

- [ ] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs (documentation)
- [ ] test (tests)
- [ ] chore/refactor

## How to test

List exact steps to test your changes.

## Checklist

- [ ] My code follows the project style and conventions
- [ ] I added/updated tests where appropriate
- [ ] I updated docs where needed
- [ ] I ran relevant checks locally
- [ ] I verified this does not break existing behavior

## Screenshots (if UI changes)

Add before/after screenshots or screen recording.

## Related issue

Closes #391 
