### PR TITLE
feat: Improve Invoice View — filters, CSV export & toolbar redesign (#393)

### DIFF
--- a/backend/src/api/routes/invoices.py
+++ b/backend/src/api/routes/invoices.py
@@ -1,4 +1,5 @@
-from io import BytesIO
+import csv
+from io import BytesIO, StringIO
 from datetime import date, datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -124,6 +125,57 @@ def create_invoice(
         raise HTTPException(status_code=500, detail=str(e))
 
 
+def _apply_invoice_filters(
+    query,
+    db: Session,
+    active_company: CompanyProfile,
+    *,
+    search: str = "",
+    show_cancelled: bool = False,
+    financial_year_id: int | None = None,
+    product_id: int | None = None,
+    include_description: bool = False,
+    voucher_type: str | None = None,
+    date_from: date | None = None,
+    date_to: date | None = None,
+):
+    """Apply the Invoice Feed filters to a base query. Shared by the list and CSV export endpoints."""
+    if not show_cancelled:
+        query = query.filter(Invoice.status == "active")
+    if financial_year_id is not None:
+        query = query.filter(Invoice.financial_year_id == financial_year_id)
+    if voucher_type is not None:
+        query = query.filter(Invoice.voucher_type == voucher_type)
+    if date_from is not None:
+        query = query.filter(func.date(Invoice.invoice_date) >= date_from)
+    if date_to is not None:
+        query = query.filter(func.date(Invoice.invoice_date) <= date_to)
+    if search.strip():
+        term = f"%{search.strip()}%"
+        product_match = Product.name.ilike(term)
+        if include_description:
+            product_match = or_(product_match, InvoiceItem.description.ilike(term))
+        product_match_subq = (
+            db.query(InvoiceItem.invoice_id)
+            .join(Product, Product.id == InvoiceItem.product_id)
+            .filter(
+                Product.company_id == active_company.id,
+                product_match,
+            )
+            .subquery()
+        )
+        query = query.filter(
+            or_(
+                Invoice.ledger_name.ilike(term),
+                Invoice.id.in_(product_match_subq),
+            )
+        )
+    if product_id is not None:
+        product_subq = db.query(InvoiceItem.invoice_id).filter(InvoiceItem.product_id == product_id).subquery()
+        query = query.filter(Invoice.id.in_(product_subq))
+    return query
+
+
 @router.get("", response_model=PaginatedInvoiceOut, include_in_schema=False)
 @router.get("/", response_model=PaginatedInvoiceOut)
 def list_invoices(
@@ -134,39 +186,27 @@ def list_invoices(
     financial_year_id: int | None = Query(None),
     product_id: int | None = Query(None),
     include_description: bool = Query(False),
+    voucher_type: str | None = Query(None),
+    date_from: date | None = Query(None),
+    date_to: date | None = Query(None),
     db: Session = Depends(get_db),
     _: User = Depends(get_current_user),
     active_company: CompanyProfile = Depends(get_active_company),
 ):
     try:
-      base = db.query(Invoice).filter(Invoice.company_id == active_company.id)
-      if not show_cancelled:
-        base = base.filter(Invoice.status == "active")
-      if financial_year_id is not None:
-        base = base.filter(Invoice.financial_year_id == financial_year_id)
-      if search.strip():
-        term = f"%{search.strip()}%"
-        product_match = Product.name.ilike(term)
-        if include_description:
-          product_match = or_(product_match, InvoiceItem.description.ilike(term))
-        product_match_subq = (
-          db.query(InvoiceItem.invoice_id)
-          .join(Product, Product.id == InvoiceItem.product_id)
-          .filter(
-            Product.company_id == active_company.id,
-            product_match,
-          )
-          .subquery()
-        )
-        base = base.filter(
-          or_(
-            Invoice.ledger_name.ilike(term),
-            Invoice.id.in_(product_match_subq),
-          )
-        )
-      if product_id is not None:
-        product_subq = db.query(InvoiceItem.invoice_id).filter(InvoiceItem.product_id == product_id).subquery()
-        base = base.filter(Invoice.id.in_(product_subq))
+      base = _apply_invoice_filters(
+        db.query(Invoice).filter(Invoice.company_id == active_company.id),
+        db,
+        active_company,
+        search=search,
+        show_cancelled=show_cancelled,
+        financial_year_id=financial_year_id,
+        product_id=product_id,
+        include_description=include_description,
+        voucher_type=voucher_type,
+        date_from=date_from,
+        date_to=date_to,
+      )
 
       summary_row = base.with_entities(
         func.coalesce(func.sum(Invoice.total_amount), 0),
@@ -218,6 +258,93 @@ def list_invoices(
           financial_year_id=financial_year_id,
         ),
       )
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+_VOUCHER_TYPE_LABELS = {"sales": "Sales", "purchase": "Purchase"}
+
+_CSV_COLUMNS = [
+    "Invoice Number",
+    "Invoice Date",
+    "Voucher Type",
+    "Party Name",
+    "GSTIN",
+    "Taxable Value",
+    "CGST",
+    "SGST",
+    "IGST",
+    "Grand Total",
+    "Payment Status",
+]
+
+
+@router.get("/export")
+def export_invoices_csv(
+    search: str = Query(""),
+    show_cancelled: bool = Query(False),
+    financial_year_id: int | None = Query(None),
+    product_id: int | None = Query(None),
+    include_description: bool = Query(False),
+    voucher_type: str | None = Query(None),
+    date_from: date | None = Query(None),
+    date_to: date | None = Query(None),
+    db: Session = Depends(get_db),
+    _: User = Depends(get_current_user),
+    active_company: CompanyProfile = Depends(get_active_company),
+):
+    """Export every invoice matching the current Invoice Feed filters as CSV (all pages)."""
+    try:
+        base = _apply_invoice_filters(
+            db.query(Invoice).filter(Invoice.company_id == active_company.id),
+            db,
+            active_company,
+            search=search,
+            show_cancelled=show_cancelled,
+            financial_year_id=financial_year_id,
+            product_id=product_id,
+            include_description=include_description,
+            voucher_type=voucher_type,
+            date_from=date_from,
+            date_to=date_to,
+        )
+
+        invoices = (
+            base.options(joinedload(Invoice.ledger))
+            .order_by(Invoice.id.desc())
+            .all()
+        )
+        payment_summaries = build_invoice_payment_summaries(db, invoices)
+
+        buffer = StringIO(newline="")
+        writer = csv.writer(buffer)
+        writer.writerow(_CSV_COLUMNS)
+        for invoice in invoices:
+            summary = payment_summaries.get(invoice.id)
+            payment_status = summary.payment_status if summary else "unpaid"
+            invoice_date = invoice.invoice_date.date().isoformat() if invoice.invoice_date else ""
+            writer.writerow([
+                invoice.invoice_number or "",
+                invoice_date,
+                _VOUCHER_TYPE_LABELS.get(invoice.voucher_type, invoice.voucher_type or ""),
+                invoice.ledger_name or "",
+                invoice.ledger_gst or "",
+                f"{Decimal(invoice.taxable_amount or 0):.2f}",
+                f"{Decimal(invoice.cgst_amount or 0):.2f}",
+                f"{Decimal(invoice.sgst_amount or 0):.2f}",
+                f"{Decimal(invoice.igst_amount or 0):.2f}",
+                f"{Decimal(invoice.total_amount or 0):.2f}",
+                payment_status,
+            ])
+
+        # utf-8-sig: the BOM makes Excel read non-ASCII party names / symbols correctly.
+        csv_bytes = buffer.getvalue().encode("utf-8-sig")
+        filename = f"invoices_{date.today().isoformat()}.csv"
+        return StreamingResponse(
+            BytesIO(csv_bytes),
+            media_type="text/csv; charset=utf-8",
+            headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+        )
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 

--- a/backend/tests/api/test_invoice_view_filters_export.py
+++ b/backend/tests/api/test_invoice_view_filters_export.py
@@ -1,0 +1,139 @@
+"""Tests for #393 — Invoice View voucher-type filter, date-range filter, and CSV export."""
+
+import csv
+import io
+
+from fastapi.testclient import TestClient
+
+
+def _create_product(client: TestClient, sku: str, name: str, price: float = 100.0) -> dict:
+    res = client.post("/api/products/", json={
+        "sku": sku,
+        "name": name,
+        "price": price,
+        "gst_rate": 18,
+        "maintain_inventory": True,
+        "initial_quantity": 500,
+    })
+    assert res.status_code == 200, res.text
+    return res.json()
+
+
+def _create_ledger(client: TestClient, name: str, gst: str) -> dict:
+    res = client.post("/api/ledgers/", json={
+        "name": name,
+        "address": "123 Test St",
+        "gst": gst,
+        "phone_number": "9876543210",
+        "email": "test@example.com",
+        "website": "",
+        "bank_name": "",
+        "branch_name": "",
+        "account_name": "",
+        "account_number": "",
+        "ifsc_code": "",
+        "opening_balance": 0,
+    })
+    assert res.status_code == 200, res.text
+    return res.json()
+
+
+def _create_invoice(client: TestClient, product_id: int, ledger_id: int,
+                    voucher_type: str, invoice_date: str) -> dict:
+    res = client.post("/api/invoices/", json={
+        "ledger_id": ledger_id,
+        "voucher_type": voucher_type,
+        "invoice_date": invoice_date,
+        "tax_inclusive": False,
+        "apply_round_off": False,
+        "items": [{"product_id": product_id, "quantity": 2, "unit_price": 100}],
+    })
+    assert res.status_code == 200, res.text
+    return res.json()
+
+
+def _seed(client: TestClient) -> None:
+    product = _create_product(client, "VF-1", "View Filter Product")
+    sales_ledger = _create_ledger(client, "Sales Customer", "27AADCB2230M1ZT")
+    purchase_ledger = _create_ledger(client, "Purchase Supplier", "29AADCB2230M1ZX")
+    _create_invoice(client, product["id"], sales_ledger["id"], "sales", "2026-01-15")
+    _create_invoice(client, product["id"], sales_ledger["id"], "sales", "2026-03-20")
+    _create_invoice(client, product["id"], purchase_ledger["id"], "purchase", "2026-02-10")
+
+
+class TestInvoiceViewFilters:
+    def test_voucher_type_filter(self, client):
+        _seed(client)
+
+        all_res = client.get("/api/invoices/", params={"page_size": 100})
+        assert all_res.status_code == 200
+        assert all_res.json()["total"] == 3
+
+        sales_res = client.get("/api/invoices/", params={"voucher_type": "sales", "page_size": 100})
+        assert sales_res.status_code == 200
+        sales_items = sales_res.json()["items"]
+        assert len(sales_items) == 2
+        assert all(i["voucher_type"] == "sales" for i in sales_items)
+
+        purchase_res = client.get("/api/invoices/", params={"voucher_type": "purchase", "page_size": 100})
+        assert purchase_res.status_code == 200
+        purchase_items = purchase_res.json()["items"]
+        assert len(purchase_items) == 1
+        assert purchase_items[0]["voucher_type"] == "purchase"
+
+    def test_date_range_filter_is_inclusive(self, client):
+        _seed(client)
+
+        res = client.get("/api/invoices/", params={
+            "date_from": "2026-02-01",
+            "date_to": "2026-03-20",
+            "page_size": 100,
+        })
+        assert res.status_code == 200
+        items = res.json()["items"]
+        # Feb 10 purchase + Mar 20 sales fall in range; Jan 15 excluded.
+        assert len(items) == 2
+        dates = sorted(i["invoice_date"][:10] for i in items)
+        assert dates == ["2026-02-10", "2026-03-20"]
+
+    def test_date_from_only(self, client):
+        _seed(client)
+        res = client.get("/api/invoices/", params={"date_from": "2026-02-10", "page_size": 100})
+        assert res.status_code == 200
+        assert res.json()["total"] == 2
+
+
+class TestInvoiceExportCsv:
+    def _read_csv(self, res):
+        assert res.status_code == 200, res.text
+        assert res.headers["content-type"].startswith("text/csv")
+        assert "attachment" in res.headers["content-disposition"]
+        text = res.content.decode("utf-8-sig")
+        return list(csv.reader(io.StringIO(text)))
+
+    def test_export_has_expected_columns_and_rows(self, client):
+        _seed(client)
+        rows = self._read_csv(client.get("/api/invoices/export"))
+        header = rows[0]
+        assert header == [
+            "Invoice Number", "Invoice Date", "Voucher Type", "Party Name", "GSTIN",
+            "Taxable Value", "CGST", "SGST", "IGST", "Grand Total", "Payment Status",
+        ]
+        # 3 invoices seeded + header row.
+        assert len(rows) == 4
+
+    def test_export_respects_voucher_type_filter(self, client):
+        _seed(client)
+        rows = self._read_csv(client.get("/api/invoices/export", params={"voucher_type": "purchase"}))
+        assert len(rows) == 2  # header + 1 purchase
+        assert rows[1][2] == "Purchase"
+        assert rows[1][3] == "Purchase Supplier"
+
+    def test_export_respects_date_range_filter(self, client):
+        _seed(client)
+        rows = self._read_csv(client.get("/api/invoices/export", params={
+            "date_from": "2026-03-01",
+            "date_to": "2026-03-31",
+        }))
+        assert len(rows) == 2  # header + Mar 20 sales
+        assert rows[1][1] == "2026-03-20"

--- a/frontend/src/features/invoices/api.ts
+++ b/frontend/src/features/invoices/api.ts
@@ -1,6 +1,8 @@
 import api from '../../api/client';
 import type { CompanyProfile, Invoice, Ledger, LedgerAddress, LedgerAddressCreate, LedgerAddressUpdate, OutstandingInvoice, PaginatedInvoices, Product } from '../../types/api';
 
+export type VoucherTypeFilter = 'all' | 'sales' | 'purchase';
+
 type InvoiceFilters = {
   page: number;
   pageSize: number;
@@ -9,7 +11,12 @@ type InvoiceFilters = {
   financialYearId?: number;
   productId?: number;
   includeDescription?: boolean;
+  voucherType?: VoucherTypeFilter;
+  dateFrom?: string;
+  dateTo?: string;
 };
+
+export type InvoiceExportFilters = Omit<InvoiceFilters, 'page' | 'pageSize'>;
 
 export type DueInvoiceFilters = {
   page: number;
@@ -40,7 +47,34 @@ function buildInvoiceParams(filters: InvoiceFilters) {
     params.include_description = true;
   }
 
+  if (filters.voucherType && filters.voucherType !== 'all') {
+    params.voucher_type = filters.voucherType;
+  }
+
+  if (filters.dateFrom) {
+    params.date_from = filters.dateFrom;
+  }
+
+  if (filters.dateTo) {
+    params.date_to = filters.dateTo;
+  }
+
   return params;
+}
+
+export async function exportInvoicesCsv(filters: InvoiceExportFilters): Promise<void> {
+  const params = buildInvoiceParams({ ...filters, page: 1, pageSize: 1 });
+  delete params.page;
+  delete params.page_size;
+
+  const res = await api.get('/invoices/export', { params, responseType: 'blob' });
+
+  const url = window.URL.createObjectURL(res.data as Blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = `invoices_${new Date().toISOString().slice(0, 10)}.csv`;
+  link.click();
+  window.URL.revokeObjectURL(url);
 }
 
 export async function fetchInvoiceById(invoiceId: number): Promise<Invoice> {

--- a/frontend/src/features/invoices/queryKeys.ts
+++ b/frontend/src/features/invoices/queryKeys.ts
@@ -14,8 +14,11 @@ export const invoiceQueryKeys = {
     showCancelled: boolean,
     financialYearId?: number,
     productId?: number,
-    includeDescription?: boolean
-  ) => ['invoices', 'list', page, pageSize, search, showCancelled, financialYearId ?? 'all', productId ?? 'all', includeDescription ?? false] as const,
+    includeDescription?: boolean,
+    voucherType?: string,
+    dateFrom?: string,
+    dateTo?: string
+  ) => ['invoices', 'list', page, pageSize, search, showCancelled, financialYearId ?? 'all', productId ?? 'all', includeDescription ?? false, voucherType ?? 'all', dateFrom ?? 'none', dateTo ?? 'none'] as const,
   dues: (
     page: number,
     pageSize: number,

--- a/frontend/src/pages/InvoicesAdvancedView.tsx
+++ b/frontend/src/pages/InvoicesAdvancedView.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { LayoutGrid, Table as TableIcon, X } from 'lucide-react';
+import { ChevronDown, Download, LayoutGrid, SlidersHorizontal, Table as TableIcon, X } from 'lucide-react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import api, { getApiErrorMessage } from '../api/client';
 import type { Invoice } from '../types/api';
@@ -14,7 +14,7 @@ import type { Product } from '../types/api';
 import { useInvoiceFeedViewStore } from '../store/useInvoiceFeedViewStore';
 import { useInvoiceModalStore } from '../store/useInvoiceModalStore';
 import { useInvoiceCancelStore } from '../store/useInvoiceCancelStore';
-import { fetchCompanyProfile, fetchInvoicePage, fetchProducts } from '../features/invoices/api';
+import { exportInvoicesCsv, fetchCompanyProfile, fetchInvoicePage, fetchProducts } from '../features/invoices/api';
 import { invoiceQueryKeys } from '../features/invoices/queryKeys';
 import EmptyState from '../components/EmptyState';
 
@@ -42,6 +42,33 @@ function calculateBreakdown(rows: Invoice[]): Breakdown {
   };
 }
 
+function toISODate(d: Date): string {
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+type DatePreset = 'today' | 'this_month' | 'prev_month';
+
+function computePreset(preset: DatePreset): { from: string; to: string } {
+  const now = new Date();
+  switch (preset) {
+    case 'today':
+      return { from: toISODate(now), to: toISODate(now) };
+    case 'this_month':
+      return {
+        from: toISODate(new Date(now.getFullYear(), now.getMonth(), 1)),
+        to: toISODate(new Date(now.getFullYear(), now.getMonth() + 1, 0)),
+      };
+    case 'prev_month':
+      return {
+        from: toISODate(new Date(now.getFullYear(), now.getMonth() - 1, 1)),
+        to: toISODate(new Date(now.getFullYear(), now.getMonth(), 0)),
+      };
+  }
+}
+
 export default function InvoicesAdvancedView() {
   const { activeFY, loading: fyLoading } = useFY();
   const navigate = useNavigate();
@@ -49,6 +76,8 @@ export default function InvoicesAdvancedView() {
   const { requestCancel } = useInvoiceCancelStore();
   const [actionError, setActionError] = useState('');
   const [actionSuccess, setActionSuccess] = useState('');
+  const [exporting, setExporting] = useState(false);
+  const [filtersOpen, setFiltersOpen] = useState(false);
 
   const restoreMutation = useMutation({
     mutationFn: (invoiceId: number) => api.post(`/invoices/${invoiceId}/restore`),
@@ -88,6 +117,44 @@ export default function InvoicesAdvancedView() {
     restoreMutation.mutate(invoice.id);
   }
 
+  async function handleExportCsv() {
+    setExporting(true);
+    setActionError('');
+    try {
+      await exportInvoicesCsv({
+        search: invoiceSearch,
+        showCancelled,
+        financialYearId: shouldUseAllFY ? undefined : activeFY?.id,
+        productId: productId ?? undefined,
+        includeDescription: searchDescription,
+        voucherType,
+        dateFrom,
+        dateTo,
+      });
+      setActionSuccess('Invoice CSV downloaded.');
+    } catch (err) {
+      setActionError(getApiErrorMessage(err, 'Unable to export invoices'));
+    } finally {
+      setExporting(false);
+    }
+  }
+
+  function handleApplyPreset(preset: 'today' | 'this_month' | 'prev_month' | 'current_fy') {
+    if (preset === 'current_fy') {
+      if (activeFY) {
+        setDateRange(activeFY.start_date.slice(0, 10), activeFY.end_date.slice(0, 10));
+      }
+      return;
+    }
+    const { from, to } = computePreset(preset);
+    setDateRange(from, to);
+  }
+
+  function handleResetFilters() {
+    resetFilters();
+    setSearchParams({});
+  }
+
   const [searchParams, setSearchParams] = useSearchParams();
 
   const {
@@ -98,6 +165,9 @@ export default function InvoicesAdvancedView() {
     allowAllFY,
     page,
     productId,
+    voucherType,
+    dateFrom,
+    dateTo,
     setViewType,
     setInvoiceSearch,
     setSearchDescription,
@@ -106,6 +176,11 @@ export default function InvoicesAdvancedView() {
     setPage,
     resetPage,
     setProductId,
+    setVoucherType,
+    setDateFrom,
+    setDateTo,
+    setDateRange,
+    resetFilters,
   } = useInvoiceFeedViewStore();
 
   // Sync ?product_id from URL into store on mount
@@ -127,7 +202,7 @@ export default function InvoicesAdvancedView() {
   const financialYearId = shouldUseAllFY ? undefined : activeFY?.id;
 
   const invoicesQuery = useQuery({
-    queryKey: invoiceQueryKeys.list(page, pageSize, invoiceSearch, showCancelled, financialYearId, productId ?? undefined, searchDescription),
+    queryKey: invoiceQueryKeys.list(page, pageSize, invoiceSearch, showCancelled, financialYearId, productId ?? undefined, searchDescription, voucherType, dateFrom, dateTo),
     queryFn: () => fetchInvoicePage({
       page,
       pageSize,
@@ -136,6 +211,9 @@ export default function InvoicesAdvancedView() {
       financialYearId,
       productId: productId ?? undefined,
       includeDescription: searchDescription,
+      voucherType,
+      dateFrom,
+      dateTo,
     }),
     enabled: isFYReady && !fyLoading,
   });
@@ -152,7 +230,7 @@ export default function InvoicesAdvancedView() {
 
   useEffect(() => {
     resetPage();
-  }, [invoiceSearch, searchDescription, showCancelled, allowAllFY, activeFY?.id, productId]);
+  }, [invoiceSearch, searchDescription, showCancelled, allowAllFY, activeFY?.id, productId, voucherType, dateFrom, dateTo]);
 
   const invoices = invoicesQuery.data?.items ?? [];
   const totalPages = invoicesQuery.data?.total_pages ?? 1;
@@ -228,6 +306,15 @@ export default function InvoicesAdvancedView() {
     );
   }
 
+  const activeFilterCount = [
+    voucherType !== 'all',
+    Boolean(dateFrom),
+    Boolean(dateTo),
+    allowAllFY,
+    searchDescription,
+    showCancelled,
+  ].filter(Boolean).length;
+
   return (
     <div className="invoice-feed-view stack">
       <section className="panel invoice-feed-view__header">
@@ -236,48 +323,34 @@ export default function InvoicesAdvancedView() {
             <p className="eyebrow">Invoices</p>
             <h1 className="page-title" style={{ margin: 0 }}>Invoice Feed</h1>
           </div>
-        </div>
 
-        <div className="invoice-feed-view__controls">
-          {/* View Toggle */}
-          <div className="button-row">
+          {/* View switcher — segmented tabs, kept separate from the action buttons */}
+          <div className="invoice-feed-view__view-tabs" role="tablist" aria-label="Invoice view">
             <button
               type="button"
+              role="tab"
+              aria-selected={viewType === 'card'}
               onClick={() => setViewType('card')}
-              className={`button button--small ${
-                viewType === 'card'
-                  ? 'button--primary'
-                  : 'button--ghost'
-              }`}
+              className={`button button--small ${viewType === 'card' ? 'button--primary' : 'button--ghost'}`}
             >
-              <LayoutGrid size={18} />
+              <LayoutGrid size={16} />
               Card
             </button>
             <button
               type="button"
+              role="tab"
+              aria-selected={viewType === 'table'}
               onClick={() => setViewType('table')}
-              className={`button button--small ${
-                viewType === 'table'
-                  ? 'button--primary'
-                  : 'button--ghost'
-              }`}
+              className={`button button--small ${viewType === 'table' ? 'button--primary' : 'button--ghost'}`}
             >
-              <TableIcon size={18} />
+              <TableIcon size={16} />
               Table
             </button>
           </div>
+        </div>
 
-          {/* FY Filter Toggle */}
-          <label className="invoice-feed-view__checkbox">
-            <input
-              type="checkbox"
-              checked={allowAllFY}
-              onChange={(e) => setAllowAllFY(e.target.checked)}
-            />
-            <span>Search all FY</span>
-          </label>
-
-          {/* Search */}
+        {/* Toolbar: search + primary actions */}
+        <div className="invoice-feed-view__toolbar">
           <input
             type="text"
             placeholder="Search by party or product..."
@@ -286,7 +359,106 @@ export default function InvoicesAdvancedView() {
             className="input invoice-feed-view__search"
           />
 
-          {/* Search item description toggle */}
+          <div className="invoice-feed-view__toolbar-actions">
+            <button
+              type="button"
+              className={`button button--small ${filtersOpen || activeFilterCount > 0 ? 'button--primary' : 'button--ghost'}`}
+              onClick={() => setFiltersOpen((open) => !open)}
+              aria-expanded={filtersOpen}
+            >
+              <SlidersHorizontal size={16} />
+              Filters
+              {activeFilterCount > 0 && (
+                <span className="invoice-feed-view__filter-badge">{activeFilterCount}</span>
+              )}
+              <ChevronDown
+                size={16}
+                className="invoice-feed-view__chevron"
+                style={{ transform: filtersOpen ? 'rotate(180deg)' : 'none' }}
+              />
+            </button>
+
+            <button
+              type="button"
+              className="button button--primary button--small"
+              onClick={handleExportCsv}
+              disabled={exporting}
+            >
+              <Download size={16} />
+              {exporting ? 'Preparing…' : 'Export CSV'}
+            </button>
+            <button
+              type="button"
+              className="button button--ghost button--small"
+              onClick={handleResetFilters}
+            >
+              Reset
+            </button>
+          </div>
+        </div>
+
+        {filtersOpen && (
+        <div className="invoice-feed-view__advanced">
+        {/* Filters: voucher type, date range, presets, toggles */}
+        <div className="invoice-feed-view__filters">
+          <label className="invoice-feed-view__field">
+            <span className="invoice-feed-view__field-label">Voucher type</span>
+            <select
+              className="input"
+              value={voucherType}
+              onChange={(e) => setVoucherType(e.target.value as typeof voucherType)}
+            >
+              <option value="all">All</option>
+              <option value="sales">Sales</option>
+              <option value="purchase">Purchase</option>
+            </select>
+          </label>
+
+          <label className="invoice-feed-view__field">
+            <span className="invoice-feed-view__field-label">From date</span>
+            <input
+              type="date"
+              className="input"
+              value={dateFrom}
+              max={dateTo || undefined}
+              onChange={(e) => setDateFrom(e.target.value)}
+            />
+          </label>
+
+          <label className="invoice-feed-view__field">
+            <span className="invoice-feed-view__field-label">To date</span>
+            <input
+              type="date"
+              className="input"
+              value={dateTo}
+              min={dateFrom || undefined}
+              onChange={(e) => setDateTo(e.target.value)}
+            />
+          </label>
+
+          <div className="invoice-feed-view__field">
+            <span className="invoice-feed-view__field-label">Quick range</span>
+            <div className="button-row">
+              <button type="button" className="button button--ghost button--small" onClick={() => handleApplyPreset('today')}>Today</button>
+              <button type="button" className="button button--ghost button--small" onClick={() => handleApplyPreset('this_month')}>This month</button>
+              <button type="button" className="button button--ghost button--small" onClick={() => handleApplyPreset('prev_month')}>Prev month</button>
+              {activeFY && (
+                <button type="button" className="button button--ghost button--small" onClick={() => handleApplyPreset('current_fy')}>Current FY</button>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Boolean toggles */}
+        <div className="invoice-feed-view__toggles">
+          <label className="invoice-feed-view__checkbox">
+            <input
+              type="checkbox"
+              checked={allowAllFY}
+              onChange={(e) => setAllowAllFY(e.target.checked)}
+            />
+            <span>Search all FY</span>
+          </label>
           <label className="invoice-feed-view__checkbox">
             <input
               type="checkbox"
@@ -295,8 +467,6 @@ export default function InvoicesAdvancedView() {
             />
             <span>Include item description</span>
           </label>
-
-          {/* Cancelled toggle */}
           <label className="invoice-feed-view__checkbox">
             <input
               type="checkbox"
@@ -306,6 +476,8 @@ export default function InvoicesAdvancedView() {
             <span>Show cancelled</span>
           </label>
         </div>
+        </div>
+        )}
 
         {/* Current FY Info */}
         {!allowAllFY && (

--- a/frontend/src/store/useInvoiceFeedViewStore.ts
+++ b/frontend/src/store/useInvoiceFeedViewStore.ts
@@ -2,6 +2,8 @@ import { create } from 'zustand';
 
 type ViewType = 'card' | 'table';
 
+export type VoucherTypeFilter = 'all' | 'sales' | 'purchase';
+
 type InvoiceFeedViewState = {
   viewType: ViewType;
   invoiceSearch: string;
@@ -10,6 +12,9 @@ type InvoiceFeedViewState = {
   allowAllFY: boolean;
   page: number;
   productId: number | null;
+  voucherType: VoucherTypeFilter;
+  dateFrom: string;
+  dateTo: string;
   setViewType: (viewType: ViewType) => void;
   setInvoiceSearch: (invoiceSearch: string) => void;
   setSearchDescription: (searchDescription: boolean) => void;
@@ -18,16 +23,28 @@ type InvoiceFeedViewState = {
   setPage: (page: number) => void;
   resetPage: () => void;
   setProductId: (productId: number | null) => void;
+  setVoucherType: (voucherType: VoucherTypeFilter) => void;
+  setDateFrom: (dateFrom: string) => void;
+  setDateTo: (dateTo: string) => void;
+  setDateRange: (dateFrom: string, dateTo: string) => void;
+  resetFilters: () => void;
+};
+
+const initialFilters = {
+  invoiceSearch: '',
+  searchDescription: false,
+  showCancelled: false,
+  page: 1,
+  productId: null as number | null,
+  voucherType: 'all' as VoucherTypeFilter,
+  dateFrom: '',
+  dateTo: '',
 };
 
 export const useInvoiceFeedViewStore = create<InvoiceFeedViewState>((set) => ({
   viewType: 'card',
-  invoiceSearch: '',
-  searchDescription: false,
-  showCancelled: false,
   allowAllFY: false,
-  page: 1,
-  productId: null,
+  ...initialFilters,
   setViewType: (viewType) => set({ viewType }),
   setInvoiceSearch: (invoiceSearch) => set({ invoiceSearch }),
   setSearchDescription: (searchDescription) => set({ searchDescription }),
@@ -36,4 +53,9 @@ export const useInvoiceFeedViewStore = create<InvoiceFeedViewState>((set) => ({
   setPage: (page) => set({ page }),
   resetPage: () => set({ page: 1 }),
   setProductId: (productId) => set({ productId }),
+  setVoucherType: (voucherType) => set({ voucherType }),
+  setDateFrom: (dateFrom) => set({ dateFrom }),
+  setDateTo: (dateTo) => set({ dateTo }),
+  setDateRange: (dateFrom, dateTo) => set({ dateFrom, dateTo }),
+  resetFilters: () => set({ ...initialFilters }),
 }));

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1674,14 +1674,125 @@ textarea {
 }
 
 .invoice-feed-view__controls {
-  display: grid;
-  grid-template-columns: auto auto minmax(240px, 1fr) auto;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+
+/* Toolbar row: search grows, actions pinned right */
+.invoice-feed-view__toolbar {
+  display: flex;
+  flex-wrap: wrap;
   gap: 12px;
   align-items: center;
 }
 
 .invoice-feed-view__search {
+  flex: 1 1 260px;
   min-width: 0;
+}
+
+.invoice-feed-view__toolbar-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  margin-left: auto;
+}
+
+.invoice-feed-view__toolbar-actions .button,
+.invoice-feed-view__view-tabs .button {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* Segmented view switcher (Card / Table), styled as tabs */
+.invoice-feed-view__view-tabs {
+  display: inline-flex;
+  gap: 4px;
+  padding: 4px;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: rgba(7, 13, 24, 0.55);
+  flex-shrink: 0;
+}
+
+.invoice-feed-view__view-tabs .button {
+  border-radius: 10px;
+}
+
+.invoice-feed-view__view-tabs .button--ghost {
+  background: transparent;
+  border: 0;
+}
+
+.invoice-feed-view__filter-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.28);
+  font-size: 0.72rem;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.invoice-feed-view__chevron {
+  transition: transform 160ms ease;
+  opacity: 0.8;
+}
+
+/* Collapsible advanced-filters panel */
+.invoice-feed-view__advanced {
+  margin-top: 14px;
+  padding-top: 16px;
+  border-top: 1px solid var(--line);
+  animation: invoice-feed-view__reveal 160ms ease;
+}
+
+@keyframes invoice-feed-view__reveal {
+  from { opacity: 0; transform: translateY(-4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* Filters row: labeled fields aligned along their bottom edge */
+.invoice-feed-view__filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px 20px;
+  align-items: flex-end;
+}
+
+.invoice-feed-view__field {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.invoice-feed-view__field-label {
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.invoice-feed-view__field .button-row {
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.invoice-feed-view__toggles {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 22px;
+  align-items: center;
+  margin-top: 12px;
 }
 
 .invoice-feed-view__checkbox {
@@ -2239,7 +2350,69 @@ textarea {
   }
 
   .invoice-feed-view__controls {
-    grid-template-columns: 1fr;
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  /* Stack the toolbar: search on top, actions in tidy shared rows below */
+  .invoice-feed-view__toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .invoice-feed-view__search {
+    flex: 1 1 auto;
+  }
+
+  .invoice-feed-view__toolbar-actions {
+    margin-left: 0;
+    width: 100%;
+  }
+
+  .invoice-feed-view__header .panel__header {
+    flex-wrap: wrap;
+  }
+
+  .invoice-feed-view__view-tabs {
+    flex: 1 1 100%;
+  }
+
+  .invoice-feed-view__view-tabs .button {
+    flex: 1;
+    justify-content: center;
+  }
+
+  .invoice-feed-view__toolbar-actions > .button {
+    flex: 1 1 auto;
+    justify-content: center;
+  }
+
+  /* Filters: single full-width column */
+  .invoice-feed-view__filters {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .invoice-feed-view__field {
+    width: 100%;
+  }
+
+  /* Keep quick-range presets as a wrapping row, not stacked */
+  .invoice-feed-view__field .button-row {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .invoice-feed-view__field .button-row .button {
+    flex: 1 1 auto;
+    justify-content: center;
+  }
+
+  .invoice-feed-view__toggles {
+    margin-left: 0;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
   }
 
   .invoice-feed-breakdown__grid {


### PR DESCRIPTION
Closes #393.

Enhances the **Invoice Feed** (`/invoices-view`) to make invoices easier to browse, filter and export.

## Features
- **Voucher-type filter** — All / Sales / Purchase. (Credit Note / Debit Note are separate entities in this system, so they're out of scope for the invoice feed.)
- **Date-range filter** — From/To date inputs plus quick presets: Today, This month, Prev month, Current FY. Range is inclusive on both ends.
- **CSV export** — new `GET /invoices/export` endpoint that streams **all** matching invoices across every page, respecting the active filters. Columns: Invoice Number, Invoice Date, Voucher Type, Party Name, GSTIN, Taxable Value, CGST, SGST, IGST, Grand Total, Payment Status. Uses the codebase's UTF-8-BOM convention so Excel renders it correctly.

## Toolbar redesign
- **Card / Table** switcher is now a segmented **tab control** in the panel header, separated from the action buttons.
- Advanced filters are **collapsed behind a Filters toggle** with an active-filter count badge; search + Export CSV + Reset stay visible.
- Responsive fixes so the toolbar, tabs and filters stack cleanly on mobile.

## Implementation notes
- `list_invoices` filtering extracted into a shared `_apply_invoice_filters` helper, reused by the export endpoint.
- Frontend store, query keys and API layer thread the new params; `exportInvoicesCsv()` triggers the download.

## Testing
- New backend tests (`test_invoice_view_filters_export.py`) cover the voucher/date filters and CSV export (headers, rows, filter-respect).
- Full backend suite green (390 passed). Frontend `tsc` clean; only pre-existing lint warnings.
- Verified visually in the running app at desktop/mobile × collapsed/expanded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)